### PR TITLE
[EN]: Update golangci-lint to Version v1.57.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -230,7 +230,7 @@ jobs:
   code_quality:
     name: Code Quality🎖️
     runs-on: ubuntu-latest
-    container: "golangci/golangci-lint:v1.55.2"
+    container: "golangci/golangci-lint:v1.57.2"
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,7 +101,6 @@ linters:
     - unused
     - whitespace
     - wsl
-#    - shadow
 
   # don't enable:
   # - godox  # Disabling because we need TODO lines at this stage of project.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,8 @@ linters-settings:
     lines: 100
     statements: 50
   gci:
-    local-prefixes: gofr.dev
+    sections:
+      - prefix(gofr.dev)
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -31,12 +32,14 @@ linters-settings:
   golint:
     min-confidence: 0
   gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
+    checks:
+      - argument
+      - case
+      - condition
+      - return
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
     settings:
       printf:
         funcs:
@@ -98,6 +101,7 @@ linters:
     - unused
     - whitespace
     - wsl
+#    - shadow
 
   # don't enable:
   # - godox  # Disabling because we need TODO lines at this stage of project.
@@ -105,7 +109,7 @@ linters:
 
 
 service:
-  golangci-lint-version: 1.55.x
+  golangci-lint-version: 1.57.x
 
 issues:
   # exclude-use-default: false

--- a/pkg/gofr/container/health_test.go
+++ b/pkg/gofr/container/health_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestContainer_Health(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/pkg/gofr/datasource/pubsub/google/google.go
+++ b/pkg/gofr/datasource/pubsub/google/google.go
@@ -135,6 +135,7 @@ func (g *googleClient) Subscribe(ctx context.Context, topic string) (*pubsub.Mes
 	start := time.Now()
 	err = subscription.Receive(ctx, func(_ context.Context, msg *gcPubSub.Message) {
 		end := time.Since(start)
+
 		defer cancel()
 
 		m.Topic = topic

--- a/pkg/gofr/datasource/pubsub/mqtt/mqtt_test.go
+++ b/pkg/gofr/datasource/pubsub/mqtt/mqtt_test.go
@@ -233,7 +233,7 @@ func TestMQTT_SubscribeWithFunc(t *testing.T) {
 		return nil
 	}
 
-	subcriptionFuncErr := func(_ *pubsub.Message) error {
+	subcriptionFuncErr := func(*pubsub.Message) error {
 		return errTest
 	}
 

--- a/pkg/gofr/datasource/pubsub/mqtt/mqtt_test.go
+++ b/pkg/gofr/datasource/pubsub/mqtt/mqtt_test.go
@@ -147,10 +147,12 @@ func TestMQTT_PublishFailure(t *testing.T) {
 		// case where the client has been disconnected, resulting in a Publishing failure
 		mockMetrics.EXPECT().
 			IncrementCounter(ctx, "app_pubsub_publish_total_count", "topic", "test/topic")
+
 		m := New(&Config{}, mockLogger, mockMetrics)
 
 		// Disconnect the client
 		m.Client.Disconnect(1)
+
 		err := m.Publish(ctx, "test/topic", []byte(`hello world`))
 
 		assert.NotNil(t, err)
@@ -231,7 +233,7 @@ func TestMQTT_SubscribeWithFunc(t *testing.T) {
 		return nil
 	}
 
-	subcriptionFuncErr := func(msg *pubsub.Message) error {
+	subcriptionFuncErr := func(_ *pubsub.Message) error {
 		return errTest
 	}
 

--- a/pkg/gofr/datasource/redis/redis_test.go
+++ b/pkg/gofr/datasource/redis/redis_test.go
@@ -61,9 +61,11 @@ func TestRedis_QueryLogging(t *testing.T) {
 			"REDIS_HOST": s.Host(),
 			"REDIS_PORT": s.Port(),
 		}), mockLogger, mockMetric)
+
 		assert.Nil(t, err)
 
 		result, err := client.Set(context.TODO(), "key", "value", 1*time.Minute).Result()
+
 		assert.Nil(t, err)
 		assert.Equal(t, "OK", result)
 	})
@@ -94,6 +96,7 @@ func TestRedis_PipelineQueryLogging(t *testing.T) {
 			"REDIS_HOST": s.Host(),
 			"REDIS_PORT": s.Port(),
 		}), mockLogger, mockMetric)
+
 		assert.Nil(t, err)
 
 		// Pipeline execution

--- a/pkg/gofr/datasource/sql/db_test.go
+++ b/pkg/gofr/datasource/sql/db_test.go
@@ -327,6 +327,7 @@ func TestDB_QueryError(t *testing.T) {
 		if !assert.Nil(t, rows) {
 			assert.Nil(t, rows.Err())
 		}
+
 		assert.NotNil(t, err)
 		assert.Equal(t, errSyntax, err)
 	})

--- a/pkg/gofr/exporter_test.go
+++ b/pkg/gofr/exporter_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Test_ExportSpans(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	}))
 	defer server.Close()
@@ -39,8 +39,8 @@ func Test_ExportSpans(t *testing.T) {
 }
 
 func Test_ExportSpansError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	}))
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+
 	server.Close()
 
 	exporter := NewExporter(server.URL, logging.NewLogger(logging.INFO))

--- a/pkg/gofr/exporter_test.go
+++ b/pkg/gofr/exporter_test.go
@@ -39,7 +39,7 @@ func Test_ExportSpans(t *testing.T) {
 }
 
 func Test_ExportSpansError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 
 	server.Close()
 

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -388,7 +388,7 @@ func Test_UseMiddleware(t *testing.T) {
 
 	app.UseMiddleware(testMiddleware)
 
-	app.GET("/test", func(c *Context) (interface{}, error) {
+	app.GET("/test", func(_ *Context) (interface{}, error) {
 		return "success", nil
 	})
 

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -66,20 +66,20 @@ func TestGofr_ServerRoutes(t *testing.T) {
 
 	g := New()
 
-	g.GET("/hello", func(_ *Context) (interface{}, error) {
+	g.GET("/hello", func(*Context) (interface{}, error) {
 		return helloWorld, nil
 	})
 
 	// using add() func
-	g.add(http.MethodGet, "/hello2", func(_ *Context) (interface{}, error) {
+	g.add(http.MethodGet, "/hello2", func(*Context) (interface{}, error) {
 		return helloWorld, nil
 	})
 
-	g.PUT("/hello", func(_ *Context) (interface{}, error) {
+	g.PUT("/hello", func(*Context) (interface{}, error) {
 		return helloWorld, nil
 	})
 
-	g.POST("/hello", func(_ *Context) (interface{}, error) {
+	g.POST("/hello", func(*Context) (interface{}, error) {
 		return helloWorld, nil
 	})
 
@@ -87,7 +87,7 @@ func TestGofr_ServerRoutes(t *testing.T) {
 		return fmt.Sprintf("Hello %s!", c.Param("name")), nil
 	})
 
-	g.DELETE("/delete", func(_ *Context) (interface{}, error) {
+	g.DELETE("/delete", func(*Context) (interface{}, error) {
 		return "Success", nil
 	})
 
@@ -114,7 +114,7 @@ func TestGofr_ServerRoutes(t *testing.T) {
 func TestGofr_ServerRun(t *testing.T) {
 	g := New()
 
-	g.GET("/hello", func(_ *Context) (interface{}, error) {
+	g.GET("/hello", func(*Context) (interface{}, error) {
 		return helloWorld, nil
 	})
 
@@ -388,7 +388,7 @@ func Test_UseMiddleware(t *testing.T) {
 
 	app.UseMiddleware(testMiddleware)
 
-	app.GET("/test", func(_ *Context) (interface{}, error) {
+	app.GET("/test", func(*Context) (interface{}, error) {
 		return "success", nil
 	})
 

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -66,20 +66,20 @@ func TestGofr_ServerRoutes(t *testing.T) {
 
 	g := New()
 
-	g.GET("/hello", func(c *Context) (interface{}, error) {
+	g.GET("/hello", func(_ *Context) (interface{}, error) {
 		return helloWorld, nil
 	})
 
 	// using add() func
-	g.add(http.MethodGet, "/hello2", func(c *Context) (interface{}, error) {
+	g.add(http.MethodGet, "/hello2", func(_ *Context) (interface{}, error) {
 		return helloWorld, nil
 	})
 
-	g.PUT("/hello", func(c *Context) (interface{}, error) {
+	g.PUT("/hello", func(_ *Context) (interface{}, error) {
 		return helloWorld, nil
 	})
 
-	g.POST("/hello", func(c *Context) (interface{}, error) {
+	g.POST("/hello", func(_ *Context) (interface{}, error) {
 		return helloWorld, nil
 	})
 
@@ -87,7 +87,7 @@ func TestGofr_ServerRoutes(t *testing.T) {
 		return fmt.Sprintf("Hello %s!", c.Param("name")), nil
 	})
 
-	g.DELETE("/delete", func(c *Context) (interface{}, error) {
+	g.DELETE("/delete", func(_ *Context) (interface{}, error) {
 		return "Success", nil
 	})
 
@@ -114,7 +114,7 @@ func TestGofr_ServerRoutes(t *testing.T) {
 func TestGofr_ServerRun(t *testing.T) {
 	g := New()
 
-	g.GET("/hello", func(c *Context) (interface{}, error) {
+	g.GET("/hello", func(_ *Context) (interface{}, error) {
 		return helloWorld, nil
 	})
 
@@ -199,7 +199,7 @@ func TestApp_MigratePanicRecovery(t *testing.T) {
 
 		app.container.PubSub = &container.MockPubSub{}
 
-		app.Migrate(map[int64]migration.Migrate{1: {UP: func(d migration.Datasource) error {
+		app.Migrate(map[int64]migration.Migrate{1: {UP: func(_ migration.Datasource) error {
 			panic("test panic")
 		}}})
 	})
@@ -234,7 +234,7 @@ func Test_addRoute(t *testing.T) {
 }
 
 func TestEnableBasicAuthWithFunc(t *testing.T) {
-	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -248,7 +248,7 @@ func TestEnableBasicAuthWithFunc(t *testing.T) {
 		container: c,
 	}
 
-	a.httpServer.router.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	a.httpServer.router.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Println(w, "Hello, world!")
 	}))
 

--- a/pkg/gofr/grpc/log_test.go
+++ b/pkg/gofr/grpc/log_test.go
@@ -38,10 +38,11 @@ func TestLoggingInterceptor(t *testing.T) {
 		err            = errors.New("DB error") //nolint:goerr113 // We are testing if a dynamic error would work
 		key contextKey = "id"
 
-		successHandler = func(ctx context.Context, req interface{}) (interface{}, error) {
+		successHandler = func(_ context.Context, _ interface{}) (interface{}, error) {
 			return "success", nil
 		}
-		errorHandler = func(ctx context.Context, req interface{}) (interface{}, error) {
+
+		errorHandler = func(_ context.Context, _ interface{}) (interface{}, error) {
 			return nil, err
 		}
 	)

--- a/pkg/gofr/grpc/log_test.go
+++ b/pkg/gofr/grpc/log_test.go
@@ -38,11 +38,11 @@ func TestLoggingInterceptor(t *testing.T) {
 		err            = errors.New("DB error") //nolint:goerr113 // We are testing if a dynamic error would work
 		key contextKey = "id"
 
-		successHandler = func(_ context.Context, _ interface{}) (interface{}, error) {
+		successHandler = func(context.Context, interface{}) (interface{}, error) {
 			return "success", nil
 		}
 
-		errorHandler = func(_ context.Context, _ interface{}) (interface{}, error) {
+		errorHandler = func(context.Context, interface{}) (interface{}, error) {
 			return nil, err
 		}
 	)

--- a/pkg/gofr/handler_test.go
+++ b/pkg/gofr/handler_test.go
@@ -48,7 +48,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		}
 
 		handler{
-			function: func(c *Context) (interface{}, error) {
+			function: func(_ *Context) (interface{}, error) {
 				return tc.data, tc.err
 			},
 			container: c,

--- a/pkg/gofr/handler_test.go
+++ b/pkg/gofr/handler_test.go
@@ -48,7 +48,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		}
 
 		handler{
-			function: func(_ *Context) (interface{}, error) {
+			function: func(*Context) (interface{}, error) {
 				return tc.data, tc.err
 			},
 			container: c,

--- a/pkg/gofr/http/middleware/apikey_auth_test.go
+++ b/pkg/gofr/http/middleware/apikey_auth_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_ApiKeyAuthMiddleware(t *testing.T) {
-	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("Success"))
 	})
 
@@ -53,7 +53,7 @@ func Test_ApiKeyAuthMiddleware(t *testing.T) {
 }
 
 func Test_ApiKeyAuthMiddleware_well_known(t *testing.T) {
-	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("Success"))
 	})
 

--- a/pkg/gofr/http/middleware/basic_auth_test.go
+++ b/pkg/gofr/http/middleware/basic_auth_test.go
@@ -75,15 +75,16 @@ func TestBasicAuthMiddleware(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})
 
 			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 			req.Header.Set("Authorization", tc.authHeader)
-			rr := httptest.NewRecorder()
 
+			rr := httptest.NewRecorder()
 			authMiddleware := BasicAuthMiddleware(tc.authProvider)
+
 			authMiddleware(handler).ServeHTTP(rr, req)
 
 			assert.Equal(t, tc.expectedStatusCode, rr.Code)
@@ -92,7 +93,7 @@ func TestBasicAuthMiddleware(t *testing.T) {
 }
 
 func Test_BasicAuthMiddleware_well_known(t *testing.T) {
-	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("Success"))
 	})
 

--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -73,6 +73,7 @@ func Logging(logger logger) func(inner http.Handler) http.Handler {
 			srw := &StatusResponseWriter{ResponseWriter: w}
 			traceID := trace.SpanFromContext(r.Context()).SpanContext().TraceID().String()
 			spanID := trace.SpanFromContext(r.Context()).SpanContext().SpanID().String()
+
 			srw.Header().Set("X-Correlation-ID", traceID)
 
 			defer func(res *StatusResponseWriter, req *http.Request) {

--- a/pkg/gofr/http/middleware/metrics_test.go
+++ b/pkg/gofr/http/middleware/metrics_test.go
@@ -38,7 +38,7 @@ func TestMetrics(t *testing.T) {
 		Return(nil)
 
 	router := mux.NewRouter()
-	router.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodGet).Name("/test")
 

--- a/pkg/gofr/http/middleware/oauth_test.go
+++ b/pkg/gofr/http/middleware/oauth_test.go
@@ -53,7 +53,7 @@ func (m *MockProvider) GetWithHeaders(context.Context, string, map[string]interf
 
 func TestOAuthSuccess(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodGet).Name("/test")
 	router.Use(OAuth(NewOAuth(OauthConfigs{Provider: &MockProvider{}, RefreshInterval: 10})))
@@ -83,7 +83,7 @@ func TestOAuthSuccess(t *testing.T) {
 
 func TestOAuthInvalidTokenFormat(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodGet).Name("/test")
 	router.Use(OAuth(NewOAuth(OauthConfigs{Provider: &MockProvider{}, RefreshInterval: 10})))
@@ -108,7 +108,7 @@ func TestOAuthInvalidTokenFormat(t *testing.T) {
 
 func TestOAuthEmptyAuthHeader(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodGet).Name("/test")
 	router.Use(OAuth(NewOAuth(OauthConfigs{Provider: &MockProvider{}, RefreshInterval: 10})))
@@ -132,7 +132,7 @@ func TestOAuthEmptyAuthHeader(t *testing.T) {
 
 func TestOAuthMalformedToken(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodGet).Name("/test")
 	router.Use(OAuth(NewOAuth(OauthConfigs{Provider: &MockProvider{}, RefreshInterval: 10})))
@@ -157,7 +157,7 @@ func TestOAuthMalformedToken(t *testing.T) {
 
 func TestOAuthJWKSKeyNotFound(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodGet).Name("/test")
 	router.Use(OAuth(NewOAuth(OauthConfigs{Provider: &MockProvider{}, RefreshInterval: 10})))
@@ -197,7 +197,7 @@ func TestPublicKeyFromJWKS_EmptyJWKS_ReturnsNil(t *testing.T) {
 }
 
 func Test_OAuth_well_known(t *testing.T) {
-	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("Success"))
 	})
 

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -24,6 +24,7 @@ func Tracer(inner http.Handler) http.Handler {
 
 		tr := otel.GetTracerProvider().Tracer("gofr-" + version.Framework)
 		ctx, span := tr.Start(ctx, fmt.Sprintf("%s %s", strings.ToUpper(r.Method), r.URL.Path))
+
 		defer span.End()
 
 		inner.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/gofr/http/router_test.go
+++ b/pkg/gofr/http/router_test.go
@@ -24,7 +24,7 @@ func TestRouter(t *testing.T) {
 		router := NewRouter(c)
 
 		// Add a test handler to the router
-		router.Add("GET", "/test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		router.Add("GET", "/test", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 

--- a/pkg/gofr/http/router_test.go
+++ b/pkg/gofr/http/router_test.go
@@ -61,7 +61,7 @@ func TestRouterWithMiddleware(t *testing.T) {
 		})
 
 		// Add a test handler to the router
-		router.Add("GET", "/test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		router.Add("GET", "/test", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 

--- a/pkg/gofr/httpServer_test.go
+++ b/pkg/gofr/httpServer_test.go
@@ -16,7 +16,7 @@ import (
 func TestRun_ServerStartsListening(t *testing.T) {
 	// Create a mock router and add a new route
 	router := &gofrHTTP.Router{}
-	router.Add(http.MethodGet, "/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	router.Add(http.MethodGet, "/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/pkg/gofr/logging/dynamicLevelLogger_test.go
+++ b/pkg/gofr/logging/dynamicLevelLogger_test.go
@@ -15,20 +15,14 @@ import (
 
 func TestDynamicLoggerSuccess(t *testing.T) {
 	// Create a mock server that returns a predefined log level
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		body := `{
-			"data": [
-				{
-					"serviceName": "test-service",
-					"logLevel": {
-						"LOG_LEVEL": "DEBUG"
-					}
-				}
-			]
-		}`
+
+		body := `{"data":[{"serviceName":"test-service","logLevel":{"LOG_LEVEL":"DEBUG"}}]}`
+
 		_, _ = w.Write([]byte(body))
 	}))
+
 	defer mockServer.Close()
 
 	log := testutil.StdoutOutputForFunc(func() {
@@ -56,8 +50,9 @@ func Test_fetchAndUpdateLogLevel_ErrorCases(t *testing.T) {
 
 	remoteService := service.NewHTTPService("http://", logger, nil)
 
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+
 		body := `{
 			"data": [
 				{

--- a/pkg/gofr/service/apikey_auth_test.go
+++ b/pkg/gofr/service/apikey_auth_test.go
@@ -25,6 +25,7 @@ func Test_APIKeyAuthProvider_Get(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 
 		w.WriteHeader(http.StatusOK)
+
 		_, err := w.Write(body)
 		if err != nil {
 			return

--- a/pkg/gofr/service/basic_auth_test.go
+++ b/pkg/gofr/service/basic_auth_test.go
@@ -29,6 +29,7 @@ func TestBasicAuthProvider_Get(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 
 		w.WriteHeader(http.StatusOK)
+
 		_, err := w.Write(body)
 		if err != nil {
 			return

--- a/pkg/gofr/service/circuit_breaker_test.go
+++ b/pkg/gofr/service/circuit_breaker_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func testServer() *httptest.Server {
-	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 

--- a/pkg/gofr/service/oauth_test.go
+++ b/pkg/gofr/service/oauth_test.go
@@ -20,7 +20,7 @@ func oAuthHTTPServer(t *testing.T) *httptest.Server {
 		header := r.Header.Get("Authorization")
 		token := strings.Split(header, " ")
 
-		parsedToken, _ := jwt.Parse(token[1], func(_ *jwt.Token) (interface{}, error) {
+		parsedToken, _ := jwt.Parse(token[1], func(*jwt.Token) (interface{}, error) {
 			return []byte("my-secret-key"), nil
 		})
 

--- a/pkg/gofr/service/oauth_test.go
+++ b/pkg/gofr/service/oauth_test.go
@@ -20,7 +20,7 @@ func oAuthHTTPServer(t *testing.T) *httptest.Server {
 		header := r.Header.Get("Authorization")
 		token := strings.Split(header, " ")
 
-		parsedToken, _ := jwt.Parse(token[1], func(token *jwt.Token) (interface{}, error) {
+		parsedToken, _ := jwt.Parse(token[1], func(_ *jwt.Token) (interface{}, error) {
 			return []byte("my-secret-key"), nil
 		})
 

--- a/pkg/gofr/subscriber_test.go
+++ b/pkg/gofr/subscriber_test.go
@@ -73,7 +73,7 @@ func TestSubscriptionManager_HandlerError(t *testing.T) {
 		// Run the subscriber in a goroutine
 		go func() {
 			subscriptionManager.startSubscriber("test-topic",
-				func(c *Context) error {
+				func(_ *Context) error {
 					return handleError("error in test-topic")
 				})
 		}()
@@ -103,7 +103,7 @@ func TestSubscriptionManager_SubscribeError(t *testing.T) {
 		// Run the subscriber in a goroutine
 		go func() {
 			subscriptionManager.startSubscriber("abc",
-				func(c *Context) error {
+				func(_ *Context) error {
 					return handleError("error in abc")
 				})
 		}()
@@ -133,7 +133,7 @@ func TestSubscriptionManager_PanicRecovery(t *testing.T) {
 		// Run the subscriber in a goroutine
 		go func() {
 			subscriptionManager.startSubscriber("abc",
-				func(c *Context) error {
+				func(_ *Context) error {
 					panic("test panic")
 				})
 		}()

--- a/pkg/gofr/subscriber_test.go
+++ b/pkg/gofr/subscriber_test.go
@@ -73,7 +73,7 @@ func TestSubscriptionManager_HandlerError(t *testing.T) {
 		// Run the subscriber in a goroutine
 		go func() {
 			subscriptionManager.startSubscriber("test-topic",
-				func(_ *Context) error {
+				func(*Context) error {
 					return handleError("error in test-topic")
 				})
 		}()
@@ -103,7 +103,7 @@ func TestSubscriptionManager_SubscribeError(t *testing.T) {
 		// Run the subscriber in a goroutine
 		go func() {
 			subscriptionManager.startSubscriber("abc",
-				func(_ *Context) error {
+				func(*Context) error {
 					return handleError("error in abc")
 				})
 		}()
@@ -133,7 +133,7 @@ func TestSubscriptionManager_PanicRecovery(t *testing.T) {
 		// Run the subscriber in a goroutine
 		go func() {
 			subscriptionManager.startSubscriber("abc",
-				func(_ *Context) error {
+				func(*Context) error {
 					panic("test panic")
 				})
 		}()


### PR DESCRIPTION
## Description:
- Update **golangci-lint** version from **v1.55.2** to **v1.57.2**

## Additional Information:
- Remove all deprecated linter flags 
  - WARN [config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. enable `shadow` instead.
  - WARN [config_reader] The configuration option `linters.gci.local-prefixes` is deprecated, using `prefix()` inside `linters.gci.sections`. 
  - WARN [config_reader] The configuration option `linters.gomnd.settings` is deprecated. using the options `linters.gomnd.checks`,`linters.gomnd.ignored-numbers`,`linters.gomnd.ignored-files`,`linters.gomnd.ignored-functions`. 

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

