### PR TITLE
Remove error for .local.env

### DIFF
--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -44,9 +44,11 @@ func (e *EnvLoader) read(folder string) {
 	// If 'APP_ENV' is not set , GoFr will first try to read '.local.env', if failed then it
 	// will read default env file.
 	err := godotenv.Load(overrideFile)
-	if err != nil && env != "" {
-		e.logger.Warnf("Failed to load config from file: %v, Err: %v", overrideFile, err)
-	} else if err == nil {
+	if err != nil {
+		if env != "" {
+			e.logger.Warnf("Failed to load config from file: %v, Err: %v", overrideFile, err)
+		}
+	} else {
 		e.logger.Infof("Loaded config from file: %v", overrideFile)
 
 		return

--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -7,6 +7,11 @@ import (
 	"github.com/joho/godotenv"
 )
 
+const (
+	defaultFileName         = "/.env"
+	defaultOverrideFileName = "/.local.env"
+)
+
 type EnvLoader struct {
 	logger logger
 }
@@ -24,30 +29,30 @@ func NewEnvFile(configFolder string, logger logger) *EnvLoader {
 }
 
 func (e *EnvLoader) read(folder string) {
-	var defaultFile = folder + "/.env"
+	var (
+		defaultFile  = folder + defaultFileName
+		overrideFile = folder + defaultOverrideFileName
+		env          = e.Get("APP_ENV")
+	)
 
-	overrideFile := func() string {
-		gofrEnv := e.Get("APP_ENV")
-		if gofrEnv != "" {
-			return fmt.Sprintf("%s/.%s.env", folder, gofrEnv)
-		}
-
-		return fmt.Sprintf("%s/.local.env", folder)
-	}()
+	if env != "" {
+		overrideFile = fmt.Sprintf("%s/.%s.env", folder, env)
+	}
 
 	// If 'APP_ENV' is set to x, then GoFr will try to read '.x.env' file from configs directory, if failed it will read
 	// the default file '.env'.
 	// If 'APP_ENV' is not set , GoFr will first try to read '.local.env', if failed then it
 	// will read default env file.
-	if err := godotenv.Load(overrideFile); err != nil {
+	err := godotenv.Load(overrideFile)
+	if err != nil && env != "" {
 		e.logger.Warnf("Failed to load config from file: %v, Err: %v", overrideFile, err)
-	} else {
+	} else if err == nil {
 		e.logger.Infof("Loaded config from file: %v", overrideFile)
 
 		return
 	}
 
-	if err := godotenv.Load(defaultFile); err != nil {
+	if err = godotenv.Load(defaultFile); err != nil {
 		e.logger.Warnf("Failed to load config from file: %v, Err: %v", defaultFile, err)
 	} else {
 		e.logger.Infof("Loaded config from file: %v", defaultFile)


### PR DESCRIPTION
**Description:**

-   Moved `defaultFileName` and `defaultOverrideFileName` to const block
-  Refactored the logic to not throw an error for .local.env unless specified in `APP_ENV`

Closes #416 

