### PR TITLE
[EN] Replace reflect.DeepEqual with assert.Equal

### DIFF
--- a/cmd/gofr/migration/handler/migrate_test.go
+++ b/cmd/gofr/migration/handler/migrate_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -313,9 +312,7 @@ func Test_runMigration(t *testing.T) {
 			return
 		}
 
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("TEST[%d] Faile runMigration() got = %v, want %v", i, got, tt.want)
-		}
+		assert.Equal(t, tt.want, got, "TEST[%d], Failed.\n%s", i, tt.name)
 	}
 }
 

--- a/cmd/gofr/migration/migrate_test.go
+++ b/cmd/gofr/migration/migrate_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -177,14 +176,12 @@ func TestRedisAndMongo_Migration(t *testing.T) {
 
 	for i, v := range testcases {
 		err := Migrate(appName, dbmigration.NewRedis(redis), v.migrations, v.method, logger)
-		if !reflect.DeepEqual(err, v.err) {
-			t.Errorf("[TESTCASE%d]Redis : Got %v\tExpected %v\n", i+1, err, v.err)
-		}
+
+		assert.Equal(t, v.err, err, "TEST[%d], Failed.\n", i)
 
 		err = Migrate(appName, dbmigration.NewMongo(mongo), v.migrations, v.method, logger)
-		if !reflect.DeepEqual(err, v.err) {
-			t.Errorf("[TESTCASE%d]Mongo : Got %v\tExpected %v\n", i+1, err, v.err)
-		}
+
+		assert.Equal(t, v.err, err, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -230,9 +227,8 @@ func TestSQL_Migration(t *testing.T) {
 
 	for i, v := range testcases {
 		err := Migrate(appName, dbmigration.NewGorm(pgsql.DB), v.migrations, v.method, logger)
-		if !reflect.DeepEqual(err, v.err) {
-			t.Errorf("[TESTCASE%d]Got %v\tExpected %v\n", i+1, err, v.err)
-		}
+
+		assert.Equal(t, v.err, err, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -281,9 +277,8 @@ func TestCassandra_Migration(t *testing.T) {
 
 	for i, v := range testcases {
 		err := Migrate(appName, dbmigration.NewCassandra(&cassandra), v.migrations, v.method, logger)
-		if !reflect.DeepEqual(err, v.err) {
-			t.Errorf("[TESTCASE%d]Got %v\tExpected %v\n", i+1, err, v.err)
-		}
+
+		assert.Equal(t, v.err, err, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/cmd/gofr/test/schemas.go
+++ b/cmd/gofr/test/schemas.go
@@ -2,9 +2,9 @@ package test
 
 import (
 	"net/http"
-	"reflect"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/google/go-cmp/cmp"
 )
 
 type APIValues struct {
@@ -78,7 +78,7 @@ func (s *Swagger) convertIntoIntegrationTestSchema() IntegrationTestSchema {
 }
 
 func populateSlice(inputSlice []IntegrationTestCase, value IntegrationTestCase) []IntegrationTestCase {
-	if reflect.DeepEqual(IntegrationTestCase{}, value) {
+	if cmp.Equal(IntegrationTestCase{}, value) {
 		return inputSlice
 	}
 

--- a/examples/using-cassandra/stores/person/person_test.go
+++ b/examples/using-cassandra/stores/person/person_test.go
@@ -2,15 +2,15 @@ package person
 
 import (
 	"os"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	
 	"gofr.dev/examples/using-cassandra/models"
 	"gofr.dev/pkg/datastore"
 	"gofr.dev/pkg/errors"
 	"gofr.dev/pkg/gofr"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -41,7 +41,7 @@ func createMap(input []models.Person) map[models.Person]int {
 	output := make(map[models.Person]int)
 
 	for _, val := range input {
-		if reflect.DeepEqual(val, models.Person{}) {
+		if cmp.Equal(val, models.Person{}) {
 			output[val]++
 		}
 	}

--- a/examples/using-pubsub/handlers/handler_test.go
+++ b/examples/using-pubsub/handlers/handler_test.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -107,7 +106,7 @@ func TestProducerHandler(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://dummy", nil)
 	context := gofr.NewContext(nil, request.NewHTTPRequest(req), app)
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			context.SetPathParams(map[string]string{
@@ -122,9 +121,7 @@ func TestProducerHandler(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Producer() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got, "TEST[%d], Failed.\n", i)
 		})
 	}
 }

--- a/examples/using-solr/store/customer/customer_test.go
+++ b/examples/using-solr/store/customer/customer_test.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"reflect"
 	"testing"
+	
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/examples/using-solr/store"
 	"gofr.dev/pkg/datastore"
@@ -46,9 +47,7 @@ func TestCustomer_ListResponse(t *testing.T) {
 		t.Errorf("Expected nil error\tGot %v", err)
 	}
 
-	if !reflect.DeepEqual(resp, expectedResp) {
-		t.Errorf("Expected %v\tGot %v\n", expectedResp, resp)
-	}
+	assert.Equal(t, expectedResp, resp, "TEST Failed.\n")
 }
 
 func TestCustomer_Create(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/gocql/gocql v1.6.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/mock v1.6.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.5.0
 	github.com/googleapis/gax-go/v2 v2.12.0
 	github.com/gookit/color v1.5.4

--- a/pkg/datastore/cql_test.go
+++ b/pkg/datastore/cql_test.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"crypto/tls"
 	"io"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/gocql/gocql"
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg"
 	"gofr.dev/pkg/gofr/config"
@@ -236,9 +234,7 @@ func TestDataStore_CassandraHealthCheck(t *testing.T) {
 		con, _ := GetNewCassandra(logger, &mockCassConfig)
 		output := con.HealthCheck()
 
-		if !reflect.DeepEqual(tc.expected, output) {
-			t.Errorf("[FAILED]%v expected: %v, got: %v", i, tc.expected, output)
-		}
+		assert.Equal(t, tc.expected, output, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -289,9 +285,7 @@ func Test_CassandraHealthCheck(t *testing.T) {
 
 	output := con.HealthCheck()
 
-	if !reflect.DeepEqual(expected, output) {
-		t.Errorf("expected: %v, got: %v", expected, output)
-	}
+	assert.Equal(t, expected, output, "TEST Failed.\n")
 }
 
 func TestCQL_HealthCheck_NilObject(t *testing.T) {
@@ -303,9 +297,8 @@ func TestCQL_HealthCheck_NilObject(t *testing.T) {
 	var cql *Cassandra
 
 	resp := cql.HealthCheck()
-	if !reflect.DeepEqual(expected, resp) {
-		t.Errorf("expected: %v, got: %v", expected, resp)
-	}
+
+	assert.Equal(t, expected, resp, "TEST Failed.\n")
 }
 
 func Test_IncorrectSSLCertPathCql(t *testing.T) {

--- a/pkg/datastore/elasticsearch_test.go
+++ b/pkg/datastore/elasticsearch_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -67,9 +66,7 @@ func TestDataStore_ElasticsearchHealthCheck_ErrorLog(t *testing.T) {
 
 	output := conn.HealthCheck()
 
-	if !reflect.DeepEqual(output, expectedResp) {
-		t.Errorf("[TESTCASE] Failed.\nExpected: %v,\nGot: %v", expectedResp, output)
-	}
+	assert.Equal(t, expectedResp, output, "TEST Failed.\n")
 
 	if !assert.Contains(t, b.String(), expectedLogMessage) {
 		t.Errorf("expected: %v, got: %v", expectedLogMessage, b.String())
@@ -92,9 +89,8 @@ func TestDataStore_ElasticsearchHealthCheck(t *testing.T) {
 		conn, _ := NewElasticsearchClient(log.NewMockLogger(io.Discard), &mockConfig)
 
 		output := conn.HealthCheck()
-		if !reflect.DeepEqual(output, tc.expected) {
-			t.Errorf("[TESTCASE%v] Failed.\nExpected: %v,\nGot: %v", i+1, tc.expected, output)
-		}
+
+		assert.Equal(t, tc.expected, output, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -181,9 +177,7 @@ func Test_Bind(t *testing.T) {
 			t.Errorf("TESTCASE[%v] expected no error, got %v", i, err)
 		}
 
-		if !reflect.DeepEqual(tc.expOut, d) {
-			t.Errorf("TESTCASE[%v] expected %v, got %v", i, tc.expOut, d)
-		}
+		assert.Equal(t, tc.expOut, d, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -264,9 +258,7 @@ func Test_BindArray(t *testing.T) {
 		{ID: "1", Name: "test"},
 	}
 
-	if !reflect.DeepEqual(expData, d) {
-		t.Errorf("expected %v, got %v", expData, d)
-	}
+	assert.Equal(t, expData, d, "TEST Failed.\n")
 }
 
 func insertData(t *testing.T, es *Elasticsearch, data data) {

--- a/pkg/datastore/mongodb_test.go
+++ b/pkg/datastore/mongodb_test.go
@@ -311,7 +311,7 @@ func Test_MongoMonitorSucceeded(t *testing.T) {
 		got := toMap(m.event)
 
 		// ensuring the key is deleted
-		assert.Equal(t, tc.expectedLog, got, "TEST[%d], Failed.\n", i)
+		assert.Equal(t, tc.expectedMap, got, "TEST[%d], Failed.\n", i)
 
 		if !strings.Contains(b.String(), tc.expectedLog) {
 			t.Errorf("[TESTCASE%d]Failed.Expected: %v\nGot: %v", i+1, tc.expectedLog, b.String())
@@ -352,7 +352,7 @@ func Test_MongoMonitorFailed(t *testing.T) {
 		}
 
 		// ensuring the key is deleted
-		assert.Equal(t, tc.expectedLog, got, "TEST[%d], Failed.\n", i)
+		assert.Equal(t, tc.expectedMap, got, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/pkg/datastore/mongodb_test.go
+++ b/pkg/datastore/mongodb_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -115,9 +114,8 @@ func TestGetMongoConfigFromEnv_SSL_RetryWrites(t *testing.T) {
 		t.Setenv("MONGO_DB_RETRY_WRITES", testcases[i].retryWrites)
 
 		_, err := getMongoConfigFromEnv()
-		if !reflect.DeepEqual(err, testcases[i].expErr) {
-			t.Errorf("Expected: %v, Got:%v", testcases[i].expErr, err)
-		}
+
+		assert.Equal(t, testcases[i].expErr, err, "TEST[%d], Failed.\n", i)
 	}
 
 	t.Setenv("MONGO_DB_ENABLE_SSL", oldEnableSSL)
@@ -170,9 +168,8 @@ func TestDataStore_HealthCheck(t *testing.T) {
 		conn, _ := GetNewMongoDB(logger, &mockConfig)
 
 		output := conn.HealthCheck()
-		if !reflect.DeepEqual(output, tc.expected) {
-			t.Errorf("TESTCASE [%v] FAILED, Got %v, Expected %v", i, output, tc.expected)
-		}
+
+		assert.Equal(t, tc.expected, output, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -227,9 +224,8 @@ func TestDataStore_HealthCheck_Down(t *testing.T) {
 	}
 
 	resp := m.HealthCheck()
-	if !reflect.DeepEqual(resp, expectedResponse) {
-		t.Errorf("expected %v\tgot %v", expectedResponse, resp)
-	}
+
+	assert.Equal(t, expectedResponse, resp, "TEST Failed.\n")
 }
 
 func Test_MonitorMongo(t *testing.T) {
@@ -282,9 +278,7 @@ func Test_MongoMonitorStarted(t *testing.T) {
 
 		got := toMap(m.event)
 
-		if !reflect.DeepEqual(got, tc.expectedEvent) {
-			t.Errorf("[TESTCASE%d]Failed.Expected: %v\nGot: %v", i+1, tc.expectedEvent, got)
-		}
+		assert.Equal(t, tc.expectedEvent, got, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -317,9 +311,7 @@ func Test_MongoMonitorSucceeded(t *testing.T) {
 		got := toMap(m.event)
 
 		// ensuring the key is deleted
-		if !reflect.DeepEqual(got, tc.expectedMap) {
-			t.Errorf("[TESTCASE%d]Failed.Expected: %v\nGot: %v", i+1, tc.expectedMap, got)
-		}
+		assert.Equal(t, tc.expectedLog, got, "TEST[%d], Failed.\n", i)
 
 		if !strings.Contains(b.String(), tc.expectedLog) {
 			t.Errorf("[TESTCASE%d]Failed.Expected: %v\nGot: %v", i+1, tc.expectedLog, b.String())
@@ -360,9 +352,7 @@ func Test_MongoMonitorFailed(t *testing.T) {
 		}
 
 		// ensuring the key is deleted
-		if !reflect.DeepEqual(got, tc.expectedMap) {
-			t.Errorf("[TESTCASE%d]Failed.Expected: %v\nGot: %v", i+1, tc.expectedMap, got)
-		}
+		assert.Equal(t, tc.expectedLog, got, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/pkg/datastore/pubsub/eventhub/eventhub_test.go
+++ b/pkg/datastore/pubsub/eventhub/eventhub_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,9 +86,8 @@ func TestEventhub_HealthCheck(t *testing.T) {
 		conn, _ := New(&testConfig)
 
 		resp := conn.HealthCheck()
-		if !reflect.DeepEqual(resp, v.resp) {
-			t.Errorf("[TESTCASE%d]Failed.Got %v\tExpected %v\n", i+1, resp, v.resp)
-		}
+
+		assert.Equal(t, v.resp, resp, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -105,9 +103,8 @@ func TestEventhub_HealthCheck_Down(t *testing.T) {
 		}
 
 		resp := e.HealthCheck()
-		if !reflect.DeepEqual(resp, expected) {
-			t.Errorf("Expected %v\tGot %v\n", expected, resp)
-		}
+
+		assert.Equal(t, expected, resp, "TEST Failed.\n")
 	}
 
 	{
@@ -123,9 +120,8 @@ func TestEventhub_HealthCheck_Down(t *testing.T) {
 		con, _ := New(&c)
 
 		resp := con.HealthCheck()
-		if !reflect.DeepEqual(resp, expected) {
-			t.Errorf("Expected %v\tGot %v\n", expected, resp)
-		}
+
+		assert.Equal(t, expected, resp, "TEST Failed.\n")
 	}
 
 	{
@@ -146,9 +142,8 @@ func TestEventhub_HealthCheck_Down(t *testing.T) {
 		e.hub = nil
 
 		resp := e.HealthCheck()
-		if !reflect.DeepEqual(resp, expected) {
-			t.Errorf("Expected %v\tGot %v\n", expected, resp)
-		}
+
+		assert.Equal(t, expected, resp, "TEST Failed.\n")
 	}
 }
 

--- a/pkg/datastore/pubsub/kafka/kafka_test.go
+++ b/pkg/datastore/pubsub/kafka/kafka_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -90,11 +89,10 @@ func TestNewKafkaConsumer(t *testing.T) {
 		{&Config{Brokers: "localhost:2009", Topics: []string{"some-topic"}}, nil},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		_, err := NewKafkaConsumer(test.config)
-		if !reflect.DeepEqual(test.err, err) {
-			t.Errorf("FAILED, expected: %v, got: %v", test.err, err)
-		}
+
+		assert.Equal(t, test.err, err, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -468,9 +466,7 @@ func TestKafkaHealthCheck(t *testing.T) {
 		conn, _ := New(&mockConfig, logger)
 		output := conn.HealthCheck()
 
-		if !reflect.DeepEqual(tc.expected, output) {
-			t.Errorf("[TESTCASE%v]Failed. Got%v Expected%v", i+1, output, tc.expected)
-		}
+		assert.Equal(t, tc.expected, output, "TEST[%d], Failed.\n", i)
 
 		if !strings.Contains(b.String(), tc.logMessage) {
 			t.Errorf("Test Failed \nExpected: %v\nGot: %v", tc.logMessage, b.String())

--- a/pkg/datastore/redis_test.go
+++ b/pkg/datastore/redis_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net"
-	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -91,7 +90,7 @@ func TestNewRedisCluster(t *testing.T) {
 		{"Error case", args{log.NewLogger(), &goRedis.ClusterOptions{}}, nil, true},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewRedisCluster(tt.args.clusterOptions)
@@ -101,9 +100,7 @@ func TestNewRedisCluster(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewRedisCluster() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got, "TEST[%d], Failed.\n%s", i, tt.name)
 		})
 	}
 }

--- a/pkg/datastore/ycql_test.go
+++ b/pkg/datastore/ycql_test.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"bytes"
 	"io"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -219,9 +218,7 @@ func TestDataStore_YCQLHealthCheck(t *testing.T) {
 		con, _ := GetNewYCQL(logger, &mockConfig)
 		output := con.HealthCheck()
 
-		if !reflect.DeepEqual(tc.expected, output) {
-			t.Errorf("[FAILED]%v expected: %v, got: %v", i, tc.expected, output)
-		}
+		assert.Equal(t, tc.expected, output, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -272,9 +269,7 @@ func Test_YCQLHealthCheck_Down(t *testing.T) {
 
 	output := con.HealthCheck()
 
-	if !reflect.DeepEqual(expected, output) {
-		t.Errorf("expected: %v, got: %v", expected, output)
-	}
+	assert.Equal(t, expected, output, "TEST Failed.\n")
 }
 
 func TestYCQL_HealthCheck_NilObject(t *testing.T) {
@@ -286,9 +281,8 @@ func TestYCQL_HealthCheck_NilObject(t *testing.T) {
 	var ycql *YCQL
 
 	resp := ycql.HealthCheck()
-	if !reflect.DeepEqual(expected, resp) {
-		t.Errorf("expected: %v, got: %v", expected, resp)
-	}
+
+	assert.Equal(t, expected, resp, "TEST Failed.\n")
 }
 
 func Test_IncorrectSSLCertPathYCQL(t *testing.T) {

--- a/pkg/file/gcp_test.go
+++ b/pkg/file/gcp_test.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,9 +37,7 @@ func Test_gcp_fetch(t *testing.T) {
 
 	resp := gcpFile.fetch(localFile.FD)
 
-	if reflect.DeepEqual(resp, err) {
-		t.Errorf("expected: %v, got: %v", resp, err)
-	}
+	assert.NotEqual(t, err, resp, "TEST Failed.\n")
 
 	_ = localFile.Close()
 }
@@ -54,9 +51,7 @@ func Test_gcp_push(t *testing.T) {
 
 	resp := gcpFile.push(localFile.FD)
 
-	if reflect.DeepEqual(resp, nil) {
-		t.Errorf("expected: %v, got: %v", resp, nil)
-	}
+	assert.NotNil(t, resp, "TEST Failed.\n")
 
 	_ = localFile.Close()
 }

--- a/pkg/gofr/app-server_test.go
+++ b/pkg/gofr/app-server_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -346,9 +345,8 @@ func TestFilterValidRoutes(t *testing.T) {
 	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := filterValidRoutes(tc.input)
-			if !reflect.DeepEqual(result, tc.expected) {
-				t.Errorf("TEST[%d] Failed,Expected %v, but got %v", i, tc.expected, result)
-			}
+
+			assert.Equal(t, tc.expected, result, "TEST[%d], Failed.\n%s", i, tc.name)
 		})
 	}
 }

--- a/pkg/gofr/cache/redis_test.go
+++ b/pkg/gofr/cache/redis_test.go
@@ -1,9 +1,10 @@
 package cache
 
 import (
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/datastore"
 	"gofr.dev/pkg/gofr/config"
@@ -26,9 +27,8 @@ func testRedisCacherGet(t *testing.T, redis RedisCacher) {
 	expectedVal := []byte("123")
 
 	resp, _ := redis.Get("k1")
-	if !reflect.DeepEqual(resp, expectedVal) {
-		t.Errorf("[RedisGet]Failed.Got %v\tExpected %v\n", resp, expectedVal)
-	}
+
+	assert.Equal(t, expectedVal, resp, "TEST Failed.\n")
 }
 
 func testRedisCacherSet(t *testing.T, redis RedisCacher) {

--- a/pkg/gofr/context_test.go
+++ b/pkg/gofr/context_test.go
@@ -5,7 +5,6 @@ import (
 	ctx "context"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"sync"
 	"testing"
 
@@ -58,9 +57,7 @@ func TestContext_Params(t *testing.T) {
 		c := NewContext(nil, req, nil)
 		params := c.Params()
 
-		if !reflect.DeepEqual(params, tc.expected) {
-			t.Errorf("FAILED, Expected: %v, Got: %v", tc.expected, params)
-		}
+		assert.Equal(t, tc.expected, params, "TEST[%d], Failed.\n")
 	}
 }
 
@@ -203,9 +200,8 @@ func Test_Log(t *testing.T) {
 		// fetch the appData from request context and generate a map of type map[string]interface{}, if appData is nil
 		// then getAppData will return empty map
 		data := getAppData(c.req.Request().Context())
-		if !reflect.DeepEqual(data, tc.data) {
-			t.Errorf("Failed[%v] expected value:%v \n got: %v", i, tc.data, data)
-		}
+
+		assert.Equal(t, tc.data, data, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -229,9 +225,8 @@ func TestLog_CorrelationModify(t *testing.T) {
 	}
 
 	got, _ := c.req.Request().Context().Value(appData).(map[string]interface{})
-	if !reflect.DeepEqual(got, expected) {
-		t.Errorf("FAILED, Expected: %v, Got: %v", expected, got)
-	}
+
+	assert.Equal(t, expected, got, "TEST Failed.\n")
 }
 
 func TestContext_ValidateClaimSubPFCX(t *testing.T) {

--- a/pkg/gofr/dbConfig_test.go
+++ b/pkg/gofr/dbConfig_test.go
@@ -350,7 +350,7 @@ func Test_getElasticSearchConfigFromEnv(t *testing.T) {
 	for i, tc := range testcases {
 		output := elasticSearchConfigFromEnv(tc.input, tc.prefix)
 
-		assert.Equal(t, tc, output, output, "TEST[%d], Failed.\n", i)
+		assert.Equal(t, tc.output, output, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/pkg/gofr/dbConfig_test.go
+++ b/pkg/gofr/dbConfig_test.go
@@ -3,7 +3,6 @@ package gofr
 import (
 	"crypto/tls"
 	"io"
-	"reflect"
 	"testing"
 	"time"
 
@@ -97,10 +96,8 @@ func Test_cassandraConfigFromEnv(t *testing.T) {
 		cassandraConfig := cassandraConfigFromEnv(tc.configLoc, tc.prefix)
 		expectedConfig := tc.expectedConfig
 
-		if !reflect.DeepEqual(cassandraConfig, &expectedConfig) {
-			if tc.expectedError == false {
-				t.Errorf("Test[%d]Fail:%vGot: %v,expected:%v", i, tc.name, cassandraConfig, tc.expectedConfig)
-			}
+		if tc.expectedError == false {
+			assert.Equal(t, &expectedConfig, cassandraConfig, "TEST[%d], Failed.\n%s", i, tc.name)
 		}
 	}
 }
@@ -149,10 +146,9 @@ func Test_GetYcqlConfigs(t *testing.T) {
 
 	for i, tc := range testCases {
 		cassandraConfig := getYcqlConfigs(tc.configLoc, tc.prefix)
-		if !reflect.DeepEqual(cassandraConfig, tc.expectedConfig) {
-			if tc.expectedError == false {
-				t.Errorf("Testcase[%v] Failed:%vGot: %v,expected:%v", i, tc.name, cassandraConfig, tc.expectedConfig)
-			}
+
+		if tc.expectedError == false {
+			assert.Equal(t, tc.expectedConfig, cassandraConfig, "TEST[%d], Failed.\n%s", i, tc.name)
 		}
 	}
 }
@@ -182,9 +178,7 @@ func Test_kafkaConfigFromEnv(t *testing.T) {
 		res := kafkaConfigFromEnv(tc.config, "")
 		mockConfg := tc.expectedConfig
 
-		if !reflect.DeepEqual(res, &mockConfg) {
-			t.Errorf("Test case failed [%v]. Got: %v,expected:%v", i, tc.config, tc.expectedConfig)
-		}
+		assert.Equal(t, &mockConfg, res, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -258,14 +252,12 @@ func Test_mongoDBConfigFromEnv(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		mongoConfig := mongoDBConfigFromEnv(tc.configLoc, tc.prefix)
 		expConfig := tc.expectedConfig
 
-		if !reflect.DeepEqual(mongoConfig, &expConfig) {
-			if tc.expectedError == false {
-				t.Errorf("Got: %v,expected:%v", mongoConfig, tc.expectedConfig)
-			}
+		if tc.expectedError == false {
+			assert.Equal(t, &expConfig, mongoConfig, "TEST[%d], Failed.\n%s", i, tc.name)
 		}
 	}
 }
@@ -294,9 +286,8 @@ func Test_dynamoDBConfigFromEnv(t *testing.T) {
 
 	for i, tc := range testcases {
 		cfg := dynamoDBConfigFromEnv(tc.inputConfig, tc.prefix)
-		if !reflect.DeepEqual(cfg, expConfig) {
-			t.Errorf("Test case failed [%v], Got: %v,expected:%v", i, cfg, expConfig)
-		}
+
+		assert.Equal(t, expConfig, cfg, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -359,9 +350,7 @@ func Test_getElasticSearchConfigFromEnv(t *testing.T) {
 	for i, tc := range testcases {
 		output := elasticSearchConfigFromEnv(tc.input, tc.prefix)
 
-		if !reflect.DeepEqual(output, tc.output) {
-			t.Errorf("[TESTCASE%v] Failed.\nExpected:%v\nGot: %v", i+1, tc.output, output)
-		}
+		assert.Equal(t, tc, output, output, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -150,7 +150,7 @@ func TestGofrUseMiddlewarePopulated(t *testing.T) {
 
 	assert.Equal(t, 2, len(g.Server.mws), "TEST Failed.\n")
 
-	assert.Equal(t, []Middleware{sampleMW1, sampleMW2}, g.Server.mws, "TEST Failed.\n")
+	assert.NotEqual(t, []Middleware{sampleMW1, sampleMW2}, g.Server.mws, "TEST Failed.\n")
 }
 
 func sampleMW1(h http.Handler) http.Handler {

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -132,9 +131,9 @@ func TestGofrUseMiddleware(t *testing.T) {
 
 	g.Server.UseMiddleware(mws...)
 
-	if len(g.Server.mws) != 2 || !reflect.DeepEqual(g.Server.mws, mws) {
-		t.Errorf("FAILED, Expected: %v, Got: %v", mws, g.Server.mws)
-	}
+	assert.Equal(t, 2, len(g.Server.mws), "TEST Failed.\n")
+
+	assert.Equal(t, mws, g.Server.mws, "TEST Failed.\n")
 }
 
 func TestGofrUseMiddlewarePopulated(t *testing.T) {
@@ -149,9 +148,9 @@ func TestGofrUseMiddlewarePopulated(t *testing.T) {
 
 	g.Server.UseMiddleware(mws...)
 
-	if len(g.Server.mws) != 2 || reflect.DeepEqual(g.Server.mws, []Middleware{sampleMW1, sampleMW2}) {
-		t.Errorf("FAILED, Expected: %v, Got: %v", mws, g.Server.mws)
-	}
+	assert.Equal(t, 2, len(g.Server.mws), "TEST Failed.\n")
+
+	assert.Equal(t, []Middleware{sampleMW1, sampleMW2}, g.Server.mws, "TEST Failed.\n")
 }
 
 func sampleMW1(h http.Handler) http.Handler {
@@ -170,9 +169,7 @@ func TestGofr_Config(t *testing.T) { // check config is properly set or not?
 	g := New()
 	val := g.Config.Get("APP_NAME")
 
-	if !reflect.DeepEqual(expected, val) {
-		t.Errorf("FAILED, Expected: %v, Got: %v", expected, val)
-	}
+	assert.Equal(t, expected, val, "TEST Failed.\n")
 }
 
 func TestGofr_Patch(t *testing.T) {

--- a/pkg/gofr/handler_test.go
+++ b/pkg/gofr/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -187,9 +186,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 
 	expectedResponse := []byte(`{"data":{"product":{"name":"Orange","categoryId":1}}}`)
 
-	if !reflect.DeepEqual(string(expectedResponse), strings.TrimSpace(w.Body)) {
-		t.Errorf("Failed. Incorrect Response format. Expected %v\tGot %v\n", string(expectedResponse), w.Body)
-	}
+	assert.Equal(t, string(expectedResponse), strings.TrimSpace(w.Body), "TEST Failed.\n")
 }
 
 type product struct {
@@ -259,14 +256,9 @@ func TestHandler_ServeHTTP_PartialContent(t *testing.T) {
 	//nolint:lll // response should be of this type
 	expectedResponse := []byte(`{"data":{"errors":[{"code":"","reason":"test error","datetime":{"value":"2020-07-01T14:54:41Z","timezone":"IST"}}],"product":{"categoryId":1,"name":"Orange"}}}`)
 
-	if !reflect.DeepEqual(string(expectedResponse), strings.TrimSpace(w.Body)) {
-		t.Errorf("Failed. Incorrect Response format. Expected %v\tGot %v\n", string(expectedResponse), w.Body)
-		return
-	}
+	assert.Equal(t, string(expectedResponse), strings.TrimSpace(w.Body), "TEST Failed.\n")
 
-	if w.Status != 206 {
-		t.Errorf("Failed. StatusCode expected: 206, got: %v", w.Status)
-	}
+	assert.Equal(t, http.StatusPartialContent, w.Status, "TEST Failed.\n")
 }
 
 // TestHandler_ServeHTTP_EntityAlreadyExists
@@ -290,14 +282,9 @@ func TestHandler_ServeHTTP_EntityAlreadyExists(t *testing.T) {
 
 	expectedResponse := []byte(`{"data":{"product":{"name":"Orange","categoryId":1}}}`)
 
-	if !reflect.DeepEqual(string(expectedResponse), strings.TrimSpace(w.Body)) {
-		t.Errorf("Failed. Incorrect Response format. Expected %v\tGot %v\n", string(expectedResponse), w.Body)
-		return
-	}
+	assert.Equal(t, string(expectedResponse), strings.TrimSpace(w.Body), "TEST Failed.\n")
 
-	if w.Status != 200 {
-		t.Errorf("Failed. StatusCode expected: 200, got: %v", w.Status)
-	}
+	assert.Equal(t, http.StatusOK, w.Status, "TEST Failed.\n")
 }
 
 // Test_HealthInvalidMethod checks the health for method.
@@ -404,14 +391,9 @@ func TestHTTP_Respond_Delete(t *testing.T) {
 
 	expectedResponse := []byte(`{"data":null}`)
 
-	if !reflect.DeepEqual(string(expectedResponse), strings.TrimSpace(w.Body)) {
-		t.Errorf("Failed. Incorrect Response format. Expected %v\tGot %v\n", string(expectedResponse), w.Body)
-		return
-	}
+	assert.Equal(t, string(expectedResponse), strings.TrimSpace(w.Body), "TEST Failed.\n")
 
-	if w.Status != http.StatusNoContent {
-		t.Errorf("Failed. StatusCode expected: %v, got: %v", http.StatusNoContent, w.Status)
-	}
+	assert.Equal(t, http.StatusNoContent, w.Status, "TEST Failed.\n")
 }
 
 // TestHandler_ServeHTTP_Error tests the different error cases returned from Respond

--- a/pkg/gofr/health_test.go
+++ b/pkg/gofr/health_test.go
@@ -98,7 +98,7 @@ func Test_server_HeartCheck(t *testing.T) {
 			time.Sleep(3 * time.Second)
 			got := fmt.Sprintf("%s", s.Server.Router)
 
-			assert.Equal(t, tt.want, got, "TEST[%d], Failed.\n", i)
+			assert.NotEqual(t, tt.want, got, "TEST[%d], Failed.\n", i)
 		})
 	}
 }

--- a/pkg/gofr/health_test.go
+++ b/pkg/gofr/health_test.go
@@ -3,7 +3,6 @@ package gofr
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 	"time"
 
@@ -90,7 +89,8 @@ func Test_server_HeartCheck(t *testing.T) {
 	}{
 		{"test1", "GET /.well-known/health-check"},
 	}
-	for _, tt := range tests {
+
+	for i, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			http.DefaultServeMux = new(http.ServeMux)
@@ -98,9 +98,7 @@ func Test_server_HeartCheck(t *testing.T) {
 			time.Sleep(3 * time.Second)
 			got := fmt.Sprintf("%s", s.Server.Router)
 
-			if reflect.DeepEqual(got, tt.want) {
-				t.Errorf(" got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got, "TEST[%d], Failed.\n", i)
 		})
 	}
 }

--- a/pkg/gofr/metrics/promvec_test.go
+++ b/pkg/gofr/metrics/promvec_test.go
@@ -33,7 +33,6 @@ func Test_IncCounter(t *testing.T) {
 	}
 }
 
-//nolint:dupl // duplicate code is for different metrics
 func Test_AddCounter(t *testing.T) {
 	tcs := []struct {
 		desc string
@@ -108,7 +107,6 @@ func Test_SetGauge(t *testing.T) {
 	}
 }
 
-//nolint:dupl // duplicate code is for different metrics
 func Test_ObserveSummary(t *testing.T) {
 	tcs := []struct {
 		desc string

--- a/pkg/gofr/metrics/promvec_test.go
+++ b/pkg/gofr/metrics/promvec_test.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -29,9 +28,8 @@ func Test_IncCounter(t *testing.T) {
 
 	for i, tc := range tcs {
 		err = p.IncCounter(tc.name, "200", http.MethodPost)
-		if !reflect.DeepEqual(tc.err, err) {
-			t.Errorf("TESTCASE[%v] expected error %T, got %T", i, tc.err, err)
-		}
+
+		assert.Equal(t, tc.err, err, "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }
 
@@ -55,9 +53,8 @@ func Test_AddCounter(t *testing.T) {
 
 	for i, tc := range tcs {
 		err = p.AddCounter(tc.name, float64(i), "200", http.MethodPost)
-		if !reflect.DeepEqual(tc.err, err) {
-			t.Errorf("TESTCASE[%v] expected error %v, got %v", i, tc.err, err)
-		}
+
+		assert.Equal(t, tc.err, err, "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }
 
@@ -82,9 +79,8 @@ func Test_ObserveHistogram(t *testing.T) {
 
 	for i, tc := range tcs {
 		err = p.ObserveHistogram(tc.name, float64(i), "200", http.MethodPost)
-		if !reflect.DeepEqual(tc.err, err) {
-			t.Errorf("TESTCASE[%v] expected error %v, got %v", i, tc.err, err)
-		}
+
+		assert.Equal(t, tc.err, err, "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }
 
@@ -107,9 +103,8 @@ func Test_SetGauge(t *testing.T) {
 
 	for i, tc := range tcs {
 		err = p.SetGauge(tc.name, float64(i), "no_of_go_routines")
-		if !reflect.DeepEqual(tc.err, err) {
-			t.Errorf("TESTCASE[%v] expected error %v, got %v", i, tc.err, err)
-		}
+
+		assert.Equal(t, tc.err, err, "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }
 
@@ -133,9 +128,8 @@ func Test_ObserveSummary(t *testing.T) {
 
 	for i, tc := range tcs {
 		err = p.ObserveSummary(tc.name, float64(i), "200", http.MethodPost)
-		if !reflect.DeepEqual(tc.err, err) {
-			t.Errorf("TESTCASE[%v] expected error %v, got %v", i, tc.err, err)
-		}
+
+		assert.Equal(t, tc.err, err, "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }
 

--- a/pkg/gofr/openapi_test.go
+++ b/pkg/gofr/openapi_test.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 	"gofr.dev/pkg/log"
@@ -267,8 +268,8 @@ func TestOpenAPIHandlerError(t *testing.T) {
 	data := w.Body.Bytes()
 	_ = json.Unmarshal(data, &resp)
 
-	if w.Code != http.StatusNotFound && !reflect.DeepEqual(expResp, resp) {
-		t.Errorf("want status code 200 got= %v", w.Code)
+	if w.Code != http.StatusNotFound {
+		assert.Equal(t, expResp, resp, "TEST Failed.\n")
 	}
 }
 

--- a/pkg/gofr/request/cmd_test.go
+++ b/pkg/gofr/request/cmd_test.go
@@ -2,7 +2,6 @@ package request
 
 import (
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -109,9 +108,7 @@ func TestCMD_Params(t *testing.T) {
 	got := c.Params()
 	expected := c.params
 
-	if !reflect.DeepEqual(expected, got) {
-		t.Errorf("FAILED, Expected: %v, Got: %v", expected, got)
-	}
+	assert.Equal(t, expected, got, "TEST Failed.\n")
 }
 
 func TestCMD_Request(t *testing.T) {

--- a/pkg/gofr/request/http_test.go
+++ b/pkg/gofr/request/http_test.go
@@ -8,7 +8,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -99,9 +98,7 @@ func TestHTTP_Param(t *testing.T) {
 
 		got := h.Param(tc.k)
 
-		if !reflect.DeepEqual(tc.expected, got) {
-			t.Errorf("FAILED, %v expected: %v, got: %v", i, tc.expected, got)
-		}
+		assert.Equal(t, tc.expected, got, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -120,7 +117,7 @@ func TestHTTP_ParamNames(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for i, tc := range tcs {
 		var h HTTP
 
 		h.req = httptest.NewRequest("GET", urlHTTPDummy+tc.queryParams, http.NoBody)
@@ -131,9 +128,7 @@ func TestHTTP_ParamNames(t *testing.T) {
 			return len(got[i]) < len(got[j])
 		})
 
-		if !reflect.DeepEqual(tc.expected, got) {
-			t.Errorf("FAILED, expected: %v, got: %v", tc.expected, got)
-		}
+		assert.Equal(t, tc.expected, got, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -161,16 +156,14 @@ func TestHTTP_Params(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for i, tc := range tcs {
 		var h HTTP
 
 		h.req = httptest.NewRequest("GET", urlHTTPDummy+tc.queryParams, http.NoBody)
 
 		got := h.Params()
 
-		if !reflect.DeepEqual(tc.expected, got) {
-			t.Errorf("FAILED, expected: %v, got: %v", tc.expected, got)
-		}
+		assert.Equal(t, tc.expected, got, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -195,7 +188,7 @@ func TestHTTP_PathParam(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for i, tc := range tcs {
 		var h HTTP
 
 		h.req = httptest.NewRequest("GET", urlHTTPDummy, http.NoBody)
@@ -209,9 +202,7 @@ func TestHTTP_PathParam(t *testing.T) {
 
 		got := h.PathParam(tc.key)
 
-		if !reflect.DeepEqual(tc.expectedValue, got) {
-			t.Errorf("FAILED, expected: %v, got: %v", tc.expectedValue, got)
-		}
+		assert.Equal(t, tc.expectedValue, got, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -235,7 +226,7 @@ func TestHTTP_Body(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for i, tc := range tcs {
 		var (
 			h   HTTP
 			req = httptest.NewRequest(http.MethodPost, urlHTTPDummy, tc.reqBody)
@@ -245,12 +236,10 @@ func TestHTTP_Body(t *testing.T) {
 
 		response, err := h.Body()
 
-		if reflect.DeepEqual(tc.reqBody, malformedReader{}) && err == nil {
-			t.Errorf("FAILED, expected: %v, got: %v", "read error", err)
-		}
+		if err == nil {
+			assert.NotEqual(t, tc.reqBody, malformedReader{}, "TEST[%d], Failed.\n", i)
 
-		if err == nil && string(response) != rb {
-			t.Errorf("FAILED, expected: %v, got: %v", rb, string(response))
+			assert.Equal(t, rb, string(response), "TEST[%d], Failed.\n", i)
 		}
 	}
 }
@@ -310,7 +299,7 @@ func TestHTTP_Bind(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
+	for i, tc := range tcs {
 		var (
 			h   HTTP
 			req = httptest.NewRequest(http.MethodPost, urlHTTPDummy, tc.reqBody)
@@ -324,9 +313,7 @@ func TestHTTP_Bind(t *testing.T) {
 
 		err := h.Bind(tc.i)
 
-		if err != nil && !reflect.DeepEqual(tc.err, err) {
-			t.Errorf("FAILED, expected: %v, got: %v", tc.err, err)
-		}
+		assert.Equal(t, tc.err, err, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/pkg/gofr/responder/http_test.go
+++ b/pkg/gofr/responder/http_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -48,7 +47,7 @@ func TestNewContextualResponder(t *testing.T) {
 		{"text/plain", "X-Correlation-ID", &HTTP{w: w, resType: TEXT, method: "GET", path: path, correlationID: correlationID}},
 	}
 
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		r := httptest.NewRequest("GET", "/dummy", http.NoBody)
 
 		// handler to set the routeKey in request context
@@ -65,9 +64,9 @@ func TestNewContextualResponder(t *testing.T) {
 		r.Header.Set("Content-Type", tc.contentType)
 		r.Header.Set(tc.correlationIDHeader, correlationID)
 
-		if got := NewContextualResponder(w, r); !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("NewContextualResponder() = %v, want %v", got, tc.want)
-		}
+		got := NewContextualResponder(w, r)
+
+		assert.Equal(t, tc.want, got, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/pkg/gofr/router_test.go
+++ b/pkg/gofr/router_test.go
@@ -2,7 +2,6 @@ package gofr
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -32,9 +31,7 @@ func TestRouteLog(t *testing.T) {
 
 	got := fmt.Sprintf("%s"+"", g.Server.Router)
 
-	if !reflect.DeepEqual(got, expected) {
-		t.Errorf("expected: %v, got: %v", expected, got)
-	}
+	assert.Equal(t, expected, got, "TEST Failed.\n")
 }
 
 // TestRouter_WellKnownEndpoint test Router for well-known endpoints

--- a/pkg/gofr/types/address_test.go
+++ b/pkg/gofr/types/address_test.go
@@ -2,9 +2,10 @@ package types
 
 import (
 	"encoding/json"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -68,14 +69,13 @@ func TestAddress_Check(t *testing.T) {
 		{"address with county", Address{AddressLines: []string{"banglored"}, CityTown: "bengaluru",
 			StateProvince: "karnataka", CountryCode: "IN", PostalCode: "560043", DeliveryPoint: "23", County: "Franklin"}, nil},
 	}
-	for _, tt := range tests {
+
+	for i, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := Validate(&tt.addstruct)
 
-			if !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("%v, Failed. Got :%v\tExpected: %v", tt.name, err, tt.err)
-			}
+			assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n%s", i, tt.name)
 		})
 	}
 }

--- a/pkg/gofr/types/currency_test.go
+++ b/pkg/gofr/types/currency_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -21,12 +22,11 @@ func TestCurrency_Check(t *testing.T) {
 		{"wrong currency format passed", "USD ABCD efg", errors.InvalidParam{Param: []string{"currency"}}},
 		{"symbolic representation of currency", "$ 123.00", errors.InvalidParam{Param: []string{"currencyCountryCode"}}},
 	}
-	for _, tt := range tests {
+
+	for i, tt := range tests {
 		tt := tt
 		err := Validate(tt.currency)
 
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("%v, Failed. Got :%v\tExpected: %v", tt.name, err, tt.err)
-		}
+		assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n%s", i, tt.name)
 	}
 }

--- a/pkg/gofr/types/date_test.go
+++ b/pkg/gofr/types/date_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -19,12 +20,12 @@ func TestDate_Check(t *testing.T) {
 		{"date format incorrect", "2018-10-1", errors.InvalidParam{Param: []string{"date"}}},
 		{"date format incorrect datetime", "2018-10-01 10-05-02", errors.InvalidParam{Param: []string{"date"}}},
 	}
-	for _, tt := range tests {
+
+	for i, tt := range tests {
 		tt := tt
 
 		err := Validate(tt.date)
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("%v, Failed. Got :%v\tExpected: %v", tt.name, err, tt.err)
-		}
+
+		assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n%s", i, tt.name)
 	}
 }

--- a/pkg/gofr/types/datetime_test.go
+++ b/pkg/gofr/types/datetime_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+	
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -17,14 +18,13 @@ func TestDatetime_Check(t *testing.T) {
 		{"empty timezone struct", Datetime{Value: "2018-07-14T05:00:00Z", Timezone: ".."}, errors.InvalidParam{Param: []string{"timezone"}}},
 		{"correct datetime struct", Datetime{Value: "2018-07-14T05:00:00Z", Timezone: "America/New_York"}, nil},
 	}
-	for _, tt := range tests {
+
+	for i, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := Validate(tt.dateTime)
 
-			if !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("%v, Failed. Got :%v\tExpected: %v", tt.name, err, tt.err)
-			}
+			assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n%s", i, tt.name)
 		})
 	}
 }
@@ -40,14 +40,13 @@ func Test_DatetimeJson(t *testing.T) {
 			Value []string
 		}{Value: []string{"hello"}}, errors.InvalidParam{Param: []string{"datetime"}}},
 	}
-	for _, tt := range tests {
+
+	for i, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := Validate(Datetime{})
 
-			if !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("%v, Failed. Got :%v\tExpected: %v", tt.name, err, tt.err)
-			}
+			assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n%s", i, tt.name)
 		})
 	}
 }

--- a/pkg/gofr/types/datetime_test.go
+++ b/pkg/gofr/types/datetime_test.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"testing"
-	
+
 	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"

--- a/pkg/gofr/types/duration_test.go
+++ b/pkg/gofr/types/duration_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -31,8 +32,7 @@ func TestDuration_Check(t *testing.T) {
 		tt := tt
 
 		err := Validate(tt.duration)
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("[TESTCASE%d]Failed. Got :%v\tExpected: %v", i+1, err, tt.err)
-		}
+
+		assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n%s", i, tt.name)
 	}
 }

--- a/pkg/gofr/types/email_test.go
+++ b/pkg/gofr/types/email_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -28,12 +29,11 @@ func TestEmail_Check(t *testing.T) {
 		{"incorrect format for email with whitespace", "añ abcd@gmail.com", errors.InvalidParam{Param: []string{"emailAddress"}}},
 	}
 
-	for _, c := range tc {
+	for i, c := range tc {
 		c := c
 
 		r := Validate(c.email)
-		if !reflect.DeepEqual(r, c.expectedErr) {
-			t.Errorf("%v Expected value: %v for %v got %v", c.name, c.expectedErr, c.email, r)
-		}
+
+		assert.Equal(t, c.expectedErr, r, "TEST[%d], Failed.\n%s", i, c.name)
 	}
 }

--- a/pkg/gofr/types/enum_test.go
+++ b/pkg/gofr/types/enum_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -27,8 +28,7 @@ func TestEnum_Check(t *testing.T) {
 		e := Enum{ValidValues: v.valid, Value: v.value, Parameter: "abc"}
 
 		err := e.Check()
-		if !reflect.DeepEqual(err, v.err) {
-			t.Errorf("[TESTCASE%d]Failed.Got %v\tExpected %v\n", i+1, err, v.err)
-		}
+
+		assert.Equal(t, v.err, err, "TEST[%d], Failed.\n", i)
 	}
 }

--- a/pkg/gofr/types/latitude_test.go
+++ b/pkg/gofr/types/latitude_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -21,8 +22,7 @@ func TestLatitude_Check(t *testing.T) {
 		tt := tt
 
 		err := Validate(&tt.latitude)
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("[TESTCASE %d]Failed. Got :%v\tExpected: %v", i+1, err, tt.err)
-		}
+
+		assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n", i)
 	}
 }

--- a/pkg/gofr/types/location_test.go
+++ b/pkg/gofr/types/location_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -19,7 +20,8 @@ func TestLocation_Check(t *testing.T) {
 		{"correct location struct", 34.00, 12, nil},
 		{"invalid latitude and longitude", -100, 1110, errors.InvalidParam{Param: []string{"lat"}}},
 	}
-	for _, tt := range tests {
+
+	for i, tt := range tests {
 		tt := tt
 		locstruct := Location{
 			Latitude:  &tt.lat,
@@ -29,9 +31,7 @@ func TestLocation_Check(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := Validate(locstruct)
 
-			if !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("%v, Failed. Got :%v\tExpected: %v", tt.name, err, tt.err)
-			}
+			assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n%s", i, tt.name)
 		})
 	}
 }
@@ -56,7 +56,7 @@ func TestLocation_CheckEmpty(t *testing.T) {
 				errors.InvalidParam{Param: []string{"lng is nil"}}}}},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		tt := tt
 		locstruct := Location{
 			Latitude:  tt.lat,
@@ -66,9 +66,7 @@ func TestLocation_CheckEmpty(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := Validate(locstruct)
 
-			if !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("%v, Failed. Got :%v\tExpected: %v", tt.name, err, tt.err)
-			}
+			assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n%s", i, tt.name)
 		})
 	}
 }

--- a/pkg/gofr/types/longitude_test.go
+++ b/pkg/gofr/types/longitude_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -18,12 +19,12 @@ func TestLongitude_Check(t *testing.T) {
 		{"correct longitude value", 89.99, nil},
 		{"correct negative longitude value", -45.00, nil},
 	}
-	for _, tt := range tests {
+
+	for i, tt := range tests {
 		tt := tt
 
 		err := Validate(&tt.longitude)
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("%v, Failed. Got :%v\tExpected: %v", tt.name, err, tt.err)
-		}
+
+		assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n", i)
 	}
 }

--- a/pkg/gofr/types/phone_test.go
+++ b/pkg/gofr/types/phone_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -27,8 +28,7 @@ func TestPhone_Check(t *testing.T) {
 		tt := tt
 
 		err := Validate(tt.phone)
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("[TEST ID %d]Got %v\tExpected %v", i+1, err, tt.err)
-		}
+
+		assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n", i)
 	}
 }

--- a/pkg/gofr/types/rules_test.go
+++ b/pkg/gofr/types/rules_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -16,13 +17,13 @@ func TestValidate(t *testing.T) {
 		{"valid phone", []Rule{Phone("+17777777777")}, nil},
 		{"invalid phone", []Rule{Phone("+17777777777qq")}, errors.InvalidParam{Param: []string{"Phone Number contains Non Numeric characters"}}},
 	}
-	for _, tt := range tests {
+
+	for i, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := Validate(tt.rules...)
-			if !reflect.DeepEqual(err, tt.wantErr) {
-				t.Errorf("%v Validate() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-			}
+
+			assert.Equal(t, tt.wantErr, err, "TEST[%d], Failed.\n%s", i, tt.name)
 		})
 	}
 }

--- a/pkg/gofr/types/time_test.go
+++ b/pkg/gofr/types/time_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -22,8 +23,7 @@ func TestTime_Check(t *testing.T) {
 		tt := tt
 
 		err := Validate(tt.timecheck)
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("%v, Failed. Got :%v\tExpected: %v", tt.name, err, tt.err)
-		}
+
+		assert.Equal(t, tt.err, err, "TEST[%d], Failed.\n")
 	}
 }

--- a/pkg/gofr/types/timeinterval_test.go
+++ b/pkg/gofr/types/timeinterval_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -24,9 +23,8 @@ func TestTimeInterval_Check(t *testing.T) {
 
 	for i, v := range testcases {
 		err := v.input.Check()
-		if !reflect.DeepEqual(v.err, err) {
-			t.Errorf("[TESTCASE%d]Failed.Got %v\tExpected %v\n", i+1, err, v.err)
-		}
+
+		assert.Equal(t, v.err, err, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/pkg/gofr/types/timezone_test.go
+++ b/pkg/gofr/types/timezone_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 )
@@ -19,12 +20,11 @@ func TestTimeZone_Check(t *testing.T) {
 		{"incorrect format for timezone", "warzone", errors.InvalidParam{Param: []string{"timeZone"}}},
 	}
 
-	for _, c := range tc {
+	for i, c := range tc {
 		c := c
 
 		r := Validate(c.timezone)
-		if !reflect.DeepEqual(r, c.expectedErr) {
-			t.Errorf("%v Expected value: for %v got %v", c.name, c.expectedErr, c.timezone)
-		}
+
+		assert.Equal(t, c.expectedErr, r, "TEST[%d], Failed.\n%s", i, c.name)
 	}
 }

--- a/pkg/log/entry_test.go
+++ b/pkg/log/entry_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 	"time"
-	
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/log/entry_test.go
+++ b/pkg/log/entry_test.go
@@ -3,11 +3,12 @@ package log
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+	
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEntryFromInputs(t *testing.T) {
@@ -36,10 +37,10 @@ func TestEntryFromInputs(t *testing.T) {
 
 	for i, v := range testcases {
 		e, _, _ := entryFromInputs(v.format, v.args...)
-		if !reflect.DeepEqual(e.Data, v.expectedEntry.Data) || !reflect.DeepEqual(e.Message, v.expectedEntry.Message) {
-			t.Errorf("[TESTCASE%d]Failed.Expected Data:%v Message %v\nGot Data:%v Message %v\n", i+1,
-				v.expectedEntry.Data, v.expectedEntry.Message, e.Data, e.Message)
-		}
+
+		assert.Equal(t, v.expectedEntry.Data, e.Data, "TEST[%d], Failed.\n%s", i, v.desc)
+
+		assert.Equal(t, v.expectedEntry.Message, e.Message, "TEST[%d], Failed.\n%s", i, v.desc)
 	}
 }
 
@@ -83,21 +84,14 @@ func TestEntryFromStringForJSON(t *testing.T) {
 
 	for i, tc := range tests {
 		e, _, isPerfLog := entryFromInputs("", tc.args)
-		if !reflect.DeepEqual(e.Data, tc.exp.Data) {
-			t.Errorf("TESTCASE [%v] Failed. Expected data %v\tGot %v\n", i, tc.exp.Data, e.Data)
-		}
 
-		if !reflect.DeepEqual(e.Message, tc.exp.Message) {
-			t.Errorf("TESTCASE [%v] Failed. Expected message %v\tGot %v\n", i, tc.exp.Message, e.Message)
-		}
+		assert.Equal(t, tc.exp.Data, e.Data, "TEST[%d], Failed.\n", i)
 
-		if !reflect.DeepEqual(e.CorrelationID, tc.exp.CorrelationID) {
-			t.Errorf("TESTCASE [%v] Failed. Expected correlationID %v\tGot %v\n", i, tc.exp.CorrelationID, e.CorrelationID)
-		}
+		assert.Equal(t, tc.exp.Message, e.Message, "TEST[%d], Failed.\n", i)
 
-		if isPerfLog != tc.expPerfLog {
-			t.Errorf("TESTCASE [%v] Failed. Expected performanceLog %v\tGot %v\n", i, tc.expPerfLog, isPerfLog)
-		}
+		assert.Equal(t, tc.exp.CorrelationID, e.CorrelationID, "TEST[%d], Failed.\n", i)
+
+		assert.Equal(t, tc.expPerfLog, isPerfLog, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/pkg/log/level_test.go
+++ b/pkg/log/level_test.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetLevel(t *testing.T) {
@@ -62,8 +63,6 @@ func TestLevel_MarshalJSON(t *testing.T) {
 	for i, v := range testcases {
 		resp, _ := v.input.MarshalJSON()
 
-		if !reflect.DeepEqual(resp, v.output) {
-			t.Errorf("[TEST CASE %d]Failed. Expected %s\tGot %s\n", i+1, v.output, resp)
-		}
+		assert.Equal(t, v.output, resp, "TEST[%d], Failed.\n", i)
 	}
 }

--- a/pkg/middleware/ldap_test.go
+++ b/pkg/middleware/ldap_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -108,11 +107,11 @@ func Test_getGroupsFromEntries(t *testing.T) {
 		}}}, want: map[string]bool{"abc": true}},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getGroupsFromEntries(tt.args.entries); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getGroupsFromEntries() = %v, want %v", got, tt.want)
-			}
+			got := getGroupsFromEntries(tt.args.entries)
+
+			assert.Equal(t, tt.want, got, "TEST[%d], Failed.\n", i)
 		})
 	}
 }

--- a/pkg/middleware/oauth/cacheinvalidation_test.go
+++ b/pkg/middleware/oauth/cacheinvalidation_test.go
@@ -5,13 +5,13 @@ import (
 	"crypto/rsa"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 
-	"gofr.dev/pkg/middleware"
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/log"
+	"gofr.dev/pkg/middleware"
 )
 
 func getTestServerURLWithInvalidJSON() string {
@@ -77,9 +77,7 @@ func TestOAuth_cacheInvalidation(t *testing.T) {
 			t.Errorf("Testcase %v  Failed. Error Expected %v\n Got %v\n", i, tc.err, err)
 		}
 
-		if !reflect.DeepEqual(oAuth.cache.publicKeys.Keys, tc.keys) {
-			t.Errorf("Testcase %v Failed. Public keys Expected %v\nGot %v\n", i, tc.keys, oAuth.cache.publicKeys.Keys)
-		}
+		assert.Equal(t, tc.keys, oAuth.cache.publicKeys.Keys, "TEST[%d], Failed.\n", i)
 
 		if !strings.Contains(b.String(), tc.logMessage) {
 			t.Errorf("Testcase %v Failed. Log message Expected %v\nGot %v\n", i, tc.logMessage, b.String())

--- a/pkg/middleware/oauth/oauth_test.go
+++ b/pkg/middleware/oauth/oauth_test.go
@@ -9,9 +9,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/errors"
 	"gofr.dev/pkg/log"
@@ -218,11 +219,10 @@ func Test_generateRsaPublicKey(t *testing.T) {
 			nil},
 	}
 
-	for tc := range testcases {
-		_, err := generateRSAPublicKey(&testcases[tc].pubKey)
-		if !reflect.DeepEqual(err, testcases[tc].expErr) {
-			t.Errorf("Testcase[%v] failed: Expected: %v, Got: %v", tc, testcases[tc].expErr, err)
-		}
+	for i := range testcases {
+		_, err := generateRSAPublicKey(&testcases[i].pubKey)
+
+		assert.Equal(t, testcases[i].expErr, err, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/pkg/middleware/oauth/publicKey_test.go
+++ b/pkg/middleware/oauth/publicKey_test.go
@@ -2,11 +2,12 @@ package oauth
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/log"
 	"gofr.dev/pkg/middleware"
@@ -52,7 +53,7 @@ func TestGetPublicKeyError(t *testing.T) {
 	}
 
 	key := o.cache.publicKeys.Get("")
-	expKey := PublicKey{}
+	expKey := &PublicKey{}
 
 	assert.Equal(t, expKey, key, "TEST Failed.\n")
 }

--- a/pkg/middleware/oauth/publicKey_test.go
+++ b/pkg/middleware/oauth/publicKey_test.go
@@ -2,9 +2,9 @@ package oauth
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"sync"
 	"testing"
 
@@ -33,9 +33,7 @@ func Test_getPublicKey(t *testing.T) {
 
 		outputKeys := keyCache.publicKeys.Get(testcases[i].redisKey)
 
-		if !reflect.DeepEqual(outputKeys, testcases[i].key) {
-			t.Errorf("Failed testcase %d , Expected KEY : %v, Got : %v", i+1, testcases[i].key, outputKeys)
-		}
+		assert.Equal(t, testcases[i].key, outputKeys, "TEST[%d], Failed.\n", i)
 	}
 }
 
@@ -56,9 +54,7 @@ func TestGetPublicKeyError(t *testing.T) {
 	key := o.cache.publicKeys.Get("")
 	expKey := PublicKey{}
 
-	if reflect.DeepEqual(key, expKey) {
-		t.Errorf("Expected nil, Got : %v", key)
-	}
+	assert.Equal(t, expKey, key, "TEST Failed.\n")
 }
 
 func TestPublicKeys_GetRSAKey(t *testing.T) {
@@ -124,7 +120,7 @@ func Test_LoadJWK(t *testing.T) {
 		{testServer.URL + "/BAD_JSON", nil, middleware.ErrServiceDown},
 		{testServer.URL + "/SUCCESS", k.Keys, nil},
 	}
-	for _, testCase := range testCases {
+	for i, testCase := range testCases {
 		oAuth := New(log.NewLogger(), Options{
 			ValidityFrequency: 0,
 			JWKPath:           testCase.JWKPath,
@@ -135,9 +131,7 @@ func Test_LoadJWK(t *testing.T) {
 			t.Errorf("Expected error: %v, got: %v", testCase.error, err)
 		}
 
-		if !reflect.DeepEqual(keys, testCase.keys) {
-			t.Errorf("Expected keys: %v, got: %v", testCase.keys, keys)
-		}
+		assert.Equal(t, testCase.keys, keys, "TEST[%d], Failed.\n", i)
 	}
 }
 

--- a/pkg/middleware/oauth/validation_test.go
+++ b/pkg/middleware/oauth/validation_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -155,9 +154,7 @@ func TestValidateSuccess(t *testing.T) {
 		t.Errorf("Expected no error, got %v\n", err)
 	}
 
-	if !reflect.DeepEqual(resp, expectedToken) {
-		t.Errorf("Failed. Got : %v\n Expected : %v\n", resp, expectedToken)
-	}
+	assert.Equal(t, expectedToken, resp, "TEST Failed.\n")
 }
 
 func getTestServerURL() string {

--- a/pkg/service/httpCached_test.go
+++ b/pkg/service/httpCached_test.go
@@ -9,10 +9,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/gofr/config"
 	"gofr.dev/pkg/log"
@@ -45,9 +46,7 @@ func TestCacheGet(t *testing.T) {
 	// getting cached response even when order of parameter is different
 	body, _ := cacher.Get(context.TODO(), "brand", map[string]interface{}{"name": "xyz", "page": 1})
 
-	if !reflect.DeepEqual(body.Body, expected) {
-		t.Errorf("Failed.Expected %v\tGot %v", expected, body)
-	}
+	assert.Equal(t, expected, body.Body, "TEST Failed.\n")
 
 	if !strings.Contains(b.String(), expectedLog) {
 		t.Errorf("Failed.Expected Log %v\tGot %v", expectedLog, b.String())
@@ -158,9 +157,7 @@ func TestCacheGetWithHeaders(t *testing.T) {
 	body, _ := cacher.GetWithHeaders(context.TODO(), "brand", map[string]interface{}{"name": "xyz", "page": 1},
 		map[string]string{"entity": "test"})
 
-	if !reflect.DeepEqual(body.Body, expected) {
-		t.Errorf("Failed.Expected %v\tGot %v", expected, body)
-	}
+	assert.Equal(t, expected, body.Body, "TEST Failed.\n")
 
 	if !strings.Contains(b.String(), expectedLog) {
 		t.Errorf("Failed.Expected Log %v\tGot %v", expectedLog, b.String())
@@ -247,7 +244,5 @@ func TestCacheGetWithHeadersPassedKey(t *testing.T) {
 	_, _ = cacher.GetWithHeaders(context.TODO(), "brand", nil, nil)
 	body, _ := cacher.GetWithHeaders(context.TODO(), "brand", nil, nil)
 
-	if !reflect.DeepEqual(body.Body, expected) {
-		t.Errorf("Failed.Expected Log %v\tGot %v", expected, body)
-	}
+	assert.Equal(t, expected, body.Body, "TEST Failed.\n")
 }

--- a/pkg/service/http_test.go
+++ b/pkg/service/http_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -293,9 +292,8 @@ func Test_OAuth_ctx_cancel_RequestTimeout(t *testing.T) {
 			defer cancel()
 
 			_, err := svc.Get(ctx, "dummy", nil)
-			if !reflect.DeepEqual(err, testcases[i].err) {
-				t.Errorf("[TESTCASE%d]Failed.\nExpected %v\nGot %v\n", i+1, testcases[i].err, err)
-			}
+
+			assert.Equal(t, testcases[i].err, err, "TEST[%d], Failed.\n", i)
 		}()
 	}
 }
@@ -313,9 +311,7 @@ func TestCallError(t *testing.T) {
 
 	_, err := client.call(context.TODO(), http.MethodGet, "", nil, nil, nil)
 
-	if !reflect.DeepEqual(err, expectedErr) {
-		t.Errorf("Failed.Expected %v\tGot %v", expectedErr, err)
-	}
+	assert.Equal(t, expectedErr, err, "TEST Failed.\n")
 }
 
 func TestLogError(t *testing.T) {
@@ -802,9 +798,7 @@ func Test_PreCallStatusCode(t *testing.T) {
 	for i := range testcases {
 		statusCode, err := testcases[i].h.preCall()
 
-		if reflect.DeepEqual(err, &testcases[i].expectedError) {
-			t.Errorf("[TESTCASE%d]Failed. Expected: %v\tGot: %v", i+1, testcases[i].expectedError, err)
-		}
+		assert.Equal(t, &testcases[i].expectedError, err, "TEST[%d], Failed.\n", i)
 
 		if statusCode != testcases[i].expectedStatusCode {
 			t.Errorf("[TESTCASE%d]Failed. Expected: %v\tGot: %v", i+1, testcases[i].expectedStatusCode, statusCode)

--- a/pkg/service/http_test.go
+++ b/pkg/service/http_test.go
@@ -798,7 +798,7 @@ func Test_PreCallStatusCode(t *testing.T) {
 	for i := range testcases {
 		statusCode, err := testcases[i].h.preCall()
 
-		assert.Equal(t, &testcases[i].expectedError, err, "TEST[%d], Failed.\n", i)
+		assert.NotEqual(t, &testcases[i].expectedError, err, "TEST[%d], Failed.\n", i)
 
 		if statusCode != testcases[i].expectedStatusCode {
 			t.Errorf("[TESTCASE%d]Failed. Expected: %v\tGot: %v", i+1, testcases[i].expectedStatusCode, statusCode)

--- a/pkg/service/new_test.go
+++ b/pkg/service/new_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -111,9 +110,8 @@ func TestNewHTTPService_WithHeaders(t *testing.T) {
 		resourceURL := "http://example.com"
 
 		httpSvc := NewHTTPServiceWithOptions(resourceURL, log.NewMockLogger(io.Discard), &testCases[i].options)
-		if !reflect.DeepEqual(httpSvc.customHeaders, testCases[i].headers) {
-			t.Errorf("expected headers: %v\tgot: %v", testCases[i].headers, httpSvc.customHeaders)
-		}
+
+		assert.Equal(t, testCases[i].headers, httpSvc.customHeaders, "TEST[%d], Failed.\n", i)
 
 		if httpSvc.url != resourceURL {
 			t.Errorf("resource url is not set\t got %v\texpected %v", httpSvc.url, resourceURL)
@@ -236,9 +234,7 @@ func TestNewHTTPServiceWithOptions_MultipleFeatures(t *testing.T) {
 			t.Errorf("expected auth %v\tgot %v", testCases[i].httpSvc.auth, httpSvc.auth)
 		}
 
-		if !reflect.DeepEqual(httpSvc.customHeaders, testCases[i].httpSvc.customHeaders) {
-			t.Errorf("expected headers: %v\tgot: %v", testCases[i].httpSvc.customHeaders, httpSvc.customHeaders)
-		}
+		assert.Equal(t, testCases[i].httpSvc.customHeaders, httpSvc.customHeaders, "TEST[%d], Failed.\n", i)
 
 		if httpSvc.url != resourceURL {
 			t.Errorf("resource url is not set\t got %v\texpected %v", httpSvc.url, resourceURL)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -8,8 +8,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"gofr.dev/pkg/log"
 )
@@ -28,9 +29,7 @@ func TestService_CallGet(t *testing.T) {
 		t.Errorf("Expected nil err but got %v", err)
 	}
 
-	if !reflect.DeepEqual(resp.Body, expectedResp) {
-		t.Errorf("Failed. Got %v\tExpected %v", resp.Body, expectedResp)
-	}
+	assert.Equal(t, expectedResp, resp.Body, "TEST Failed.\n")
 }
 
 func TestBind(t *testing.T) {
@@ -70,9 +69,7 @@ func TestBindStrict(t *testing.T) {
 	s := &httpService{contentType: TEXT}
 	_ = s.BindStrict(data, &str)
 
-	if !reflect.DeepEqual(str, expected) {
-		t.Errorf("Failed. Expected %v\tGot %v\n", expected, str)
-	}
+	assert.Equal(t, expected, str, "TEST Failed.\n")
 
 	type resp struct {
 		Name string `json:"name"`
@@ -120,9 +117,7 @@ func TestBindResponseText(t *testing.T) {
 	s := &httpService{contentType: TEXT}
 	_ = s.Bind(data, &input)
 
-	if !reflect.DeepEqual(input, expected) {
-		t.Errorf("Failed. Expected %v\tGot %v\n", expected, input)
-	}
+	assert.Equal(t, expected, input, "TEST Failed.\n")
 }
 
 func TestBindResponseJSON(t *testing.T) {
@@ -134,9 +129,7 @@ func TestBindResponseJSON(t *testing.T) {
 	s := &httpService{contentType: JSON}
 	_ = s.Bind(data, &input)
 
-	if !reflect.DeepEqual(input, expected) {
-		t.Errorf("Failed. Expected %v\tGot %v\n", expected, input)
-	}
+	assert.Equal(t, expected, input, "TEST Failed.\n")
 }
 
 func TestBindResponseXML(t *testing.T) {
@@ -153,9 +146,7 @@ func TestBindResponseXML(t *testing.T) {
 	s := &httpService{contentType: XML}
 	_ = s.Bind(b, &input)
 
-	if !reflect.DeepEqual(input, expected) {
-		t.Errorf("Failed. Expected %v\tGot %v\n", expected, input)
-	}
+	assert.Equal(t, expected, input, "TEST Failed.\n")
 }
 
 func TestXMLPOST(t *testing.T) {
@@ -220,9 +211,7 @@ func TestJSONPUT(t *testing.T) {
 
 	expected.headers = body.headers // needed to test the header fields, since the Date is not a constant.
 
-	if !reflect.DeepEqual(expected, body) {
-		t.Errorf("Failed.Expected %v\tGot %v", expected, re)
-	}
+	assert.Equal(t, expected, body, "TEST Failed.\n")
 
 	ts.Close()
 }
@@ -262,9 +251,7 @@ func TestJSONPatch(t *testing.T) {
 
 	expected.headers = body.headers // needed to test the header fields, since the Date is not a constant.
 
-	if !reflect.DeepEqual(expected, body) {
-		t.Errorf("Failed.Expected %v\tGot %v", expected, re)
-	}
+	assert.Equal(t, expected, body, "TEST Failed.\n")
 }
 
 //nolint:gocognit,gocyclo // breaking down function will reduce readability and reduce cognitive complexity
@@ -286,9 +273,7 @@ func TestHTTPMethodWithHeaders(t *testing.T) {
 		t.Errorf("Expected nil err but got %v", err)
 	}
 
-	if !reflect.DeepEqual(resp.Body, expectedResp) {
-		t.Errorf("Failed. Got %v\tExpected %v", resp.Body, expectedResp)
-	}
+	assert.Equal(t, expectedResp, resp.Body, "TEST Failed.\n")
 
 	// Test PostWithHeaders
 	resp, err = s.PostWithHeaders(context.TODO(), "", nil, nil, map[string]string{"entity": "test"})
@@ -296,9 +281,7 @@ func TestHTTPMethodWithHeaders(t *testing.T) {
 		t.Errorf("Expected nil err but got %v", err)
 	}
 
-	if !reflect.DeepEqual(resp.Body, expectedResp) {
-		t.Errorf("Failed. Got %v\tExpected %v", resp.Body, expectedResp)
-	}
+	assert.Equal(t, expectedResp, resp.Body, "TEST Failed.\n")
 
 	// Test PutWithHeaders
 	resp, err = s.PutWithHeaders(context.TODO(), "", nil, nil, map[string]string{"entity": "test"})
@@ -306,9 +289,7 @@ func TestHTTPMethodWithHeaders(t *testing.T) {
 		t.Errorf("Expected nil err but got %v", err)
 	}
 
-	if !reflect.DeepEqual(resp.Body, expectedResp) {
-		t.Errorf("Failed. Got %v\tExpected %v", resp.Body, expectedResp)
-	}
+	assert.Equal(t, expectedResp, resp.Body, "TEST Failed.\n")
 
 	// Test PatchWithHeaders
 	resp, err = s.PatchWithHeaders(context.TODO(), "", nil, nil, map[string]string{"entity": "test"})
@@ -316,9 +297,7 @@ func TestHTTPMethodWithHeaders(t *testing.T) {
 		t.Errorf("Expected nil err but got %v", err)
 	}
 
-	if !reflect.DeepEqual(resp.Body, expectedResp) {
-		t.Errorf("Failed. Got %v\tExpected %v", resp.Body, expectedResp)
-	}
+	assert.Equal(t, expectedResp, resp.Body, "TEST Failed.\n")
 
 	// Test DeleteWithHeaders
 	resp, err = s.DeleteWithHeaders(context.TODO(), "", nil, map[string]string{"entity": "test"})
@@ -326,7 +305,5 @@ func TestHTTPMethodWithHeaders(t *testing.T) {
 		t.Errorf("Expected nil err but got %v", err)
 	}
 
-	if !reflect.DeepEqual(resp.Body, expectedResp) {
-		t.Errorf("Failed. Got %v\tExpected %v", resp.Body, expectedResp)
-	}
+	assert.Equal(t, expectedResp, resp.Body, "TEST Failed.\n")
 }

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -254,7 +254,6 @@ func TestJSONPatch(t *testing.T) {
 	assert.Equal(t, expected, body, "TEST Failed.\n")
 }
 
-//nolint:gocognit,gocyclo // breaking down function will reduce readability and reduce cognitive complexity
 func TestHTTPMethodWithHeaders(t *testing.T) {
 	expectedResp := []byte(`{"entity":"test"}`)
 


### PR DESCRIPTION
Currently, reflect.DeepEqual and assert.Equal both are being used in the tests which is not ideal and only one of them should be used everywhere.
Hence, have replaced `reflect.DeepEqual()` with `assert.Equal()` in all the tests.

Closes: #153