### PR TITLE
Fix formatting for service call logs

### DIFF
--- a/pkg/gofr/service/logger.go
+++ b/pkg/gofr/service/logger.go
@@ -20,7 +20,7 @@ type Log struct {
 }
 
 func (l *Log) PrettyPrint(writer io.Writer) {
-	fmt.Fprintf(writer, "\u001B[38;5;8m%s \u001B[38;5;%dm%d\u001B[0m %8d\u001B[38;5;8mµs\u001B[0m %s %s \n",
+	fmt.Fprintf(writer, "\u001B[38;5;8m%s \u001B[38;5;%dm%-6d\u001B[0m %8d\u001B[38;5;8mµs\u001B[0m %s %s \n",
 		l.CorrelationID, colorForStatusCode(l.ResponseCode),
 		l.ResponseCode, l.ResponseTime, l.HTTPMethod, l.URI)
 }

--- a/pkg/gofr/service/logger_test.go
+++ b/pkg/gofr/service/logger_test.go
@@ -20,7 +20,7 @@ func TestLog_PrettyPrint(t *testing.T) {
 
 	l.PrettyPrint(w)
 
-	assert.Equal(t, "\u001B[38;5;8mabc-test-correlation-id \u001B[38;5;34m200\u001B[0m      100\u001B[38;5;8mµs\u001B[0m GET /api/test \n",
+	assert.Equal(t, "\u001B[38;5;8mabc-test-correlation-id \u001B[38;5;34m200   \u001B[0m      100\u001B[38;5;8mµs\u001B[0m GET /api/test \n",
 		w.String())
 }
 


### PR DESCRIPTION
- Fixed logs format for http service calls

**Before:**
<img width="932" alt="Screenshot 2024-05-14 at 3 43 56 PM" src="https://github.com/gofr-dev/gofr/assets/44723623/71a3260a-0fff-4afd-9302-7f6343dd1960">

**After:**
<img width="930" alt="Screenshot 2024-05-14 at 3 44 29 PM" src="https://github.com/gofr-dev/gofr/assets/44723623/28a9eadd-7dfe-484d-af26-e7245b7a219d">

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

