### PR TITLE
fix CMD application unnecessary logs

### DIFF
--- a/pkg/gofr/container/container.go
+++ b/pkg/gofr/container/container.go
@@ -36,12 +36,33 @@ type Container struct {
 	SQL   *sql.DB
 }
 
+func NewEmptyContainer() *Container {
+	return &Container{}
+}
+
 func NewContainer(conf config.Config) *Container {
 	c := &Container{
-		Logger: logging.NewRemoteLogger(logging.GetLevelFromString(conf.Get("LOG_LEVEL")), conf.Get("REMOTE_LOG_URL"),
-			conf.GetOrDefault("REMOTE_LOG_FETCH_INTERVAL", "15")),
 		appName:    conf.GetOrDefault("APP_NAME", "gofr-app"),
 		appVersion: conf.GetOrDefault("APP_VERSION", "dev"),
+	}
+
+	c.Create(conf)
+
+	return c
+}
+
+func (c *Container) Create(conf config.Config) {
+	if c.appName != "" {
+		c.appName = conf.GetOrDefault("APP_NAME", "gofr-app")
+	}
+
+	if c.appVersion != "" {
+		c.appVersion = conf.GetOrDefault("APP_VERSION", "dev")
+	}
+
+	if c.Logger == nil {
+		c.Logger = logging.NewRemoteLogger(logging.GetLevelFromString(conf.Get("LOG_LEVEL")), conf.Get("REMOTE_LOG_URL"),
+			conf.GetOrDefault("REMOTE_LOG_FETCH_INTERVAL", "15"))
 	}
 
 	c.Debug("Container is being created")
@@ -74,8 +95,6 @@ func NewContainer(conf config.Config) *Container {
 			SubscriptionName: conf.Get("GOOGLE_SUBSCRIPTION_NAME"),
 		}, c.Logger)
 	}
-
-	return c
 }
 
 // GetHTTPService returns registered http services.

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -91,10 +91,11 @@ func NewCMD() *App {
 	app := &App{}
 	app.readConfig()
 
-	app.container = container.NewContainer(app.Config)
+	app.container = container.NewEmptyContainer()
+	app.container.Logger = logging.NewFileLogger(app.Config.Get("CMD_LOGS_FILE"))
 	app.cmd = &cmd{}
-	// app.container.Logger = logging.NewSilentLogger() // TODO - figure out a proper way to log in CMD
 
+	app.container.Create(app.Config)
 	app.initTracer()
 
 	return app

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -205,9 +205,9 @@ func Test_addRoute(t *testing.T) {
 		a := NewCMD()
 
 		a.SubCommand("log", func(c *Context) (interface{}, error) {
-			c.Logger.Info("handler called")
+			c.Logger.Info("logging in handler")
 
-			return nil, nil
+			return "handler called", nil
 		})
 
 		a.Run()

--- a/pkg/gofr/logging/logger.go
+++ b/pkg/gofr/logging/logger.go
@@ -15,6 +15,8 @@ import (
 	"gofr.dev/pkg/gofr/service"
 )
 
+const fileMode = 0644
+
 type Logger interface {
 	Debug(args ...interface{})
 	Debugf(format string, args ...interface{})
@@ -205,11 +207,23 @@ func NewLogger(level Level) Logger {
 }
 
 // TODO - Do we need this? Only used for CMD log silencing.
-func NewSilentLogger() Logger {
+func NewFileLogger(path string) Logger {
 	l := &logger{
 		normalOut: io.Discard,
 		errorOut:  io.Discard,
 	}
+
+	if path != "" {
+		return l
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, fileMode)
+	if err != nil {
+		return l
+	}
+
+	l.normalOut = f
+	l.errorOut = f
 
 	return l
 }

--- a/pkg/gofr/logging/logger_test.go
+++ b/pkg/gofr/logging/logger_test.go
@@ -337,7 +337,7 @@ func TestPrettyPrint_ServiceAndDefaultLogs(t *testing.T) {
 
 func Test_NewSilentLoggerSTDOutput(t *testing.T) {
 	logs := testutil.StdoutOutputForFunc(func() {
-		l := NewSilentLogger()
+		l := NewFileLogger("")
 
 		l.Info("Info Logs")
 		l.Debug("Debug Logs")


### PR DESCRIPTION
Running a cmd application, logs are getting printed as running an HTTP application, which is not expected of a CMD app

![image](https://github.com/gofr-dev/gofr/assets/44166352/0b687f24-6fe0-4d33-b21f-b9e0283c76b3)

Added a new file logging function to print the logs to a file using `CMD_LOGS_FILE` env, and if the file name is not present the logs are sent to io.Discard, so they are not printed on the terminal.

Also segregated the initialization of data sources to Create() so that we can change a container's features (ex. Logger).