### PR TITLE
allow adding custom middleware

### DIFF
--- a/docs/advanced-guide/middlewares/page.md
+++ b/docs/advanced-guide/middlewares/page.md
@@ -1,0 +1,49 @@
+# Middleware in GoFr
+
+Middleware allows you to intercept and manipulate HTTP requests and responses flowing through your application's 
+router. Middlewares can perform tasks such as authentication, authorization, caching and more, before 
+or after the request reaches your application's handler.
+
+## Adding Custom Middleware in GoFr
+
+By adding custom middleware to your GoFr application, user can easily extend its functionality and implement 
+cross-cutting concerns in a modular and reusable way.
+User can use the `UseMiddleware` method on your GoFr application instance to register your custom middleware.
+
+### Example:
+
+```go
+import (
+    "net/http"
+
+    "gofr.dev/pkg/gofr"
+)
+
+// Define your custom middleware function
+func customMiddleware() gofr.Middleware {
+    return func(inner http.Handler) http.Handler {
+        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            // Your custom logic here
+            // For example, logging, authentication, etc.
+            
+            // Call the next handler in the chain
+            inner.ServeHTTP(w, r)
+        })
+    }
+}
+
+func main() {
+    // Create a new instance of your GoFr application
+    app := gofr.New()
+
+    // Add your custom middleware to the application
+    app.UseMiddleware(customMiddleware())
+
+    // Define your application routes and handlers
+    // ...
+
+    // Run your GoFr application
+    app.Run()
+}
+```
+

--- a/docs/advanced-guide/middlewares/page.md
+++ b/docs/advanced-guide/middlewares/page.md
@@ -1,7 +1,7 @@
 # Middleware in GoFr
 
 Middleware allows you to intercept and manipulate HTTP requests and responses flowing through your application's 
-router. Middlewares can perform tasks such as authentication, authorization, caching and more, before 
+router. Middlewares can perform tasks such as authentication, authorization, caching etc. before 
 or after the request reaches your application's handler.
 
 ## Adding Custom Middleware in GoFr

--- a/docs/navigation.js
+++ b/docs/navigation.js
@@ -17,6 +17,7 @@ export const navigation = [
             { title: 'Remote Log Level Change', href: '/docs/advanced-guide/remote-log-level-change' },
             { title: 'Publishing Custom Metrics', href: '/docs/advanced-guide/publishing-custom-metrics' },
             { title: 'Custom Spans in Tracing', href: '/docs/advanced-guide/custom-spans-in-tracing' },
+            {title: 'Adding Custom Middleware',href: '/docs/advanced-guide/middlewares'},
             { title: 'HTTP Communication', href: '/docs/advanced-guide/http-communication' },
             { title: 'HTTP Authentication', href: '/docs/advanced-guide/http-authentication' },
             { title: 'Circuit Breaker Support', href: '/docs/advanced-guide/circuit-breaker' },

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -23,6 +23,7 @@ import (
 	"gofr.dev/pkg/gofr/config"
 	"gofr.dev/pkg/gofr/container"
 	"gofr.dev/pkg/gofr/datasource"
+	gofrHTTP "gofr.dev/pkg/gofr/http"
 	"gofr.dev/pkg/gofr/http/middleware"
 	"gofr.dev/pkg/gofr/logging"
 	"gofr.dev/pkg/gofr/metrics"
@@ -365,6 +366,11 @@ func (a *App) AddRESTHandlers(object interface{}) error {
 	a.registerCRUDHandlers(e, object)
 
 	return nil
+}
+
+// UseMiddleware is a setter method for adding user defined custom middleware to GoFr's router.
+func (a *App) UseMiddleware(middlewares ...gofrHTTP.Middleware) {
+	a.httpServer.useMiddleware(middlewares...)
 }
 
 func (a *App) UseMongo(db datasource.Mongo) {

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -3,6 +3,7 @@ package gofr
 import (
 	"context"
 	"fmt"
+	gofrHTTP "gofr.dev/pkg/gofr/http"
 	"net/http"
 	"os"
 	"strconv"
@@ -23,7 +24,6 @@ import (
 	"gofr.dev/pkg/gofr/config"
 	"gofr.dev/pkg/gofr/container"
 	"gofr.dev/pkg/gofr/datasource"
-	gofrHTTP "gofr.dev/pkg/gofr/http"
 	"gofr.dev/pkg/gofr/http/middleware"
 	"gofr.dev/pkg/gofr/logging"
 	"gofr.dev/pkg/gofr/metrics"
@@ -370,7 +370,7 @@ func (a *App) AddRESTHandlers(object interface{}) error {
 
 // UseMiddleware is a setter method for adding user defined custom middleware to GoFr's router.
 func (a *App) UseMiddleware(middlewares ...gofrHTTP.Middleware) {
-	a.httpServer.useMiddleware(middlewares...)
+	a.httpServer.router.UseMiddleware(middlewares...)
 }
 
 func (a *App) UseMongo(db datasource.Mongo) {

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -3,7 +3,6 @@ package gofr
 import (
 	"context"
 	"fmt"
-	gofrHTTP "gofr.dev/pkg/gofr/http"
 	"net/http"
 	"os"
 	"strconv"
@@ -24,6 +23,7 @@ import (
 	"gofr.dev/pkg/gofr/config"
 	"gofr.dev/pkg/gofr/container"
 	"gofr.dev/pkg/gofr/datasource"
+	gofrHTTP "gofr.dev/pkg/gofr/http"
 	"gofr.dev/pkg/gofr/http/middleware"
 	"gofr.dev/pkg/gofr/logging"
 	"gofr.dev/pkg/gofr/metrics"

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -376,7 +376,16 @@ func Test_UseMiddleware(t *testing.T) {
 		})
 	}
 
-	app := New()
+	c := container.NewContainer(config.NewMockConfig(nil))
+
+	app := &App{
+		httpServer: &httpServer{
+			router: gofrHTTP.NewRouter(c),
+			port:   8001,
+		},
+		container: c,
+	}
+
 	app.UseMiddleware(testMiddleware)
 
 	app.GET("/test", func(c *Context) (interface{}, error) {
@@ -391,7 +400,7 @@ func Test_UseMiddleware(t *testing.T) {
 	}
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"http://localhost:"+strconv.Itoa(defaultHTTPPort)+"/test", http.NoBody)
+		"http://localhost:8001"+"/test", http.NoBody)
 
 	resp, err := netClient.Do(req)
 	if err != nil {

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -367,3 +367,43 @@ func Test_initTracer_invalidConfig(t *testing.T) {
 
 	assert.Contains(t, errLogMessage, "unsupported trace exporter.")
 }
+
+func Test_UseMiddleware(t *testing.T) {
+	testMiddleware := func(inner http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Test-Middleware", "applied")
+			inner.ServeHTTP(w, r)
+		})
+	}
+
+	app := New()
+	app.UseMiddleware(testMiddleware)
+
+	app.GET("/test", func(c *Context) (interface{}, error) {
+		return "success", nil
+	})
+
+	go app.Run()
+	time.Sleep(1 * time.Second)
+
+	var netClient = &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"http://localhost:"+strconv.Itoa(defaultHTTPPort)+"/test", http.NoBody)
+
+	resp, err := netClient.Do(req)
+	if err != nil {
+		t.Errorf("error while making http request in Test_UseMiddleware. err : %v", err)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "Test_UseMiddleware Failed! Expected Status 200 Got : %v", resp.StatusCode)
+
+	// checking if the testMiddleware has added the required header in the response properly.
+	testHeaderValue := resp.Header.Get("X-Test-Middleware")
+	assert.Equal(t, "applied", testHeaderValue, "Test_UseMiddleware Failed! header value mismatch.")
+}

--- a/pkg/gofr/httpServer.go
+++ b/pkg/gofr/httpServer.go
@@ -34,8 +34,3 @@ func (s *httpServer) Run(c *container.Container) {
 
 	c.Error(srv.ListenAndServe())
 }
-
-// useMiddleware redirects the middleware registration to the router.
-func (s *httpServer) useMiddleware(mws ...gofrHTTP.Middleware) {
-	s.router.UseMiddleware(mws...)
-}

--- a/pkg/gofr/httpServer.go
+++ b/pkg/gofr/httpServer.go
@@ -34,3 +34,8 @@ func (s *httpServer) Run(c *container.Container) {
 
 	c.Error(srv.ListenAndServe())
 }
+
+// useMiddleware redirects the middleware registration to the router.
+func (s *httpServer) useMiddleware(mws ...gofrHTTP.Middleware) {
+	s.router.UseMiddleware(mws...)
+}


### PR DESCRIPTION
## Pull Request Template


**Description:**

- Added a exported method `app.UseMiddleware()` that allows user to add their custom middleware.
- Closes issue #493 

### Example Usage:
```go
package main

import (
	"fmt"
	"net/http"

        "gofr.dev/pkg/gofr"
	"gofr.dev/pkg/gofr/logging"
)

func main() {
	// Create a new application
	a := gofr.New()
	
	a.UseMiddleware(customMiddleware(a.Logger()))

	a.GET("/hello", HelloHandler)
	
	a.Run()
}

func HelloHandler(c *gofr.Context) (interface{}, error) {
	name := c.Param("name")
	if name == "" {
		c.Log("Name came empty")
		name = "World"
	}

	return fmt.Sprintf("Hello %s!", name), nil
}

func customMiddleware(logger logging.Logger) func(inner http.Handler) http.Handler {
	return func(inner http.Handler) http.Handler {
		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			logger.Infof("hi! from custom middleware")

			inner.ServeHTTP(w, r)
		})
	}
}
```

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

