### PR TITLE
Add support for labels in gauge metrics

### DIFF
--- a/pkg/gofr/datasource/sql/metrics.go
+++ b/pkg/gofr/datasource/sql/metrics.go
@@ -4,5 +4,5 @@ import "context"
 
 type Metrics interface {
 	RecordHistogram(ctx context.Context, name string, value float64, labels ...string)
-	SetGauge(name string, value float64)
+	SetGauge(name string, value float64, labels ...string)
 }

--- a/pkg/gofr/datasource/sql/mock_metrics.go
+++ b/pkg/gofr/datasource/sql/mock_metrics.go
@@ -57,13 +57,18 @@ func (mr *MockMetricsMockRecorder) RecordHistogram(ctx, name, value any, labels 
 }
 
 // SetGauge mocks base method.
-func (m *MockMetrics) SetGauge(name string, value float64) {
+func (m *MockMetrics) SetGauge(name string, value float64, labels ...string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetGauge", name, value)
+	varargs := []any{name, value}
+	for _, a := range labels {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "SetGauge", varargs...)
 }
 
 // SetGauge indicates an expected call of SetGauge.
-func (mr *MockMetricsMockRecorder) SetGauge(name, value any) *gomock.Call {
+func (mr *MockMetricsMockRecorder) SetGauge(name, value any, labels ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGauge", reflect.TypeOf((*MockMetrics)(nil).SetGauge), name, value)
+	varargs := append([]any{name, value}, labels...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGauge", reflect.TypeOf((*MockMetrics)(nil).SetGauge), varargs...)
 }

--- a/pkg/gofr/http/metrics.go
+++ b/pkg/gofr/http/metrics.go
@@ -8,5 +8,5 @@ type Metrics interface {
 	IncrementCounter(ctx context.Context, name string, labels ...string)
 	DeltaUpDownCounter(ctx context.Context, name string, value float64, labels ...string)
 	RecordHistogram(ctx context.Context, name string, value float64, labels ...string)
-	SetGauge(name string, value float64)
+	SetGauge(name string, value float64, labels ...string)
 }

--- a/pkg/gofr/http/middleware/metrics.go
+++ b/pkg/gofr/http/middleware/metrics.go
@@ -14,7 +14,7 @@ type metrics interface {
 	IncrementCounter(ctx context.Context, name string, labels ...string)
 	DeltaUpDownCounter(ctx context.Context, name string, value float64, labels ...string)
 	RecordHistogram(ctx context.Context, name string, value float64, labels ...string)
-	SetGauge(name string, value float64)
+	SetGauge(name string, value float64, labels ...string)
 }
 
 // Metrics is a middleware that records request response time metrics using the provided metrics interface.

--- a/pkg/gofr/http/middleware/metrics_test.go
+++ b/pkg/gofr/http/middleware/metrics_test.go
@@ -27,7 +27,7 @@ func (m *mockMetrics) RecordHistogram(ctx context.Context, name string, value fl
 	m.Called(ctx, name, value, labels)
 }
 
-func (m *mockMetrics) SetGauge(name string, value float64) {
+func (m *mockMetrics) SetGauge(name string, value float64, labels ...string) {
 	m.Called(name, value)
 }
 

--- a/pkg/gofr/http/middleware/metrics_test.go
+++ b/pkg/gofr/http/middleware/metrics_test.go
@@ -27,7 +27,7 @@ func (m *mockMetrics) RecordHistogram(ctx context.Context, name string, value fl
 	m.Called(ctx, name, value, labels)
 }
 
-func (m *mockMetrics) SetGauge(name string, value float64, labels ...string) {
+func (m *mockMetrics) SetGauge(name string, value float64, _ ...string) {
 	m.Called(name, value)
 }
 

--- a/pkg/gofr/metrics/register.go
+++ b/pkg/gofr/metrics/register.go
@@ -38,6 +38,13 @@ type metricsManager struct {
 	logger Logger
 }
 
+// Developer Note: float64Gauge is used instead of metric.Float64ObservableGauge because we need a synchronous gauge metric
+// and otel/metric supports only asynchronous gauge (Float64ObservableGauge).
+// And if we use the otel/metric, we would not be able to have support for labels, Hence created a custom type to implement it.
+type float64Gauge struct {
+	observations map[attribute.Set]float64
+}
+
 // NewMetricsManager creates a new metrics manager instance with the provided metric  meter and logger.
 func NewMetricsManager(meter metric.Meter, logger Logger) Manager {
 	return &metricsManager{
@@ -112,13 +119,6 @@ func (m *metricsManager) NewHistogram(name, desc string, buckets ...float64) {
 	if err != nil {
 		m.logger.Error(err)
 	}
-}
-
-// Developer Note: float64Gauge is used instead of metric.Float64ObservableGauge because we need a synchronous gauge metric
-// and otel/metric supports only asynchronous (Float64ObservableGauge) metric.
-// And if we use the otel/metric, we would not be able to have support for labels, Hence created a custom type to implement it.
-type float64Gauge struct {
-	observations map[attribute.Set]float64
 }
 
 // NewGauge registers a new gauge metrics. This metric can set

--- a/pkg/gofr/metrics/register.go
+++ b/pkg/gofr/metrics/register.go
@@ -121,17 +121,13 @@ type float64Gauge struct {
 	observations map[attribute.Set]float64
 }
 
-func newFloat64Gauge() *float64Gauge {
-	return &float64Gauge{observations: make(map[attribute.Set]float64)}
-}
-
 // NewGauge registers a new gauge metrics. This metric can set
 // the value of metric to a particular value, but it doesn't store the last recorded value for the metrics.
 //
 //	Usage:
 //	m.NewGauge("memory_usage", "Current memory usage in bytes")
 func (m *metricsManager) NewGauge(name, desc string) {
-	gauge := *newFloat64Gauge()
+	gauge := float64Gauge{observations: make(map[attribute.Set]float64)}
 
 	_, err := m.meter.Float64ObservableGauge(name, metric.WithDescription(desc), metric.WithFloat64Callback(gauge.callbackFunc))
 	if err != nil {
@@ -242,9 +238,7 @@ func (m *metricsManager) SetGauge(name string, value float64, labels ...string) 
 		return
 	}
 
-	attrs := m.getAttributes(name, labels...)
-
-	gauge.set(value, attribute.NewSet(attrs...))
+	gauge.set(value, attribute.NewSet(m.getAttributes(name, labels...)...))
 }
 
 func (f *float64Gauge) set(val float64, attrs attribute.Set) {

--- a/pkg/gofr/metrics/register.go
+++ b/pkg/gofr/metrics/register.go
@@ -144,7 +144,7 @@ func (m *metricsManager) NewGauge(name, desc string) {
 
 // callbackFunc implements the callback function for the underlying asynchronous gauge
 // it observes the current state of all previous set() calls.
-func (f *float64Gauge) callbackFunc(ctx context.Context, o metric.Float64Observer) error {
+func (f *float64Gauge) callbackFunc(_ context.Context, o metric.Float64Observer) error {
 	for attrs, val := range f.observations {
 		o.Observe(val, metric.WithAttributeSet(attrs))
 	}

--- a/pkg/gofr/metrics/register.go
+++ b/pkg/gofr/metrics/register.go
@@ -21,7 +21,7 @@ type Manager interface {
 	IncrementCounter(ctx context.Context, name string, labels ...string)
 	DeltaUpDownCounter(ctx context.Context, name string, value float64, labels ...string)
 	RecordHistogram(ctx context.Context, name string, value float64, labels ...string)
-	SetGauge(name string, value float64)
+	SetGauge(name string, value float64, labels ...string)
 }
 
 // Logger defines a simple interface for logging messages at different log levels.
@@ -114,13 +114,26 @@ func (m *metricsManager) NewHistogram(name, desc string, buckets ...float64) {
 	}
 }
 
+// Developer Note: float64Gauge is used instead of metric.Float64ObservableGauge because we need a synchronous gauge metric
+// and otel/metric supports only asynchronous (Float64ObservableGauge) metric.
+// And if we use the otel/metric, we would not be able to have support for labels, Hence created a custom type to implement it.
+type float64Gauge struct {
+	observations map[attribute.Set]float64
+}
+
+func newFloat64Gauge() *float64Gauge {
+	return &float64Gauge{observations: make(map[attribute.Set]float64)}
+}
+
 // NewGauge registers a new gauge metrics. This metric can set
-// the value of metric to a particular value but it doesn't store the last recorded value for the metrics.
+// the value of metric to a particular value, but it doesn't store the last recorded value for the metrics.
 //
 //	Usage:
 //	m.NewGauge("memory_usage", "Current memory usage in bytes")
 func (m *metricsManager) NewGauge(name, desc string) {
-	gauge, err := m.meter.Float64ObservableGauge(name, metric.WithDescription(desc))
+	gauge := *newFloat64Gauge()
+
+	_, err := m.meter.Float64ObservableGauge(name, metric.WithDescription(desc), metric.WithFloat64Callback(gauge.callbackFunc))
 	if err != nil {
 		m.logger.Error(err)
 
@@ -131,6 +144,16 @@ func (m *metricsManager) NewGauge(name, desc string) {
 	if err != nil {
 		m.logger.Error(err)
 	}
+}
+
+// callbackFunc implements the callback function for the underlying asynchronous gauge
+// it observes the current state of all previous set() calls.
+func (f *float64Gauge) callbackFunc(ctx context.Context, o metric.Float64Observer) error {
+	for attrs, val := range f.observations {
+		o.Observe(val, metric.WithAttributeSet(attrs))
+	}
+
+	return nil
 }
 
 // IncrementCounter increases the specified registered counter metric by 1.
@@ -211,7 +234,7 @@ func (m *metricsManager) RecordHistogram(ctx context.Context, name string, value
 //	Usage:
 //	manager.SetGauge("memory_usage", 1024*1024*100)
 //	// Set memory usage to 100 MB
-func (m *metricsManager) SetGauge(name string, value float64) {
+func (m *metricsManager) SetGauge(name string, value float64, labels ...string) {
 	gauge, err := m.store.getGauge(name)
 	if err != nil {
 		m.logger.Error(err)
@@ -219,18 +242,13 @@ func (m *metricsManager) SetGauge(name string, value float64) {
 		return
 	}
 
-	_, err = m.meter.RegisterCallback(callbackFunc(gauge, value), gauge)
-	if err != nil {
-		m.logger.Error(err)
-	}
+	attrs := m.getAttributes(name, labels...)
+
+	gauge.set(value, attribute.NewSet(attrs...))
 }
 
-func callbackFunc(name metric.Float64ObservableGauge, field float64) func(_ context.Context, o metric.Observer) error {
-	return func(_ context.Context, o metric.Observer) error {
-		o.ObserveFloat64(name, field)
-
-		return nil
-	}
+func (f *float64Gauge) set(val float64, attrs attribute.Set) {
+	f.observations[attrs] = val
 }
 
 // getAttributes validates the given labels and convert them to corresponding otel attributes.

--- a/pkg/gofr/metrics/store.go
+++ b/pkg/gofr/metrics/store.go
@@ -8,7 +8,7 @@ type store struct {
 	counter       map[string]metric.Int64Counter
 	upDownCounter map[string]metric.Float64UpDownCounter
 	histogram     map[string]metric.Float64Histogram
-	gauge         map[string]metric.Float64ObservableGauge
+	gauge         map[string]float64Gauge
 }
 
 // Store represents a store for registered metrics. It provides methods to retrieve and manage different
@@ -17,11 +17,11 @@ type Store interface {
 	getCounter(name string) (metric.Int64Counter, error)
 	getUpDownCounter(name string) (metric.Float64UpDownCounter, error)
 	getHistogram(name string) (metric.Float64Histogram, error)
-	getGauge(name string) (metric.Float64ObservableGauge, error)
+	getGauge(name string) (float64Gauge, error)
 	setCounter(name string, m metric.Int64Counter) error
 	setUpDownCounter(name string, m metric.Float64UpDownCounter) error
 	setHistogram(name string, m metric.Float64Histogram) error
-	setGauge(name string, m metric.Float64ObservableGauge) error
+	setGauge(name string, m float64Gauge) error
 }
 
 func newOtelStore() Store {
@@ -29,7 +29,7 @@ func newOtelStore() Store {
 		counter:       make(map[string]metric.Int64Counter),
 		upDownCounter: make(map[string]metric.Float64UpDownCounter),
 		histogram:     make(map[string]metric.Float64Histogram),
-		gauge:         make(map[string]metric.Float64ObservableGauge),
+		gauge:         make(map[string]float64Gauge),
 	}
 }
 
@@ -60,10 +60,10 @@ func (s store) getHistogram(name string) (metric.Float64Histogram, error) {
 	return m, nil
 }
 
-func (s store) getGauge(name string) (metric.Float64ObservableGauge, error) {
+func (s store) getGauge(name string) (float64Gauge, error) {
 	m, ok := s.gauge[name]
 	if !ok {
-		return nil, metricsNotRegistered{metricsName: name}
+		return m, metricsNotRegistered{metricsName: name}
 	}
 
 	return m, nil
@@ -102,7 +102,7 @@ func (s store) setHistogram(name string, m metric.Float64Histogram) error {
 	return metricsAlreadyRegistered{metricsName: name}
 }
 
-func (s store) setGauge(name string, m metric.Float64ObservableGauge) error {
+func (s store) setGauge(name string, m float64Gauge) error {
 	_, ok := s.gauge[name]
 	if !ok {
 		s.gauge[name] = m


### PR DESCRIPTION
- Currently, labels support is not there for gauge metrics due to usage of [asynchronous](https://pkg.go.dev/go.opentelemetry.io/otel/metric@v1.24.0#Float64ObservableGauge) type metric.
- Added a custom type `float64Gauge` and implemented the required methods i.e `callbackFunc` and `set` on the custom type so that we can add the support of labels.
Closes: #489

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.