### PR TITLE
Add Service request log format for success responses and errors

### DIFF
--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -15,7 +15,7 @@ func main() {
 	// Create a new application
 	a := gofr.New()
 
-	a.AddHTTPService("anotherService", "http://localhost:8000")
+	a.AddHTTPService("anotherService", "http://localhost:9000")
 
 	// Add all the routes
 	a.GET("/hello", HelloHandler)

--- a/pkg/gofr/logging/logger.go
+++ b/pkg/gofr/logging/logger.go
@@ -114,10 +114,12 @@ func (l *logger) prettyPrint(e logEntry, out io.Writer) {
 			e.Level.color(), e.Level.String()[0:4], e.Time.Format("15:04:05"), msg.Type, "SQL", msg.Duration, msg.Query)
 	case service.Log:
 		fmt.Fprintf(out, "\u001B[38;5;%dm%s\u001B[0m [%s] \u001B[38;5;8m%s \u001B[38;5;%dm%d\u001B[0m %8d\u001B[38;5;8mµs\u001B[0m %s %s \n",
-			e.Level.color(), e.Level.String()[0:4], e.Time.Format("15:04:05"), msg.CorrelationID, colorForStatusCode(msg.ResponseCode), msg.ResponseCode, msg.ResponseTime, msg.HTTPMethod, msg.URI)
+			e.Level.color(), e.Level.String()[0:4], e.Time.Format("15:04:05"), msg.CorrelationID, colorForStatusCode(msg.ResponseCode),
+			msg.ResponseCode, msg.ResponseTime, msg.HTTPMethod, msg.URI)
 	case service.ErrorLog:
-		fmt.Fprintf(out, "\u001B[38;5;%dm%s\u001B[0m [%s] \u001B[38;5;8m%s \u001B[38;5;%dm%d\u001B[0m %8d\u001B[38;5;8mµs\u001B[0m %s %s \n",
-			e.Level.color(), e.Level.String()[0:4], e.Time.Format("15:04:05"), msg.CorrelationID, colorForStatusCode(msg.ResponseCode), msg.ResponseCode, msg.ResponseTime, msg.HTTPMethod, msg.URI)
+		fmt.Fprintf(out, "\u001B[38;5;%dm%s\u001B[0m [%s] \u001B[38;5;8m%s \u001B[38;5;%dm%d\u001B[0m %8d\u001B[38;5;8mµs\u001B[0m %s %s \033[0;31m %s \n",
+			e.Level.color(), e.Level.String()[0:4], e.Time.Format("15:04:05"), msg.CorrelationID, colorForStatusCode(msg.ResponseCode),
+			msg.ResponseCode, msg.ResponseTime, msg.HTTPMethod, msg.URI, msg.ErrorMessage)
 	default:
 		fmt.Fprintf(out, "\u001B[38;5;%dm%s\u001B[0m [%s] %v\n", e.Level.color(), e.Level.String()[0:4], e.Time.Format("15:04:05"), e.Message)
 	}
@@ -125,14 +127,13 @@ func (l *logger) prettyPrint(e logEntry, out io.Writer) {
 
 // colorForStatusCode provide color for the status code in the terminal when logs is being pretty-printed.
 func colorForStatusCode(status int) int {
-	responseCodeColors := map[int]int{
-		200: 34,
-		404: 220,
-		500: 202,
-	}
-
-	if color, ok := responseCodeColors[status]; ok {
-		return color
+	switch {
+	case status >= 200 && status < 300:
+		return 34
+	case status >= 400 && status < 500:
+		return 220
+	case status >= 500 && status < 600:
+		return 202
 	}
 
 	return 0

--- a/pkg/gofr/service/new_test.go
+++ b/pkg/gofr/service/new_test.go
@@ -23,7 +23,7 @@ func TestNewHTTPService(t *testing.T) {
 
 	for i, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			service := NewHTTPService(tc.serviceAddress)
+			service := NewHTTPService(tc.serviceAddress, nil)
 			assert.NotNil(t, service, "TEST[%d], Failed.\n%s", i, tc.desc)
 		})
 	}


### PR DESCRIPTION
Success :
<img width="724" alt="image" src="https://github.com/gofr-dev/gofr/assets/44166352/a4afbe92-3ce4-4710-a5ff-3a6f7af65165">

Internal Server Errors : 
<img width="720" alt="image" src="https://github.com/gofr-dev/gofr/assets/44166352/9c58b332-9ff2-43cb-97e2-5b91407b114e">

Bad request and 4xx errors:
<img width="722" alt="image" src="https://github.com/gofr-dev/gofr/assets/44166352/32488beb-2708-48e0-a07e-bdf46f320b18">
