### PR TITLE
En/add span id in json logs

### DIFF
--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -22,7 +22,7 @@ func (w *StatusResponseWriter) WriteHeader(status int) {
 }
 
 type RequestLog struct {
-	ID           string `json:"id,omitempty"`
+	TraceID      string `json:"trace_id,omitempty"`
 	SpanID       string `json:"span_id,omitempty"`
 	StartTime    string `json:"start_time,omitempty"`
 	ResponseTime int64  `json:"response_time,omitempty"`
@@ -50,7 +50,7 @@ func Logging(logger logger) func(inner http.Handler) http.Handler {
 
 			defer func(res *StatusResponseWriter, req *http.Request) {
 				l := RequestLog{
-					ID:           reqID,
+					TraceID:      reqID,
 					SpanID:       spanID,
 					StartTime:    start.Format("2006-01-02T15:04:05.999999999-07:00"),
 					ResponseTime: time.Since(start).Nanoseconds() / 1000,

--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -44,13 +44,13 @@ func Logging(logger logger) func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			srw := &StatusResponseWriter{ResponseWriter: w}
-			reqID := trace.SpanFromContext(r.Context()).SpanContext().TraceID().String()
+			traceID := trace.SpanFromContext(r.Context()).SpanContext().TraceID().String()
 			spanID := trace.SpanFromContext(r.Context()).SpanContext().SpanID().String()
 			srw.Header().Set("X-Correlation-ID", reqID)
 
 			defer func(res *StatusResponseWriter, req *http.Request) {
 				l := RequestLog{
-					TraceID:      reqID,
+					TraceID:      traceID,
 					SpanID:       spanID,
 					StartTime:    start.Format("2006-01-02T15:04:05.999999999-07:00"),
 					ResponseTime: time.Since(start).Nanoseconds() / 1000,

--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -23,6 +23,7 @@ func (w *StatusResponseWriter) WriteHeader(status int) {
 
 type RequestLog struct {
 	ID           string `json:"id,omitempty"`
+	SpanID       string `json:"span_id,omitempty"`
 	StartTime    string `json:"start_time,omitempty"`
 	ResponseTime int64  `json:"response_time,omitempty"`
 	Method       string `json:"method,omitempty"`
@@ -44,11 +45,13 @@ func Logging(logger logger) func(inner http.Handler) http.Handler {
 			start := time.Now()
 			srw := &StatusResponseWriter{ResponseWriter: w}
 			reqID := trace.SpanFromContext(r.Context()).SpanContext().TraceID().String()
+			spanID := trace.SpanFromContext(r.Context()).SpanContext().SpanID().String()
 			srw.Header().Set("X-Correlation-ID", reqID)
 
 			defer func(res *StatusResponseWriter, req *http.Request) {
 				l := RequestLog{
 					ID:           reqID,
+					SpanID:       spanID,
 					StartTime:    start.Format("2006-01-02T15:04:05.999999999-07:00"),
 					ResponseTime: time.Since(start).Nanoseconds() / 1000,
 					Method:       req.Method,

--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -46,7 +46,7 @@ func Logging(logger logger) func(inner http.Handler) http.Handler {
 			srw := &StatusResponseWriter{ResponseWriter: w}
 			traceID := trace.SpanFromContext(r.Context()).SpanContext().TraceID().String()
 			spanID := trace.SpanFromContext(r.Context()).SpanContext().SpanID().String()
-			srw.Header().Set("X-Correlation-ID", reqID)
+			srw.Header().Set("X-Correlation-ID", traceID)
 
 			defer func(res *StatusResponseWriter, req *http.Request) {
 				l := RequestLog{

--- a/pkg/gofr/logging/logger.go
+++ b/pkg/gofr/logging/logger.go
@@ -109,7 +109,7 @@ func (l *logger) prettyPrint(e logEntry, out io.Writer) {
 	case middleware.RequestLog:
 		fmt.Fprintf(out, "\u001B[38;5;%dm%s\u001B[0m [%s] \u001B[38;5;8m%s \u001B[38;5;%dm%d\u001B[0m "+
 			"%8d\u001B[38;5;8mµs\u001B[0m %s %s \n", e.Level.color(), e.Level.String()[0:4],
-			e.Time.Format("15:04:05"), msg.ID, colorForStatusCode(msg.Response), msg.Response, msg.ResponseTime, msg.Method, msg.URI)
+			e.Time.Format("15:04:05"), msg.TraceID, colorForStatusCode(msg.Response), msg.Response, msg.ResponseTime, msg.Method, msg.URI)
 	case sql.Log:
 		fmt.Fprintf(out, "\u001B[38;5;%dm%s\u001B[0m [%s] \u001B[38;5;8m%-32s \u001B[38;5;24m%s\u001B[0m %8d\u001B[38;5;8mµs\u001B[0m %s\n",
 			e.Level.color(), e.Level.String()[0:4], e.Time.Format("15:04:05"), msg.Type, "SQL", msg.Duration, msg.Query)

--- a/pkg/gofr/logging/logger.go
+++ b/pkg/gofr/logging/logger.go
@@ -34,7 +34,7 @@ type logger struct {
 }
 
 type logEntry struct {
-	Level   Level       `json:"Level"`
+	Level   Level       `json:"level"`
 	Time    time.Time   `json:"time"`
 	Message interface{} `json:"message"`
 }


### PR DESCRIPTION
Add one more field `span_id` in the json logs.

```json
{
  "level": "INFO",
  "time": "2024-02-06T15:07:42.277813+05:30",
  "message": {
    "trace_id": "cb5e08781c8ec038d8f9fbe2b478e54f",
    "span_id": "a65a1bc00a988165",
    "start_time": "2024-02-06T15:07:41.482988+05:30",
    "response_time": 794767,
    "method": "GET",
    "user_agent": "PostmanRuntime/7.33.0",
    "ip": "[::1]:62349",
    "uri": "/service",
    "response": 200
  }
}
```