### PR TITLE
Fix Test_move in ftp

### DIFF
--- a/pkg/file/ftp.go
+++ b/pkg/file/ftp.go
@@ -19,6 +19,7 @@ type ftpOp interface {
 	List(dir string) (entries []*pkgFtp.Entry, err error)
 	Move(source, destination string) error
 	Mkdir(path string) error
+	Close() error
 }
 
 type ftp struct {
@@ -62,6 +63,11 @@ func (s *ftpConn) Move(source, destination string) error {
 // Mkdir to create new directory on ftp
 func (s *ftpConn) Mkdir(path string) error {
 	return s.conn.MakeDir(path)
+}
+
+// Close to quit the ftp connections
+func (s *ftpConn) Close() error {
+	return s.conn.Quit()
 }
 
 // createNestedDirFTP utility method to create directory recursively
@@ -188,6 +194,8 @@ func (f ftp) move(source, destination string) error {
 	if err != nil {
 		return err
 	}
+
+	defer f.conn.Close()
 
 	err = f.conn.Move(source, destination)
 	if err != nil {

--- a/pkg/file/ftp_test.go
+++ b/pkg/file/ftp_test.go
@@ -347,13 +347,13 @@ func Test_move(t *testing.T) {
 	}{
 		{"Success case: able to move file", "testDir", "testDestination", nil},
 		{"Failure case: remote path does not exists", "invalid", "destination",
-			&textproto.Error{Code: 550, Msg: "RNFR command failed."}},
+			&textproto.Error{}},
 	}
 
 	for i, tc := range tests {
 		err = f.move(tc.source, tc.destination)
 
-		assert.Equalf(t, tc.expErr, err, "Test[%d] failed: %v", i+1, tc.desc)
+		assert.IsTypef(t, tc.expErr, err, "Test[%d] failed: %v", i+1, tc.desc)
 	}
 
 	cleanUp(t, conn)

--- a/pkg/file/ftp_test.go
+++ b/pkg/file/ftp_test.go
@@ -347,13 +347,13 @@ func Test_move(t *testing.T) {
 	}{
 		{"Success case: able to move file", "testDir", "testDestination", nil},
 		{"Failure case: remote path does not exists", "invalid", "destination",
-			&textproto.Error{}},
+			&textproto.Error{Code: 550, Msg: "RNFR command failed."}},
 	}
 
 	for i, tc := range tests {
 		err = f.move(tc.source, tc.destination)
 
-		assert.IsTypef(t, tc.expErr, err, "Test[%d] failed: %v", i+1, tc.desc)
+		assert.Equalf(t, tc.expErr, err, "Test[%d] failed: %v", i+1, tc.desc)
 	}
 
 	cleanUp(t, conn)
@@ -403,4 +403,8 @@ func cleanUp(t *testing.T, conn *pkgFtp.ServerConn) {
 	if err != nil {
 		t.Fatalf("error while closing the connection to the host: %v", err)
 	}
+}
+
+func (s *mockFtpConn) Close() error {
+	return nil
 }

--- a/pkg/file/retryFileStore_test.go
+++ b/pkg/file/retryFileStore_test.go
@@ -125,3 +125,7 @@ func (m mockFtpOp) Move(string, string) error {
 func (m mockFtpOp) Mkdir(string) error {
 	return nil
 }
+
+func (m mockFtpOp) Close() error {
+	return nil
+}


### PR DESCRIPTION
**Previosuly,** Test_Move fails intermittently due to lot of ftp connections it is making.
**Currently,** We are closing connection at end after operation has been completed in Test_move such that we will not get connection related errors.

closes #15 