### PR TITLE
Add check for uint16 bounds in Azure Filestore

### DIFF
--- a/pkg/file/azure.go
+++ b/pkg/file/azure.go
@@ -3,6 +3,7 @@ package file
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"net/url"
 	"os"
@@ -62,7 +63,11 @@ func newAzureFile(c *AzureConfig, filename string, mode Mode) (*azure, error) {
 			return nil, err
 		}
 
-		azFile.parallelism = uint16(pl)
+		if pl>=0 && pl<= math.MaxUint16{
+			azFile.parallelism = uint16(pl)
+		} else {
+			azFile.parallelism = uint16(0)
+		}
 	}
 
 	return azFile, nil

--- a/pkg/file/azure.go
+++ b/pkg/file/azure.go
@@ -63,11 +63,7 @@ func newAzureFile(c *AzureConfig, filename string, mode Mode) (*azure, error) {
 			return nil, err
 		}
 
-		if pl>=0 && pl<= math.MaxUint16{
-			azFile.parallelism = uint16(pl)
-		} else {
-			azFile.parallelism = uint16(0)
-		}
+		azFile.parallelism = validateAndConvertToUint16(pl)
 	}
 
 	return azFile, nil
@@ -104,4 +100,12 @@ func (a *azure) list(string) ([]string, error) {
 func randomString() string {
 	r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec //  Use of weak random number generator
 	return strconv.Itoa(r.Int())
+}
+
+func validateAndConvertToUint16(num int) uint16 {
+	if num >= 0 && num <= math.MaxUint16 {
+		return uint16(num)
+	}
+
+	return uint16(0)
 }

--- a/pkg/file/azure_test.go
+++ b/pkg/file/azure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"math"
 	"net/url"
 	"strconv"
 	"testing"
@@ -100,6 +101,26 @@ func Test_azure_push(t *testing.T) {
 	assert.Equal(t, expErr, actualErr, "Tests failed")
 
 	_ = localFile.Close()
+}
+
+func TestValidateAndConvertToUint16(t *testing.T) {
+	tests := []struct {
+		desc   string
+		input  int
+		output uint16
+	}{
+		{"less than 0", -1, uint16(0)},
+		{"is 0", 0, uint16(0)},
+		{"is max uint16", math.MaxUint16, uint16(math.MaxUint16)},
+		{"in uint16 range", 10, uint16(10)},
+		{"greater than uint16 range", math.MaxUint16 + 1, uint16(0)},
+	}
+
+	for _, tc := range tests {
+		result := validateAndConvertToUint16(tc.input)
+
+		assert.Equal(t, tc.output, result)
+	}
 }
 
 func Test_azure_fetch(t *testing.T) {


### PR DESCRIPTION
1. Add function to check uint16 limit