### PR TITLE
Remove rls global variable and fix tests

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -568,8 +568,6 @@ golang.org/x/net v0.0.0-20220725212005-46097bf591d3/go.mod h1:AaygXjzTFtRAg2ttMY
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
-golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
-golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
 golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/pkg/log/gfrLogger.go
+++ b/pkg/log/gfrLogger.go
@@ -22,6 +22,9 @@ type logger struct {
 	correlationID string
 
 	isTerminal bool
+
+	// remote logging service
+	rls levelService
 }
 
 type appInfo struct {
@@ -57,7 +60,7 @@ func (a *appInfo) getAppData() appInfo {
 func (l *logger) log(level level, format string, args ...interface{}) {
 	mu.Lock()
 
-	lvl := rls.level
+	lvl := l.rls.level
 
 	mu.Unlock()
 

--- a/pkg/log/gfrLogger_test.go
+++ b/pkg/log/gfrLogger_test.go
@@ -65,9 +65,8 @@ func TestLog(t *testing.T) {
 
 	for i, tc := range tests {
 		b := new(bytes.Buffer)
-		rls.level = 5
 
-		l := logger{correlationID: tc.correlationID, out: b, isTerminal: tc.isTerminal}
+		l := logger{correlationID: tc.correlationID, out: b, isTerminal: tc.isTerminal, rls: levelService{level: 5}}
 		syncData := sync.Map{}
 		syncData.Store("correlationID", tc.correlationIDInMap)
 

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -45,8 +45,8 @@ func newLogger() *logger {
 		syncData:  &sync.Map{},
 	}
 
-	if !rls.init {
-		rls = *newLevelService(l, name)
+	if !l.rls.init {
+		l.rls = *newLevelService(l, name)
 	}
 
 	// Set terminal to ensure proper output format.
@@ -55,12 +55,10 @@ func newLogger() *logger {
 	return l
 }
 
-// NewLogger  creates and returns a new logger instance that implements the Logger interface.
 func NewLogger() Logger {
 	return newLogger()
 }
 
-// NewCorrelationLogger creates and returns a new logger instance with a specified correlation ID.
 func NewCorrelationLogger(correlationID string) Logger {
 	l := newLogger()
 	l.correlationID = correlationID

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -12,8 +12,6 @@ const defaultAppName = "gofr-app"
 func TestNewLogger(t *testing.T) {
 	l := newLogger()
 
-	rls.init = false
-
 	if l.app.Name != defaultAppName {
 		t.Errorf("Expected APP_NAME: gofr-app     GOT:  %v", l.app.Name)
 	}

--- a/pkg/log/mock_logger.go
+++ b/pkg/log/mock_logger.go
@@ -6,13 +6,8 @@ import (
 )
 
 func NewMockLogger(output io.Writer) Logger {
-	mu.Lock()
-
-	rls.level = Debug
-
-	mu.Unlock()
-
 	return &logger{
+		rls: levelService{level: Debug},
 		out: output,
 		app: appInfo{
 			Data:      make(map[string]interface{}),


### PR DESCRIPTION
Closes #63 
Removing the `rls` global variable for remote level service we remove the change that the mock logger was causing for testing purposes!