### PR TITLE
Fix status code for response of Post and Delete requests

### DIFF
--- a/examples/http-server-using-redis/main_test.go
+++ b/examples/http-server-using-redis/main_test.go
@@ -32,7 +32,7 @@ func TestHTTPServerUsingRedis(t *testing.T) {
 		statusCode int
 	}{
 		{"post handler", http.MethodPost, []byte(`{"key1":"GoFr"}`), "/redis",
-			http.StatusOK},
+			http.StatusCreated},
 		{"post invalid body", http.MethodPost, []byte(`{key:abc}`), "/redis",
 			http.StatusInternalServerError},
 		{"get handler", http.MethodGet, nil, "/redis/key1", http.StatusOK},

--- a/examples/using-add-rest-handlers/main_test.go
+++ b/examples/using-add-rest-handlers/main_test.go
@@ -23,12 +23,12 @@ func TestIntegration_AddRESTHandlers(t *testing.T) {
 	}{
 		{"empty path", http.MethodGet, "/", nil, 404},
 		{"success Create", http.MethodPost, "/user",
-			[]byte(`{"id":10, "name":"john doe", "age":99, "isEmployed": true}`), 200},
+			[]byte(`{"id":10, "name":"john doe", "age":99, "isEmployed": true}`), 201},
 		{"success GetAll", http.MethodGet, "/user", nil, 200},
 		{"success Get", http.MethodGet, "/user/10", nil, 200},
 		{"success Update", http.MethodPut, "/user/10",
 			[]byte(`{"name":"john doe", "age":99, "isEmployed": false}`), 200},
-		{"success Delete", http.MethodDelete, "/user/10", nil, 200},
+		{"success Delete", http.MethodDelete, "/user/10", nil, 204},
 	}
 
 	for i, tc := range tests {

--- a/examples/using-file-bind/main_test.go
+++ b/examples/using-file-bind/main_test.go
@@ -30,7 +30,7 @@ func TestMain_BindError(t *testing.T) {
 	req.Header.Set("content-type", contentType)
 
 	resp, err = c.Do(req)
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 201, resp.StatusCode)
 }
 
 func generateMultiPartBody(t *testing.T) (*bytes.Buffer, string) {

--- a/examples/using-migrations/main_test.go
+++ b/examples/using-migrations/main_test.go
@@ -22,7 +22,7 @@ func TestExampleMigration(t *testing.T) {
 		statusCode int
 	}{
 		{"post new employee with valid data", http.MethodPost, "/employee",
-			[]byte(`{"id":2,"name":"John","gender":"Male","contact_number":1234567890,"dob":"2000-01-01"}`), 200},
+			[]byte(`{"id":2,"name":"John","gender":"Male","contact_number":1234567890,"dob":"2000-01-01"}`), 201},
 		{"get employee with valid name", http.MethodGet, "/employee?name=John", nil, 200},
 		{"get employee does not exist", http.MethodGet, "/employee?name=Invalid", nil, 500},
 		{"get employee with empty name", http.MethodGet, "/employee", nil, http.StatusInternalServerError},

--- a/examples/using-publisher/main_test.go
+++ b/examples/using-publisher/main_test.go
@@ -25,7 +25,7 @@ func TestExamplePublisher(t *testing.T) {
 			desc:               "valid order",
 			path:               "/publish-order",
 			body:               []byte(`{"data":{"orderId":"123","status":"pending"}}`),
-			expectedStatusCode: http.StatusOK,
+			expectedStatusCode: http.StatusCreated,
 		},
 		{
 			desc:               "invalid order",
@@ -37,7 +37,7 @@ func TestExamplePublisher(t *testing.T) {
 			desc:               "valid product",
 			path:               "/publish-product",
 			body:               []byte(`{"data":{"productId":"123","price":"599"}}`),
-			expectedStatusCode: http.StatusOK,
+			expectedStatusCode: http.StatusCreated,
 		},
 		{
 			desc:               "invalid product",

--- a/pkg/gofr/crud_handlers_test.go
+++ b/pkg/gofr/crud_handlers_test.go
@@ -32,7 +32,7 @@ func createTestContext(method, path, id string, body []byte, cont *container.Con
 	testReq.Header.Set("Content-Type", "application/json")
 	gofrReq := gofrHTTP.NewRequest(testReq)
 
-	return newContext(gofrHTTP.NewResponder(httptest.NewRecorder()), gofrReq, cont)
+	return newContext(gofrHTTP.NewResponder(httptest.NewRecorder(), method), gofrReq, cont)
 }
 
 func Test_scanEntity(t *testing.T) {

--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -30,7 +30,18 @@ type handler struct {
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	c := newContext(gofrHTTP.NewResponder(w), gofrHTTP.NewRequest(r), h.container)
+	var responder Responder
+
+	switch r.Method {
+	case http.MethodPost:
+		responder = gofrHTTP.NewPostResponder(w)
+	case http.MethodDelete:
+		responder = gofrHTTP.NewDeleteResponder(w)
+	default:
+		responder = gofrHTTP.NewResponder(w)
+	}
+
+	c := newContext(responder, gofrHTTP.NewRequest(r), h.container)
 	defer c.Trace("gofr-handler").End()
 	c.responder.Respond(h.function(c))
 }

--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -30,18 +30,7 @@ type handler struct {
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var responder Responder
-
-	switch r.Method {
-	case http.MethodPost:
-		responder = gofrHTTP.NewPostResponder(w)
-	case http.MethodDelete:
-		responder = gofrHTTP.NewDeleteResponder(w)
-	default:
-		responder = gofrHTTP.NewResponder(w)
-	}
-
-	c := newContext(responder, gofrHTTP.NewRequest(r), h.container)
+	c := newContext(gofrHTTP.NewResponder(w, r.Method), gofrHTTP.NewRequest(r), h.container)
 	defer c.Trace("gofr-handler").End()
 	c.responder.Respond(h.function(c))
 }

--- a/pkg/gofr/handler_test.go
+++ b/pkg/gofr/handler_test.go
@@ -28,11 +28,16 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		data       interface{}
 		err        error
 		statusCode int
+		body       string
 	}{
-		{"method is get, data is nil and error is nil", http.MethodGet, nil, nil, http.StatusOK},
-		{"method is get, data is mil, error is not nil", http.MethodGet, nil, errTest, http.StatusInternalServerError},
-		{"method is post, data is nil and error is nil", http.MethodPost, nil, nil, http.StatusCreated},
-		{"method is delete, data is nil and error is nil", http.MethodDelete, nil, nil, http.StatusNoContent},
+		{"method is get, data is nil and error is nil", http.MethodGet, nil, nil, http.StatusOK,
+			`{}`},
+		{"method is get, data is mil, error is not nil", http.MethodGet, nil, errTest, http.StatusInternalServerError,
+			`{"error":{"message":"some error"}}`},
+		{"method is post, data is nil and error is nil", http.MethodPost, "Created", nil, http.StatusCreated,
+			`{"data":"Created"}`},
+		{"method is delete, data is nil and error is nil", http.MethodDelete, nil, nil, http.StatusNoContent,
+			`{}`},
 	}
 
 	for i, tc := range testCases {
@@ -49,7 +54,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			container: c,
 		}.ServeHTTP(w, r)
 
-		assert.Equal(t, w.Code, tc.statusCode, "TEST[%d], Failed.\n%s", i, tc.desc)
+		assert.Containsf(t, w.Body.String(), tc.body, "TEST[%d], Failed.\n%s", i, tc.desc)
+		assert.Equal(t, tc.statusCode, w.Code, "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }
 

--- a/pkg/gofr/handler_test.go
+++ b/pkg/gofr/handler_test.go
@@ -24,17 +24,20 @@ var (
 func TestHandler_ServeHTTP(t *testing.T) {
 	testCases := []struct {
 		desc       string
+		method     string
 		data       interface{}
 		err        error
 		statusCode int
 	}{
-		{"data is nil and error is nil", nil, nil, http.StatusOK},
-		{"data is mil, error is not nil", nil, errTest, http.StatusInternalServerError},
+		{"method is get, data is nil and error is nil", http.MethodGet, nil, nil, http.StatusOK},
+		{"method is get, data is mil, error is not nil", http.MethodGet, nil, errTest, http.StatusInternalServerError},
+		{"method is post, data is nil and error is nil", http.MethodPost, nil, nil, http.StatusCreated},
+		{"method is delete, data is nil and error is nil", http.MethodDelete, nil, nil, http.StatusNoContent},
 	}
 
 	for i, tc := range testCases {
 		w := httptest.NewRecorder()
-		r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		r := httptest.NewRequest(tc.method, "/", http.NoBody)
 		c := &container.Container{
 			Logger: logging.NewLogger(logging.FATAL),
 		}

--- a/pkg/gofr/http/responder.go
+++ b/pkg/gofr/http/responder.go
@@ -9,13 +9,14 @@ import (
 )
 
 // NewResponder creates a new Responder instance from the given http.ResponseWriter..
-func NewResponder(w http.ResponseWriter) *Responder {
-	return &Responder{w: w}
+func NewResponder(w http.ResponseWriter, method string) *Responder {
+	return &Responder{w: w, method: method}
 }
 
 // Responder encapsulates an http.ResponseWriter and is responsible for crafting structured responses.
 type Responder struct {
-	w http.ResponseWriter
+	w      http.ResponseWriter
+	method string
 }
 
 // Respond sends a response with the given data and handles potential errors, setting appropriate
@@ -23,7 +24,33 @@ type Responder struct {
 func (r Responder) Respond(data interface{}, err error) {
 	statusCode, errorObj := r.HTTPStatusFromError(err)
 
-	writeResponse(r.w, data, errorObj, statusCode)
+	if errorObj == nil {
+		statusCode = r.HTTPStatusFromRequestMethod()
+	}
+
+	var resp interface{}
+	switch v := data.(type) {
+	case resTypes.Raw:
+		resp = v.Data
+	case resTypes.File:
+		r.w.Header().Set("Content-Type", v.ContentType)
+		r.w.WriteHeader(statusCode)
+
+		_, _ = r.w.Write(v.Content)
+
+		return
+	default:
+		resp = response{
+			Data:  v,
+			Error: errorObj,
+		}
+	}
+
+	r.w.Header().Set("Content-Type", "application/json")
+
+	r.w.WriteHeader(statusCode)
+
+	_ = json.NewEncoder(r.w).Encode(resp)
 }
 
 // HTTPStatusFromError maps errors to HTTP status codes.
@@ -43,104 +70,24 @@ func (r Responder) HTTPStatusFromError(err error) (status int, errObj interface{
 	}
 }
 
+// HTTPStatusFromRequestMethod maps request method to HTTP status codes.
+func (r Responder) HTTPStatusFromRequestMethod() int {
+	var statusCode int
+
+	switch r.method {
+	case http.MethodPost:
+		statusCode = http.StatusCreated
+	case http.MethodDelete:
+		statusCode = http.StatusNoContent
+	default:
+		statusCode = http.StatusOK
+	}
+
+	return statusCode
+}
+
 // response represents an HTTP response.
 type response struct {
 	Error interface{} `json:"error,omitempty"`
 	Data  interface{} `json:"data,omitempty"`
-}
-
-// NewPostResponder creates a new PostResponderResponder instance from the given http.ResponseWriter..
-func NewPostResponder(w http.ResponseWriter) *PostResponder {
-	return &PostResponder{w: w}
-}
-
-// PostResponder encapsulates an http.ResponseWriter and is responsible for crafting structured responses.
-type PostResponder struct {
-	w http.ResponseWriter
-}
-
-// Respond sends a response with the given data and handles potential errors, setting appropriate
-// status codes and formatting responses as JSON or raw data as needed.
-func (r PostResponder) Respond(data interface{}, err error) {
-	statusCode, errorObj := r.HTTPStatusFromError(err)
-
-	writeResponse(r.w, data, errorObj, statusCode)
-}
-
-// HTTPStatusFromError maps errors to HTTP status codes.
-func (r PostResponder) HTTPStatusFromError(err error) (status int, errObj interface{}) {
-	if err == nil {
-		return http.StatusCreated, nil
-	}
-
-	if errors.Is(err, http.ErrMissingFile) {
-		return http.StatusNotFound, map[string]interface{}{
-			"message": err.Error(),
-		}
-	}
-
-	return http.StatusInternalServerError, map[string]interface{}{
-		"message": err.Error(),
-	}
-}
-
-func writeResponse(w http.ResponseWriter, data, errorObj interface{}, statusCode int) {
-	var resp interface{}
-	switch v := data.(type) {
-	case resTypes.Raw:
-		resp = v.Data
-	case resTypes.File:
-		w.Header().Set("Content-Type", v.ContentType)
-		w.WriteHeader(statusCode)
-
-		_, _ = w.Write(v.Content)
-
-		return
-	default:
-		resp = response{
-			Data:  v,
-			Error: errorObj,
-		}
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-
-	w.WriteHeader(statusCode)
-
-	_ = json.NewEncoder(w).Encode(resp)
-}
-
-// NewDeleteResponder creates a new PostResponderResponder instance from the given http.ResponseWriter..
-func NewDeleteResponder(w http.ResponseWriter) *DeleteResponder {
-	return &DeleteResponder{w: w}
-}
-
-// DeleteResponder encapsulates an http.ResponseWriter and is responsible for crafting structured responses.
-type DeleteResponder struct {
-	w http.ResponseWriter
-}
-
-// Respond sends a response with the given data and handles potential errors, setting appropriate
-// status codes and formatting responses as JSON or raw data as needed.
-func (r DeleteResponder) Respond(data interface{}, err error) {
-	statusCode, errorObj := r.HTTPStatusFromError(err)
-
-	writeResponse(r.w, data, errorObj, statusCode)
-}
-
-// HTTPStatusFromError maps errors to HTTP status codes.
-func (r DeleteResponder) HTTPStatusFromError(err error) (status int, errObj interface{}) {
-	if err == nil {
-		return http.StatusNoContent, nil
-	}
-
-	if errors.Is(err, http.ErrMissingFile) {
-		return http.StatusNotFound, map[string]interface{}{
-			"message": err.Error(),
-		}
-	}
-
-	return http.StatusInternalServerError, map[string]interface{}{
-		"message": err.Error(),
-	}
 }

--- a/pkg/gofr/http/responder.go
+++ b/pkg/gofr/http/responder.go
@@ -24,10 +24,6 @@ type Responder struct {
 func (r Responder) Respond(data interface{}, err error) {
 	statusCode, errorObj := r.HTTPStatusFromError(err)
 
-	if errorObj == nil {
-		statusCode = r.HTTPStatusFromRequestMethod()
-	}
-
 	var resp interface{}
 	switch v := data.(type) {
 	case resTypes.Raw:
@@ -56,7 +52,14 @@ func (r Responder) Respond(data interface{}, err error) {
 // HTTPStatusFromError maps errors to HTTP status codes.
 func (r Responder) HTTPStatusFromError(err error) (status int, errObj interface{}) {
 	if err == nil {
-		return http.StatusOK, nil
+		switch r.method {
+		case http.MethodPost:
+			return http.StatusCreated, nil
+		case http.MethodDelete:
+			return http.StatusNoContent, nil
+		default:
+			return http.StatusOK, nil
+		}
 	}
 
 	if errors.Is(err, http.ErrMissingFile) {
@@ -68,22 +71,6 @@ func (r Responder) HTTPStatusFromError(err error) (status int, errObj interface{
 	return http.StatusInternalServerError, map[string]interface{}{
 		"message": err.Error(),
 	}
-}
-
-// HTTPStatusFromRequestMethod maps request method to HTTP status codes.
-func (r Responder) HTTPStatusFromRequestMethod() int {
-	var statusCode int
-
-	switch r.method {
-	case http.MethodPost:
-		statusCode = http.StatusCreated
-	case http.MethodDelete:
-		statusCode = http.StatusNoContent
-	default:
-		statusCode = http.StatusOK
-	}
-
-	return statusCode
 }
 
 // response represents an HTTP response.

--- a/pkg/gofr/http/responder_test.go
+++ b/pkg/gofr/http/responder_test.go
@@ -111,7 +111,7 @@ func TestPostResponder_HTTPStatusFromError(t *testing.T) {
 }
 
 func TestDeleteResponder_Respond(t *testing.T) {
-	const expStatusCode = "204 No Content"
+	const expStatusCode = 204
 
 	w := httptest.NewRecorder()
 	r := NewDeleteResponder(w)

--- a/pkg/gofr/http/responder_test.go
+++ b/pkg/gofr/http/responder_test.go
@@ -55,23 +55,3 @@ func TestResponder_HTTPStatusFromError(t *testing.T) {
 		assert.Equal(t, tc.errObj, errObj, "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }
-
-func TestResponder_HTTPStatusFromRequestMethod(t *testing.T) {
-	tests := []struct {
-		desc       string
-		method     string
-		statusCode int
-	}{
-		{"get method is used", http.MethodGet, http.StatusOK},
-		{"post method is used", http.MethodPost, http.StatusCreated},
-		{"delete method is used", http.MethodDelete, http.StatusNoContent},
-	}
-
-	for i, tc := range tests {
-		r := NewResponder(httptest.NewRecorder(), tc.method)
-
-		statusCode := r.HTTPStatusFromRequestMethod()
-
-		assert.Equal(t, tc.statusCode, statusCode, "TEST[%d], Failed.\n%s", i, tc.desc)
-	}
-}

--- a/pkg/gofr/http/responder_test.go
+++ b/pkg/gofr/http/responder_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestResponder_Respond(t *testing.T) {
-	r := NewResponder(httptest.NewRecorder())
+	r := NewResponder(httptest.NewRecorder(), http.MethodGet)
 
 	tests := []struct {
 		desc        string
@@ -32,7 +32,7 @@ func TestResponder_Respond(t *testing.T) {
 }
 
 func TestResponder_HTTPStatusFromError(t *testing.T) {
-	r := NewResponder(httptest.NewRecorder())
+	r := NewResponder(httptest.NewRecorder(), http.MethodGet)
 
 	tests := []struct {
 		desc       string
@@ -56,110 +56,22 @@ func TestResponder_HTTPStatusFromError(t *testing.T) {
 	}
 }
 
-func TestPostResponder_Respond(t *testing.T) {
-	const expStatusCode = "201 Created"
-
-	w := httptest.NewRecorder()
-	r := NewPostResponder(w)
-
-	tests := []struct {
-		desc        string
-		data        interface{}
-		contentType string
-	}{
-		{"raw response type", resTypes.Raw{}, "application/json"},
-		{"file response type", resTypes.File{ContentType: "image/png"}, "image/png"},
-		{"map response type", map[string]string{}, "application/json"},
-	}
-
-	for i, tc := range tests {
-		r.Respond(tc.data, nil)
-
-		contentType := w.Header().Get("Content-Type")
-		result := w.Result()
-
-		assert.Equal(t, expStatusCode, result.Status, "TEST[%d], Failed.\n%s", i, tc.desc)
-		assert.Equal(t, tc.contentType, contentType, "TEST[%d], Failed.\n%s", i, tc.desc)
-
-		result.Body.Close()
-	}
-}
-
-func TestPostResponder_HTTPStatusFromError(t *testing.T) {
-	r := NewPostResponder(httptest.NewRecorder())
-
+func TestResponder_HTTPStatusFromRequestMethod(t *testing.T) {
 	tests := []struct {
 		desc       string
-		input      error
+		method     string
 		statusCode int
-		errObj     interface{}
 	}{
-		{"success case", nil, http.StatusCreated, nil},
-		{"file not found", http.ErrMissingFile, http.StatusNotFound, map[string]interface{}{
-			"message": http.ErrMissingFile.Error()}},
-		{"internal server error", http.ErrHandlerTimeout, http.StatusInternalServerError,
-			map[string]interface{}{"message": http.ErrHandlerTimeout.Error()}},
+		{"get method is used", http.MethodGet, http.StatusOK},
+		{"post method is used", http.MethodPost, http.StatusCreated},
+		{"delete method is used", http.MethodDelete, http.StatusNoContent},
 	}
 
 	for i, tc := range tests {
-		statusCode, errObj := r.HTTPStatusFromError(tc.input)
+		r := NewResponder(httptest.NewRecorder(), tc.method)
+
+		statusCode := r.HTTPStatusFromRequestMethod()
 
 		assert.Equal(t, tc.statusCode, statusCode, "TEST[%d], Failed.\n%s", i, tc.desc)
-
-		assert.Equal(t, tc.errObj, errObj, "TEST[%d], Failed.\n%s", i, tc.desc)
-	}
-}
-
-func TestDeleteResponder_Respond(t *testing.T) {
-	const expStatusCode = 204
-
-	w := httptest.NewRecorder()
-	r := NewDeleteResponder(w)
-
-	tests := []struct {
-		desc        string
-		data        interface{}
-		contentType string
-	}{
-		{"raw response type", resTypes.Raw{}, "application/json"},
-		{"file response type", resTypes.File{ContentType: "image/png"}, "image/png"},
-		{"map response type", map[string]string{}, "application/json"},
-	}
-
-	for i, tc := range tests {
-		r.Respond(tc.data, nil)
-
-		contentType := w.Header().Get("Content-Type")
-		result := w.Result()
-
-		assert.Equal(t, expStatusCode, result.StatusCode, "TEST[%d], Failed.\n%s", i, tc.desc)
-		assert.Equal(t, tc.contentType, contentType, "TEST[%d], Failed.\n%s", i, tc.desc)
-
-		result.Body.Close()
-	}
-}
-
-func TestDeleteResponder_HTTPStatusFromError(t *testing.T) {
-	r := NewDeleteResponder(httptest.NewRecorder())
-
-	tests := []struct {
-		desc       string
-		input      error
-		statusCode int
-		errObj     interface{}
-	}{
-		{"success case", nil, http.StatusNoContent, nil},
-		{"file not found", http.ErrMissingFile, http.StatusNotFound, map[string]interface{}{
-			"message": http.ErrMissingFile.Error()}},
-		{"internal server error", http.ErrHandlerTimeout, http.StatusInternalServerError,
-			map[string]interface{}{"message": http.ErrHandlerTimeout.Error()}},
-	}
-
-	for i, tc := range tests {
-		statusCode, errObj := r.HTTPStatusFromError(tc.input)
-
-		assert.Equal(t, tc.statusCode, statusCode, "TEST[%d], Failed.\n%s", i, tc.desc)
-
-		assert.Equal(t, tc.errObj, errObj, "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }

--- a/pkg/gofr/http/responder_test.go
+++ b/pkg/gofr/http/responder_test.go
@@ -55,3 +55,111 @@ func TestResponder_HTTPStatusFromError(t *testing.T) {
 		assert.Equal(t, tc.errObj, errObj, "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }
+
+func TestPostResponder_Respond(t *testing.T) {
+	const expStatusCode = "201 Created"
+
+	w := httptest.NewRecorder()
+	r := NewPostResponder(w)
+
+	tests := []struct {
+		desc        string
+		data        interface{}
+		contentType string
+	}{
+		{"raw response type", resTypes.Raw{}, "application/json"},
+		{"file response type", resTypes.File{ContentType: "image/png"}, "image/png"},
+		{"map response type", map[string]string{}, "application/json"},
+	}
+
+	for i, tc := range tests {
+		r.Respond(tc.data, nil)
+
+		contentType := w.Header().Get("Content-Type")
+		result := w.Result()
+
+		assert.Equal(t, expStatusCode, result.Status, "TEST[%d], Failed.\n%s", i, tc.desc)
+		assert.Equal(t, tc.contentType, contentType, "TEST[%d], Failed.\n%s", i, tc.desc)
+
+		result.Body.Close()
+	}
+}
+
+func TestPostResponder_HTTPStatusFromError(t *testing.T) {
+	r := NewPostResponder(httptest.NewRecorder())
+
+	tests := []struct {
+		desc       string
+		input      error
+		statusCode int
+		errObj     interface{}
+	}{
+		{"success case", nil, http.StatusCreated, nil},
+		{"file not found", http.ErrMissingFile, http.StatusNotFound, map[string]interface{}{
+			"message": http.ErrMissingFile.Error()}},
+		{"internal server error", http.ErrHandlerTimeout, http.StatusInternalServerError,
+			map[string]interface{}{"message": http.ErrHandlerTimeout.Error()}},
+	}
+
+	for i, tc := range tests {
+		statusCode, errObj := r.HTTPStatusFromError(tc.input)
+
+		assert.Equal(t, tc.statusCode, statusCode, "TEST[%d], Failed.\n%s", i, tc.desc)
+
+		assert.Equal(t, tc.errObj, errObj, "TEST[%d], Failed.\n%s", i, tc.desc)
+	}
+}
+
+func TestDeleteResponder_Respond(t *testing.T) {
+	const expStatusCode = "204 No Content"
+
+	w := httptest.NewRecorder()
+	r := NewDeleteResponder(w)
+
+	tests := []struct {
+		desc        string
+		data        interface{}
+		contentType string
+	}{
+		{"raw response type", resTypes.Raw{}, "application/json"},
+		{"file response type", resTypes.File{ContentType: "image/png"}, "image/png"},
+		{"map response type", map[string]string{}, "application/json"},
+	}
+
+	for i, tc := range tests {
+		r.Respond(tc.data, nil)
+
+		contentType := w.Header().Get("Content-Type")
+		result := w.Result()
+
+		assert.Equal(t, expStatusCode, result.StatusCode, "TEST[%d], Failed.\n%s", i, tc.desc)
+		assert.Equal(t, tc.contentType, contentType, "TEST[%d], Failed.\n%s", i, tc.desc)
+
+		result.Body.Close()
+	}
+}
+
+func TestDeleteResponder_HTTPStatusFromError(t *testing.T) {
+	r := NewDeleteResponder(httptest.NewRecorder())
+
+	tests := []struct {
+		desc       string
+		input      error
+		statusCode int
+		errObj     interface{}
+	}{
+		{"success case", nil, http.StatusNoContent, nil},
+		{"file not found", http.ErrMissingFile, http.StatusNotFound, map[string]interface{}{
+			"message": http.ErrMissingFile.Error()}},
+		{"internal server error", http.ErrHandlerTimeout, http.StatusInternalServerError,
+			map[string]interface{}{"message": http.ErrHandlerTimeout.Error()}},
+	}
+
+	for i, tc := range tests {
+		statusCode, errObj := r.HTTPStatusFromError(tc.input)
+
+		assert.Equal(t, tc.statusCode, statusCode, "TEST[%d], Failed.\n%s", i, tc.desc)
+
+		assert.Equal(t, tc.errObj, errObj, "TEST[%d], Failed.\n%s", i, tc.desc)
+	}
+}


### PR DESCRIPTION
- Added types `PostResponder` and `DeleteResponder` implementing Responder interface to write responses for post and delete requests respectively
- Updated `ServeHTTP` method to create instances of `Responder` on the basis of request methods
- For details refer https://github.com/gofr-dev/gofr/issues/446