### PR TITLE
remove Origin from the list of necessary CORS header

### DIFF
--- a/pkg/middleware/cors.go
+++ b/pkg/middleware/cors.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	allowedHeaders = "Authorization, Content-Type, x-requested-with, origin, true-client-ip, X-Correlation-ID"
+	allowedHeaders = "Authorization, Content-Type, x-requested-with, true-client-ip, X-Correlation-ID"
 	allowedMethods = "PUT, POST, GET, DELETE, OPTIONS, PATCH"
 )
 
@@ -47,8 +47,6 @@ func getValidCORSHeaders(envHeaders map[string]string) map[string]string {
 
 		// If config is not set - for the three headers, set default value.
 		switch header {
-		case "Access-Control-Allow-Origin":
-			validCORSHeadersAndValues[header] = "*"
 		case "Access-Control-Allow-Headers":
 			validCORSHeadersAndValues[header] = allowedHeaders
 		case "Access-Control-Allow-Methods":
@@ -68,7 +66,6 @@ func getValidCORSHeaders(envHeaders map[string]string) map[string]string {
 // AllowedCORSHeader returns the HTTP headers used for CORS configuration in web applications.
 func AllowedCORSHeader() []string {
 	return []string{
-		"Access-Control-Allow-Origin",
 		"Access-Control-Allow-Headers",
 		"Access-Control-Allow-Methods",
 		"Access-Control-Allow-Credentials",

--- a/pkg/middleware/cors_test.go
+++ b/pkg/middleware/cors_test.go
@@ -57,7 +57,6 @@ func Test_getValidCORSHeaders(t *testing.T) {
 	}{
 		{map[string]string{},
 			map[string]string{
-				"Access-Control-Allow-Origin":  "*",
 				"Access-Control-Allow-Headers": allowedHeaders,
 				"Access-Control-Allow-Methods": allowedMethods,
 			},
@@ -65,12 +64,10 @@ func Test_getValidCORSHeaders(t *testing.T) {
 		{map[string]string{
 			"Access-Control-Max-Age":       strconv.Itoa(600),
 			"Access-Control-Allow-Headers": "",
-			"Access-Control-Allow-Origin":  "same-origin",
 			"Access-Control-Allow-Methods": http.MethodPost,
 		},
 			map[string]string{
 				"Access-Control-Max-Age":       strconv.Itoa(600),
-				"Access-Control-Allow-Origin":  "same-origin",
 				"Access-Control-Allow-Headers": allowedHeaders,
 				"Access-Control-Allow-Methods": http.MethodPost,
 			},
@@ -79,7 +76,6 @@ func Test_getValidCORSHeaders(t *testing.T) {
 			"Access-Control-Allow-Headers": "clientid",
 		},
 			map[string]string{
-				"Access-Control-Allow-Origin":  "*",
 				"Access-Control-Allow-Headers": allowedHeaders + ", clientid",
 				"Access-Control-Allow-Methods": allowedMethods,
 			},
@@ -93,7 +89,6 @@ func Test_getValidCORSHeaders(t *testing.T) {
 			map[string]string{
 				"Access-Control-Allow-Credentials": "true",
 				"Access-Control-Max-Age":           strconv.Itoa(600),
-				"Access-Control-Allow-Origin":      "*",
 				"Access-Control-Allow-Headers":     allowedHeaders,
 				"Access-Control-Allow-Methods":     allowedMethods,
 			},


### PR DESCRIPTION
- Resolves Issue #138 
- Origin Header will not be propagated from one microservice to another during interservice calls