### PR TITLE
Remove t.skip() from tests

### DIFF
--- a/.github/setups/setup.sql
+++ b/.github/setups/setup.sql
@@ -1,11 +1,18 @@
-DROP DATABASE customers;
+-- Drop the database if it exists
+DROP DATABASE IF EXISTS customers;
+
+-- Create the database
 CREATE DATABASE customers;
-\connect customers
-CREATE TABLE public.customers (
-                                  id uuid NOT NULL primary key,
-                                  name character varying(50),
-                                  email varchar(50),
-                                      phone bigint
+
+-- Switch to the 'customers' database
+USE customers;
+
+-- Create the 'customers' table in the 'public' schema
+CREATE TABLE customers (
+                           id VARCHAR(36) NOT NULL PRIMARY KEY,
+                           name VARCHAR(50),
+                           email VARCHAR(50),
+                           phone BIGINT
 );
 
 DROP TABLE IF EXISTS employees;

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -106,6 +106,11 @@ jobs:
           go-version: 1.21
         id: Go
 
+      - name: Set up AWS-SNS
+        run: |
+          chmod +x examples/using-awssns/init.sh
+          ./examples/using-awssns/init.sh
+
       - name: Load Schema of Cassandra
         run: |
           docker exec -i ${{ job.services.cassandra.id }} cqlsh --debug  < .github/setups/keyspace.cql
@@ -122,6 +127,7 @@ jobs:
       - name: Set up MySQL
         run: |
           docker exec -i ${{ job.services.mysql.id }} mysql -uroot -ppassword -e 'CREATE DATABASE test;'
+          docker exec -i ${{ job.services.mysql.id }} mysql -uroot -ppassword < ${{ github.workspace }}/.github/setups/setup.sql
 
       - name: Set up SSL Enabled MySQL
         run: |
@@ -169,7 +175,7 @@ jobs:
       - name: Test
         run: |
           export GOFR_ENV=test
-          go test ./... -v -coverprofile profile.cov -coverpkg=./...
+          go test ./... -v -short -coverprofile profile.cov -coverpkg=./...
           go tool cover -func profile.cov
 
       - name: Upload Test Coverage to Code Climate

--- a/examples/universal-example/main_test.go
+++ b/examples/universal-example/main_test.go
@@ -65,6 +65,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestUniversalIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
+
 	// call the main function
 	go main()
 	// sleep, so that every data stores get initialized properly

--- a/examples/using-awssns/Readme.md
+++ b/examples/using-awssns/Readme.md
@@ -15,9 +15,9 @@ Using Amazon SNS topics, your publisher systems can fanout messages to a large n
 
 To run the example follow the steps below :
 
-1) Run the below command on your PWD to setup awssns locally for testing.
+1) Run the below command from root directory to setup awssns locally for testing.
 
-   > `bash init.sh`
+   > `bash ./examples/using-awssns/init.sh`
 
 2) Now you can run the example on your PWD .
 

--- a/examples/using-awssns/configs/.test.env
+++ b/examples/using-awssns/configs/.test.env
@@ -1,0 +1,10 @@
+APP_VERSION=v0
+APP_NAME=aws-sns-example
+HTTP_PORT=8080
+SNS_ACCESS_KEY=dummy1
+SNS_SECRET_ACCESS_KEY=dummy1
+SNS_REGION=eu-central-1
+SNS_PROTOCOL=http
+SNS_ENDPOINT=http://localhost:4566/
+SNS_TOPIC_ARN=arn:aws:sns:eu-central-1:000000000000:order-creation-events
+NOTIFIER_BACKEND=SNS

--- a/examples/using-awssns/init.sh
+++ b/examples/using-awssns/init.sh
@@ -43,7 +43,10 @@ install_aws_cli_mac() {
 
 
 # Step 1: Start localstack docker container
-docker-compose -f Docker-Compose.yml up -d
+docker-compose -f examples/using-awssns/Docker-Compose.yml up -d
+
+# Wait for 5 seconds after starting localstack
+sleep 5
 
 # Step 2: Check operating system and install AWS CLI if not installed
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
@@ -60,23 +63,25 @@ else
 fi
 
 # Step 3: Configure AWS CLI profile
-aws configure --profile test-profile
-
-aws configure set aws_access_key_id dummy1 --profile test-profile
-aws configure set aws_secret_access_key dummy1 --profile test-profile
-aws configure set region eu-central-1 --profile test-profile
+aws configure --profile test-profile <<EOF
+dummy1
+dummy1
+eu-central-1
+json
+EOF
 
 # Step 4: Create SNS topic
 topic_arn=$(aws --endpoint-url=http://localhost:4566 sns create-topic --name order-creation-events --region eu-central-1 --profile test-profile | grep -o 'arn[^"]*')
 
 # Step 5: Set environment variables
-echo "APP_VERSION=v0" > ./configs/.local.env
-echo "APP_NAME=aws-sns-example" >> ./configs/.local.env
-echo "HTTP_PORT=8080" >> ./configs/.local.env
-echo "SNS_ACCESS_KEY=dummy1" >> ./configs/.local.env
-echo "SNS_SECRET_ACCESS_KEY=dummy1" >> ./configs/.local.env
-echo "SNS_REGION=eu-central-1" >> ./configs/.local.env
-echo "SNS_PROTOCOL=http" >> ./configs/.local.env
-echo "SNS_ENDPOINT=http://localhost:4566/" >> ./configs/.local.env
-echo "SNS_TOPIC_ARN=$topic_arn" >> ./configs/.local.env
-echo "NOTIFIER_BACKEND=SNS" >> ./configs/.local.env
+# shellcheck disable=SC2129
+echo "APP_VERSION=v0" >> examples/using-awssns/configs/.local.env
+echo "APP_NAME=aws-sns-example" >> examples/using-awssns/configs/.local.env
+echo "HTTP_PORT=8080" >> examples/using-awssns/configs/.local.env
+echo "SNS_ACCESS_KEY=dummy1" >> examples/using-awssns/configs/.local.env
+echo "SNS_SECRET_ACCESS_KEY=dummy1" >> examples/using-awssns/configs/.local.env
+echo "SNS_REGION=eu-central-1" >> examples/using-awssns/configs/.local.env
+echo "SNS_PROTOCOL=http" >> examples/using-awssns/configs/.local.env
+echo "SNS_ENDPOINT=http://localhost:4566/" >> examples/using-awssns/configs/.local.env
+echo "SNS_TOPIC_ARN=$topic_arn" >> examples/using-awssns/configs/.local.env
+echo "NOTIFIER_BACKEND=SNS" >> examples/using-awssns/configs/.local.env

--- a/examples/using-awssns/main_test.go
+++ b/examples/using-awssns/main_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package main
 
 import (

--- a/examples/using-eventhub/main_test.go
+++ b/examples/using-eventhub/main_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestServerRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
+	
 	go main()
 	time.Sleep(3 * time.Second)
 

--- a/examples/using-mysql/configs/.env
+++ b/examples/using-mysql/configs/.env
@@ -2,15 +2,11 @@
 APP_NAME=gofr-mysql-example      # Used in logging, tracing etc.
 
 #DB
-DB_SSL=require
 DB_HOST=localhost
 DB_PORT=2001
 DB_USER=root
 DB_PASSWORD=password
 DB_NAME=customers
 DB_DIALECT=mysql
-DB_CERTIFICATE_FILE=./certificateFile/client-cert.pem
-DB_KEY_FILE=./certificateFile/client-key.pem
-DB_CA_CERTIFICATE_FILE=./certificateFile/ca-cert.pem
 
 

--- a/examples/using-mysql/configs/.test.env
+++ b/examples/using-mysql/configs/.test.env
@@ -4,11 +4,8 @@ APP_NAME=gofr-mysql-example      # Used in logging, tracing etc.
 #DB
 DB_SSL=
 DB_HOST=localhost
-DB_PORT=2001
+DB_PORT=3306
 DB_USER=root
 DB_PASSWORD=password
 DB_NAME=customers
 DB_DIALECT=mysql
-DB_CERTIFICATE_FILE=./certificateFile/client-cert.pem
-DB_KEY_FILE=./certificateFile/client-key.pem
-DB_CA_CERTIFICATE_FILE=./certificateFile/ca-cert.pem

--- a/examples/using-mysql/main_test.go
+++ b/examples/using-mysql/main_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package main
 
 import (

--- a/pkg/datastore/db_test.go
+++ b/pkg/datastore/db_test.go
@@ -68,7 +68,7 @@ func TestNewORM(t *testing.T) {
 }
 
 func TestNewORM_Success(t *testing.T) {
-	t.Skip("skipping testing in short mode")
+	t.Skip("skipping tests in short mode")
 
 	dc := DBConfig{
 		SSL:               "require",
@@ -196,7 +196,7 @@ func Test_NewSQLX(t *testing.T) {
 }
 
 func TestDataStore_SQL_SQLX_HealthCheck(t *testing.T) {
-	t.Skip("skipping test in short mode")
+	t.Skip("skipping tests in short mode")
 
 	b := new(bytes.Buffer)
 	logger := log.NewMockLogger(b)
@@ -251,7 +251,7 @@ func TestDataStore_SQL_SQLX_HealthCheck(t *testing.T) {
 }
 
 func TestNewSQLX_Success(t *testing.T) {
-	t.Skip("skipping testing in short mode")
+	t.Skip("skipping tests in short mode")
 
 	{
 		dc := DBConfig{
@@ -282,7 +282,7 @@ func TestNewSQLX_Success(t *testing.T) {
 
 // Test_SQL_SQLX_HealthCheck_Down tests health check response when the db connection was made but lost in between
 func Test_SQL_SQLX_HealthCheck_Down(t *testing.T) {
-	t.Skip("skipping testing in short mode")
+	t.Skip("skipping tests in short mode")
 
 	b := new(bytes.Buffer)
 	logger := log.NewMockLogger(b)

--- a/pkg/datastore/pubsub/eventhub/eventhub_test.go
+++ b/pkg/datastore/pubsub/eventhub/eventhub_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package eventhub
 
 import (
@@ -22,6 +20,10 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
+
 	conf := config.NewGoDotEnvProvider(log.NewLogger(), "../../../../configs")
 
 	tests := []struct {
@@ -63,6 +65,10 @@ func TestNew(t *testing.T) {
 }
 
 func TestEventhub_HealthCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
+
 	conf := config.NewGoDotEnvProvider(log.NewLogger(), "../../../../configs")
 	testcases := []struct {
 		c    Config
@@ -146,6 +152,10 @@ func TestEventhub_HealthCheck_Down(t *testing.T) {
 }
 
 func TestIsSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
+
 	var e *Eventhub
 
 	logger := log.NewMockLogger(io.Discard)

--- a/pkg/file/ftp_test.go
+++ b/pkg/file/ftp_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	pkgFtp "github.com/jlaffaye/ftp"
 	"github.com/stretchr/testify/assert"
 
@@ -174,46 +173,39 @@ func Test_move_FTP(t *testing.T) {
 
 // Test_createNestedDirFTP to test behavior of createNestedDirFTP
 func Test_createNestedDirFTP(t *testing.T) {
-	t.Skip("Skipping the test as while creating directory on GHA will get permission denied error")
+	parentDir := "testDestination"
 
-	ftpCfg := &FTPConfig{
+	ftpCfg := FTPConfig{
 		Host:     "localhost",
 		User:     "myuser",
 		Password: "mypass",
 		Port:     21,
 	}
 
-	b := new(bytes.Buffer)
+	conn := initializeFTP(t, ftpCfg)
 
+	b := new(bytes.Buffer)
 	logger := log.NewMockLogger(b)
 
-	f, err := newFTPFile(ftpCfg, "ftp_test.txt", "rw")
-	if err != nil {
-		t.Fatalf("Error in creating connection to FTP: %v", err)
-	}
+	client := ftpConn{conn: conn, logger: logger}
 
-	client, ok := f.conn.(*ftpConn)
-	if !ok {
-		t.Fatalf("Unable to parse ftpConn")
-	}
-
-	client.logger = logger
-
-	parentDir := fmt.Sprintf("testDir%v", uuid.NewString())
-
-	testCases := []struct {
-		desc string
-		path string
+	tests := []struct {
+		desc   string
+		path   string
+		expLog string
 	}{
-		{"Success case: new directory will be created", parentDir},
-		{"Success case: parent dir already exists so only sub directory will be created", parentDir + "/innerTestFTPDir"},
+		{"Success case: creates a new directory", parentDir, ""},
+		{"Success case: parent dir already exists so creates only sub directory", parentDir + "/subDirectory",
+			"Error 550 Create directory operation failed. in creating directory /testDestination/"},
 	}
 
-	for i, tc := range testCases {
-		createNestedDirFTP(client, tc.path)
+	for i, tc := range tests {
+		createNestedDirFTP(&client, tc.path)
 
-		assert.Contains(t, b.String(), "", "Test [%d] Failed: %v", i+1, tc.desc)
+		assert.Containsf(t, b.String(), tc.expLog, "Test[%d] Failed: %v", i+1, tc.desc)
 	}
+
+	cleanUp(t, conn)
 }
 
 // mockFtpConn is the mock implementation of ftpOp

--- a/pkg/gofr/retryDBConnection_test.go
+++ b/pkg/gofr/retryDBConnection_test.go
@@ -220,10 +220,6 @@ func Test_elasticSearchRetry(t *testing.T) {
 }
 
 func Test_AWSSNSRetry(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping testing in short mode")
-	}
-
 	var g Gofr
 
 	logger := log.NewMockLogger(io.Discard)

--- a/pkg/log/levelService_test.go
+++ b/pkg/log/levelService_test.go
@@ -121,7 +121,7 @@ func TestRemoteLevelLogging(t *testing.T) {
 
 	newLevelService(l, "gofr-app")
 
-	time.Sleep(15 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	mu.Lock()
 	lvl := rls.level


### PR DESCRIPTION
- Remove `t.Skip()` from tests wherever needed.
- Refactor the schema of setup.sql to be loaded before testing examples.
- Remove build integration tag from tests files used to skip them in workflow.