### PR TITLE
Fix PostgreSQL support in AddRESTHandlers.

### DIFF
--- a/pkg/gofr/crud_handlers.go
+++ b/pkg/gofr/crud_handlers.go
@@ -119,14 +119,14 @@ func (e *entity) Create(c *Context) (interface{}, error) {
 		fieldValues = append(fieldValues, reflect.ValueOf(newEntity).Elem().Field(i).Interface())
 	}
 
-	stmt := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
+	rawStmt := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
 		e.name,
 		strings.Join(fieldNames, ", "),
 		strings.Repeat("?, ", len(fieldNames)-1)+"?",
 	)
-	rStmt := sql.Rebind(c.SQL.Dialect(), stmt)
+	stmt := sql.Rebind(c.SQL.Dialect(), rawStmt)
 
-	_, err = c.SQL.ExecContext(c, rStmt, fieldValues...)
+	_, err = c.SQL.ExecContext(c, stmt, fieldValues...)
 	if err != nil {
 		return nil, err
 	}
@@ -177,10 +177,10 @@ func (e *entity) Get(c *Context) (interface{}, error) {
 	newEntity := reflect.New(e.entityType).Interface()
 	id := c.Request.PathParam("id")
 
-	query := fmt.Sprintf("SELECT * FROM %s WHERE %s = ?", e.name, e.primaryKey)
-	rQuery := sql.Rebind(c.SQL.Dialect(), query)
+	rawQuery := fmt.Sprintf("SELECT * FROM %s WHERE %s = ?", e.name, e.primaryKey)
+	query := sql.Rebind(c.SQL.Dialect(), rawQuery)
 
-	row := c.SQL.QueryRowContext(c, rQuery, id)
+	row := c.SQL.QueryRowContext(c, query, id)
 
 	dest := make([]interface{}, e.entityType.NumField())
 	val := reflect.ValueOf(newEntity).Elem()
@@ -224,15 +224,15 @@ func (e *entity) Update(c *Context) (interface{}, error) {
 
 	query := strings.Join(paramsList, ", ")
 
-	stmt := fmt.Sprintf("UPDATE %s SET %s WHERE %s = %s",
+	rawStmt := fmt.Sprintf("UPDATE %s SET %s WHERE %s = %s",
 		e.name,
 		query,
 		e.primaryKey,
 		id,
 	)
-	rStmt := sql.Rebind(c.SQL.Dialect(), stmt)
+	stmt := sql.Rebind(c.SQL.Dialect(), rawStmt)
 
-	_, err = c.SQL.ExecContext(c, rStmt, fieldValues[1:]...)
+	_, err = c.SQL.ExecContext(c, stmt, fieldValues[1:]...)
 	if err != nil {
 		return nil, err
 	}
@@ -243,10 +243,10 @@ func (e *entity) Update(c *Context) (interface{}, error) {
 func (e *entity) Delete(c *Context) (interface{}, error) {
 	id := c.PathParam("id")
 
-	query := fmt.Sprintf("DELETE FROM %s WHERE %s = ?", e.name, e.primaryKey)
-	rQuery := sql.Rebind(c.SQL.Dialect(), query)
+	rawQuery := fmt.Sprintf("DELETE FROM %s WHERE %s = ?", e.name, e.primaryKey)
+	query := sql.Rebind(c.SQL.Dialect(), rawQuery)
 
-	result, err := c.SQL.ExecContext(c, rQuery, id)
+	result, err := c.SQL.ExecContext(c, query, id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gofr/datasource/sql/bind.go
+++ b/pkg/gofr/datasource/sql/bind.go
@@ -1,0 +1,47 @@
+package sql
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	DialectMysql    = "mysql"
+	DialectPostgres = "postgres"
+)
+
+const (
+	UNKNOWN = iota
+	QUESTION
+	DOLLAR
+)
+
+func Rebind(dialect, query string) string {
+	switch bindType(dialect) {
+	case QUESTION, UNKNOWN:
+		return query
+	case DOLLAR:
+		queryFormat := strings.Replace(query, "?", "%v", -1)
+		count := strings.Count(query, "?")
+		replacement := make([]interface{}, count)
+
+		for i := 0; i < count; i++ {
+			replacement[i] = fmt.Sprintf("$%v", i+1)
+		}
+
+		return fmt.Sprintf(queryFormat, replacement...)
+	}
+
+	return query
+}
+
+func bindType(dialect string) uint {
+	switch dialect {
+	case DialectMysql:
+		return QUESTION
+	case DialectPostgres:
+		return DOLLAR
+	default:
+		return UNKNOWN
+	}
+}

--- a/pkg/gofr/datasource/sql/bind.go
+++ b/pkg/gofr/datasource/sql/bind.go
@@ -10,16 +10,18 @@ const (
 	DialectPostgres = "postgres"
 )
 
+// BindVarType represents different type of bindvars in SQL queries.
+type BindVarType uint
+
 const (
-	UNKNOWN = iota
+	UNKNOWN BindVarType = iota + 1
 	QUESTION
 	DOLLAR
 )
 
 func Rebind(dialect, query string) string {
+	//nolint:exhaustive // we have only dollar bindvar type specific logic for now.
 	switch bindType(dialect) {
-	case QUESTION, UNKNOWN:
-		return query
 	case DOLLAR:
 		queryFormat := strings.Replace(query, "?", "%v", -1)
 		count := strings.Count(query, "?")
@@ -30,12 +32,12 @@ func Rebind(dialect, query string) string {
 		}
 
 		return fmt.Sprintf(queryFormat, replacement...)
+	default:
+		return query
 	}
-
-	return query
 }
 
-func bindType(dialect string) uint {
+func bindType(dialect string) BindVarType {
 	switch dialect {
 	case DialectMysql:
 		return QUESTION

--- a/pkg/gofr/datasource/sql/bind.go
+++ b/pkg/gofr/datasource/sql/bind.go
@@ -20,9 +20,7 @@ const (
 )
 
 func Rebind(dialect, query string) string {
-	//nolint:exhaustive // we have only dollar bindvar type specific logic for now.
-	switch bindType(dialect) {
-	case DOLLAR:
+	if DOLLAR == bindType(dialect) {
 		queryFormat := strings.Replace(query, "?", "%v", -1)
 		count := strings.Count(query, "?")
 		replacement := make([]interface{}, count)
@@ -32,9 +30,9 @@ func Rebind(dialect, query string) string {
 		}
 
 		return fmt.Sprintf(queryFormat, replacement...)
-	default:
-		return query
 	}
+
+	return query
 }
 
 func bindType(dialect string) BindVarType {

--- a/pkg/gofr/datasource/sql/bind_test.go
+++ b/pkg/gofr/datasource/sql/bind_test.go
@@ -43,7 +43,7 @@ func Test_Rebind(t *testing.T) {
 func Test_BindType(t *testing.T) {
 	tests := []struct {
 		dialect  string
-		expected uint
+		expected BindVarType
 	}{
 		{
 			dialect:  "mysql",

--- a/pkg/gofr/datasource/sql/bind_test.go
+++ b/pkg/gofr/datasource/sql/bind_test.go
@@ -1,0 +1,67 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Rebind(t *testing.T) {
+	tests := []struct {
+		desc     string
+		dialect  string
+		input    string
+		expected string
+	}{
+		{
+			desc:     "insert",
+			dialect:  "mysql",
+			input:    "INSERT INTO user (id, name) VALUES (?, ?)",
+			expected: "INSERT INTO user (id, name) VALUES (?, ?)",
+		},
+		{
+			desc:     "insert",
+			dialect:  "postgres",
+			input:    "INSERT INTO user (id, name) VALUES (?, ?)",
+			expected: "INSERT INTO user (id, name) VALUES ($1, $2)",
+		},
+		{
+			desc:     "insert",
+			dialect:  "any-other-dialect",
+			input:    "INSERT INTO user (id, name) VALUES (?, ?)",
+			expected: "INSERT INTO user (id, name) VALUES (?, ?)",
+		},
+	}
+	for i, tc := range tests {
+		t.Run(tc.dialect+" "+tc.desc, func(t *testing.T) {
+			actual := Rebind(tc.dialect, tc.input)
+			assert.Equal(t, tc.expected, actual, "TEST[%d], Failed.\n%s", i, tc.desc)
+		})
+	}
+}
+
+func Test_BindType(t *testing.T) {
+	tests := []struct {
+		dialect  string
+		expected uint
+	}{
+		{
+			dialect:  "mysql",
+			expected: QUESTION,
+		},
+		{
+			dialect:  "postgres",
+			expected: DOLLAR,
+		},
+		{
+			dialect:  "any-other-dialect",
+			expected: UNKNOWN,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(tc.dialect+" bind type", func(t *testing.T) {
+			actual := bindType(tc.dialect)
+			assert.Equal(t, tc.expected, actual, "TEST[%d], Failed.\n%s", i, tc.dialect+" bind type")
+		})
+	}
+}

--- a/pkg/gofr/datasource/sql/sql_mock.go
+++ b/pkg/gofr/datasource/sql/sql_mock.go
@@ -11,6 +11,10 @@ import (
 )
 
 func NewSQLMocks(t *testing.T) (*DB, sqlmock.Sqlmock, *MockMetrics) {
+	return NewSQLMocksWithConfig(t, nil)
+}
+
+func NewSQLMocksWithConfig(t *testing.T, config *DBConfig) (*DB, sqlmock.Sqlmock, *MockMetrics) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
@@ -22,7 +26,7 @@ func NewSQLMocks(t *testing.T) (*DB, sqlmock.Sqlmock, *MockMetrics) {
 	return &DB{
 		DB:      db,
 		logger:  testutil.NewMockLogger(testutil.DEBUGLOG),
-		config:  nil,
+		config:  config,
 		metrics: mockMetrics,
 	}, mock, mockMetrics
 }

--- a/pkg/gofr/datasource/sql/sql_test.go
+++ b/pkg/gofr/datasource/sql/sql_test.go
@@ -156,6 +156,15 @@ func Test_NewSQLMock(t *testing.T) {
 	assert.NotNil(t, mockMetric)
 }
 
+func Test_NewSQLMockWithConfig(t *testing.T) {
+	dbConfig := DBConfig{Dialect: "dialect", HostName: "hostname", User: "user", Password: "password", Port: "port", Database: "database"}
+	db, mock, mockMetric := NewSQLMocksWithConfig(t, &dbConfig)
+	assert.NotNil(t, db)
+	assert.Equal(t, db.config, &dbConfig)
+	assert.NotNil(t, mock)
+	assert.NotNil(t, mockMetric)
+}
+
 func Test_SQLRetryConnectionInfoLog(t *testing.T) {
 	logs := testutil.StdoutOutputForFunc(func() {
 		ctrl := gomock.NewController(t)

--- a/pkg/gofr/datasource/sql/sql_test.go
+++ b/pkg/gofr/datasource/sql/sql_test.go
@@ -159,6 +159,7 @@ func Test_NewSQLMock(t *testing.T) {
 func Test_NewSQLMockWithConfig(t *testing.T) {
 	dbConfig := DBConfig{Dialect: "dialect", HostName: "hostname", User: "user", Password: "password", Port: "port", Database: "database"}
 	db, mock, mockMetric := NewSQLMocksWithConfig(t, &dbConfig)
+
 	assert.NotNil(t, db)
 	assert.Equal(t, db.config, &dbConfig)
 	assert.NotNil(t, mock)


### PR DESCRIPTION
## PostgreSQL support in AddRESTHandlers


**Description:**

-   Fixed [issue #535](https://github.com/gofr-dev/gofr/issues/535).
-   Introduced new exported method `sql.Rebind`, used to replace **bindvars** according to dialect provided.

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.