### PR TITLE
Improve Logs

### DIFF
--- a/docs/advanced-guide/publishing-custom-metrics/page.md
+++ b/docs/advanced-guide/publishing-custom-metrics/page.md
@@ -99,7 +99,7 @@ func main() {
 
 		// transaction logic
 
-		tranTime := time.Now().Sub(transactionStartTime).Microseconds()
+		tranTime := time.Now().Sub(transactionStartTime).Milliseconds()
 
 		ctx.Metrics().RecordHistogram(ctx, "transaction_time", float64(tranTime))
 

--- a/docs/quick-start/observability/page.md
+++ b/docs/quick-start/observability/page.md
@@ -93,13 +93,13 @@ GoFr publishes metrics to port: _2121_ on _/metrics_ endpoint in prometheus form
 
 - app_sql_stats
 - histogram
-- Response time of SQL queries in microseconds
+- Response time of SQL queries in milliseconds
 
 ---
 
 - app_redis_stats
 - histogram
-- Response time of Redis commands in microseconds
+- Response time of Redis commands in milliseconds
 
 ---
 

--- a/examples/using-custom-metrics/main.go
+++ b/examples/using-custom-metrics/main.go
@@ -40,7 +40,7 @@ func TransactionHandler(c *gofr.Context) (interface{}, error) {
 
 	c.Metrics().IncrementCounter(c, transactionSuccessful)
 
-	tranTime := time.Now().Sub(transactionStartTime).Microseconds()
+	tranTime := time.Now().Sub(transactionStartTime).Milliseconds()
 
 	c.Metrics().RecordHistogram(c, transactionTime, float64(tranTime))
 	c.Metrics().DeltaUpDownCounter(c, totalCreditDaySales, 1000, "sale_type", "credit")

--- a/pkg/gofr/container/container.go
+++ b/pkg/gofr/container/container.go
@@ -150,11 +150,11 @@ func (c *Container) registerFrameworkMetrics() {
 
 	// redis metrics
 	redisBuckets := []float64{50, 75, 100, 125, 150, 200, 300, 500, 750, 1000, 1250, 1500, 2000, 2500, 3000}
-	c.Metrics().NewHistogram("app_redis_stats", "Response time of Redis commands in microseconds.", redisBuckets...)
+	c.Metrics().NewHistogram("app_redis_stats", "Response time of Redis commands in milliseconds.", redisBuckets...)
 
 	// sql metrics
 	sqlBuckets := []float64{50, 75, 100, 125, 150, 200, 300, 500, 750, 1000, 2000, 3000, 4000, 5000, 7500, 10000}
-	c.Metrics().NewHistogram("app_sql_stats", "Response time of SQL queries in microseconds.", sqlBuckets...)
+	c.Metrics().NewHistogram("app_sql_stats", "Response time of SQL queries in milliseconds.", sqlBuckets...)
 	c.Metrics().NewGauge("app_sql_open_connections", "Number of open SQL connections.")
 	c.Metrics().NewGauge("app_sql_inUse_connections", "Number of inUse SQL connections.")
 

--- a/pkg/gofr/datasource/redis/hook.go
+++ b/pkg/gofr/datasource/redis/hook.go
@@ -44,7 +44,7 @@ func (ql QueryLog) String() string {
 
 // logQuery logs the Redis query information.
 func (r *redisHook) logQuery(start time.Time, query string, args ...interface{}) {
-	duration := time.Since(start).Microseconds()
+	duration := time.Since(start).Milliseconds()
 
 	r.logger.Debug(QueryLog{
 		Query:    query,

--- a/pkg/gofr/datasource/sql/db.go
+++ b/pkg/gofr/datasource/sql/db.go
@@ -31,7 +31,7 @@ type Log struct {
 }
 
 func (d *DB) logQuery(start time.Time, queryType, query string, args ...interface{}) {
-	duration := time.Since(start).Microseconds()
+	duration := time.Since(start).Milliseconds()
 
 	d.logger.Debug(Log{
 		Type:     queryType,
@@ -97,7 +97,7 @@ type Tx struct {
 }
 
 func (t *Tx) logQuery(start time.Time, queryType, query string, args ...interface{}) {
-	duration := time.Since(start).Microseconds()
+	duration := time.Since(start).Milliseconds()
 
 	t.logger.Debug(Log{
 		Type:     queryType,

--- a/pkg/gofr/grpc/log.go
+++ b/pkg/gofr/grpc/log.go
@@ -41,7 +41,7 @@ func LoggingInterceptor(logger Logger) grpc.UnaryServerInterceptor {
 			l := RPCLog{
 				ID:           trace.SpanFromContext(ctx).SpanContext().TraceID().String(),
 				StartTime:    start.Format("2006-01-02T15:04:05.999999999-07:00"),
-				ResponseTime: time.Since(start).Microseconds(),
+				ResponseTime: time.Since(start).Milliseconds(),
 				Method:       info.FullMethod,
 			}
 

--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -39,7 +39,7 @@ type logger interface {
 	Error(...interface{})
 }
 
-// Logging is a middleware which logs response status and time in microseconds along with other data.
+// Logging is a middleware which logs response status and time in milliseconds along with other data.
 func Logging(logger logger) func(inner http.Handler) http.Handler {
 	return func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/gofr/service/new.go
+++ b/pkg/gofr/service/new.go
@@ -175,7 +175,7 @@ func (h *httpService) createAndSendRequest(ctx context.Context, method string, p
 			"status", fmt.Sprintf("%v", resp.StatusCode))
 	}
 
-	log.ResponseTime = respTime.Microseconds()
+	log.ResponseTime = respTime.Milliseconds()
 
 	if err != nil {
 		log.ResponseCode = http.StatusInternalServerError


### PR DESCRIPTION
- Convert `microseconds` to `milliseconds` in logs