### PR TITLE
Fix link for CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ If you want to say thank you and/or support the active development of GoFr:
 
 1. Add a [GitHub Star](https://github.com/gofr-dev/gofr/stargazers) to the project.
 2. Write a review or tutorial on [Medium](https://medium.com/), [Dev.to](https://dev.to/) or personal blog.
-3. Visit [CONTRIBUTING](https://github.com/gofr-dev/gofr/blob/Refactor-readme/CONTRIBUTING.md) for details on submitting patches and the contribution workflow.
+3. Visit [CONTRIBUTING](https://github.com/gofr-dev/gofr/blob/development/CONTRIBUTING.md) for details on submitting patches and the contribution workflow.


### PR DESCRIPTION
Currently link in README.md routes to a page not found. 
<img width="1295" alt="image" src="https://github.com/gofr-dev/gofr/assets/7676016/a991cf7d-a3cc-4f32-8dae-da0ef2501283">
