### PR TITLE
Remove auth for /.well-known routes

### DIFF
--- a/pkg/gofr/http/middleware/apikey_auth.go
+++ b/pkg/gofr/http/middleware/apikey_auth.go
@@ -23,16 +23,9 @@ func APIKeyAuthMiddleware(validator func(apiKey string) bool, apiKeys ...string)
 				return
 			}
 
-			if validator != nil {
-				if !validator(authKey) {
-					http.Error(w, "Unauthorized: Invalid Authorization header", http.StatusUnauthorized)
-					return
-				}
-			} else {
-				if !isPresent(authKey, apiKeys...) {
-					http.Error(w, "Unauthorized: Invalid Authorization header", http.StatusUnauthorized)
-					return
-				}
+			if !validateKey(validator, authKey, apiKeys...) {
+				http.Error(w, "Unauthorized: Invalid Authorization header", http.StatusUnauthorized)
+				return
 			}
 
 			handler.ServeHTTP(w, r)
@@ -48,4 +41,18 @@ func isPresent(authKey string, apiKeys ...string) bool {
 	}
 
 	return false
+}
+
+func validateKey(validator func(apiKey string) bool, authKey string, apiKeys ...string) bool {
+	if validator != nil {
+		if !validator(authKey) {
+			return false
+		}
+	} else {
+		if !isPresent(authKey, apiKeys...) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/gofr/http/middleware/apikey_auth.go
+++ b/pkg/gofr/http/middleware/apikey_auth.go
@@ -19,18 +19,18 @@ func APIKeyAuthMiddleware(validator func(apiKey string) bool, apiKeys ...string)
 
 			authKey := r.Header.Get("X-API-KEY")
 			if authKey == "" {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				http.Error(w, "Unauthorized: Authorization header missing", http.StatusUnauthorized)
 				return
 			}
 
 			if validator != nil {
 				if !validator(authKey) {
-					http.Error(w, "Unauthorized", http.StatusUnauthorized)
+					http.Error(w, "Unauthorized: Invalid Authorization header", http.StatusUnauthorized)
 					return
 				}
 			} else {
 				if !isPresent(authKey, apiKeys...) {
-					http.Error(w, "Unauthorized", http.StatusUnauthorized)
+					http.Error(w, "Unauthorized: Invalid Authorization header", http.StatusUnauthorized)
 					return
 				}
 			}

--- a/pkg/gofr/http/middleware/apikey_auth.go
+++ b/pkg/gofr/http/middleware/apikey_auth.go
@@ -4,6 +4,7 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 )
 
 // APIKeyAuthMiddleware creates a middleware function that enforces API key authentication based on the provided API
@@ -11,6 +12,11 @@ import (
 func APIKeyAuthMiddleware(validator func(apiKey string) bool, apiKeys ...string) func(handler http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/.well-known") {
+				handler.ServeHTTP(w, r)
+				return
+			}
+
 			authKey := r.Header.Get("X-API-KEY")
 			if authKey == "" {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)

--- a/pkg/gofr/http/middleware/basic_auth.go
+++ b/pkg/gofr/http/middleware/basic_auth.go
@@ -18,6 +18,11 @@ type BasicAuthProvider struct {
 func BasicAuthMiddleware(basicAuthProvider BasicAuthProvider) func(handler http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/.well-known") {
+				handler.ServeHTTP(w, r)
+				return
+			}
+
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
 				http.Error(w, "Unauthorized: Authorization header missing", http.StatusUnauthorized)

--- a/pkg/gofr/http/middleware/basic_auth.go
+++ b/pkg/gofr/http/middleware/basic_auth.go
@@ -47,7 +47,7 @@ func BasicAuthMiddleware(basicAuthProvider BasicAuthProvider) func(handler http.
 				return
 			}
 
-			if !validCredentials(basicAuthProvider, credentials, w) {
+			if !validateCredentials(basicAuthProvider, credentials) {
 				http.Error(w, "Unauthorized: Invalid username or password", http.StatusUnauthorized)
 				return
 			}
@@ -57,7 +57,7 @@ func BasicAuthMiddleware(basicAuthProvider BasicAuthProvider) func(handler http.
 	}
 }
 
-func validCredentials(provider BasicAuthProvider, credentials []string, w http.ResponseWriter) bool {
+func validateCredentials(provider BasicAuthProvider, credentials []string) bool {
 	if provider.ValidateFunc != nil {
 		if !provider.ValidateFunc(credentials[0], credentials[1]) {
 			return false

--- a/pkg/gofr/http/middleware/basic_auth_test.go
+++ b/pkg/gofr/http/middleware/basic_auth_test.go
@@ -90,3 +90,19 @@ func TestBasicAuthMiddleware(t *testing.T) {
 		})
 	}
 }
+
+func Test_BasicAuthMiddleware_well_known(t *testing.T) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Success"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/health-check", http.NoBody)
+	rr := httptest.NewRecorder()
+
+	authMiddleware := BasicAuthMiddleware(BasicAuthProvider{})(testHandler)
+	authMiddleware.ServeHTTP(rr, req)
+
+	assert.Equal(t, 200, rr.Code, "TEST Failed.\n")
+
+	assert.Equal(t, "Success", rr.Body.String(), "TEST Failed.\n")
+}

--- a/pkg/gofr/http/middleware/oauth.go
+++ b/pkg/gofr/http/middleware/oauth.go
@@ -94,6 +94,11 @@ type PublicKeyProvider interface {
 func OAuth(key PublicKeyProvider) func(inner http.Handler) http.Handler {
 	return func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/.well-known") {
+				inner.ServeHTTP(w, r)
+				return
+			}
+
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
 				http.Error(w, "Authorization header is required", http.StatusUnauthorized)

--- a/pkg/gofr/http/middleware/oauth_test.go
+++ b/pkg/gofr/http/middleware/oauth_test.go
@@ -195,3 +195,19 @@ func TestPublicKeyFromJWKS_EmptyJWKS_ReturnsNil(t *testing.T) {
 
 	assert.Nil(t, result)
 }
+
+func Test_OAuth_well_known(t *testing.T) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Success"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/health-check", http.NoBody)
+	rr := httptest.NewRecorder()
+
+	authMiddleware := OAuth(nil)(testHandler)
+	authMiddleware.ServeHTTP(rr, req)
+
+	assert.Equal(t, 200, rr.Code, "TEST Failed.\n")
+
+	assert.Equal(t, "Success", rr.Body.String(), "TEST Failed.\n")
+}


### PR DESCRIPTION
- Currently, authentication is enabled for `/.well-known` endpoints, which should not be happening as discussed in #461.
- Bypassed `/.well-known` routes from auth middlewares.
- Added `validateKey` and `validateCredential` functions to reduce code complexity.
Closes: #471

**Checklist:**

-   [ ] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [ ] All new code is covered by unit tests.
-   [ ] This PR does not decrease the overall code coverage.
-   [ ] I have reviewed the code comments and documentation for clarity.