### PR TITLE
[FIX] Unexport service package structs

### DIFF
--- a/pkg/gofr/service/apikey_auth.go
+++ b/pkg/gofr/service/apikey_auth.go
@@ -12,70 +12,70 @@ type APIKeyConfig struct {
 }
 
 func (a *APIKeyConfig) AddOption(h HTTP) HTTP {
-	return &APIKeyAuthProvider{
+	return &apiKeyAuthProvider{
 		apiKey: a.APIKey,
 		HTTP:   h,
 	}
 }
 
-type APIKeyAuthProvider struct {
+type apiKeyAuthProvider struct {
 	apiKey string
 
 	HTTP
 }
 
-func (a *APIKeyAuthProvider) Get(ctx context.Context, path string, queryParams map[string]interface{}) (*http.Response, error) {
+func (a *apiKeyAuthProvider) Get(ctx context.Context, path string, queryParams map[string]interface{}) (*http.Response, error) {
 	return a.GetWithHeaders(ctx, path, queryParams, nil)
 }
 
-func (a *APIKeyAuthProvider) GetWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
+func (a *apiKeyAuthProvider) GetWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
 	headers map[string]string) (*http.Response, error) {
 	headers = setXApiKey(headers, a.apiKey)
 
 	return a.HTTP.GetWithHeaders(ctx, path, queryParams, headers)
 }
 
-func (a *APIKeyAuthProvider) Post(ctx context.Context, path string, queryParams map[string]interface{},
+func (a *apiKeyAuthProvider) Post(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte) (*http.Response, error) {
 	return a.PostWithHeaders(ctx, path, queryParams, body, nil)
 }
 
-func (a *APIKeyAuthProvider) PostWithHeaders(ctx context.Context, path string, queryParams map[string]interface{}, body []byte,
+func (a *apiKeyAuthProvider) PostWithHeaders(ctx context.Context, path string, queryParams map[string]interface{}, body []byte,
 	headers map[string]string) (*http.Response, error) {
 	headers = setXApiKey(headers, a.apiKey)
 
 	return a.HTTP.PostWithHeaders(ctx, path, queryParams, body, headers)
 }
 
-func (a *APIKeyAuthProvider) Put(ctx context.Context, api string, queryParams map[string]interface{}, body []byte) (
+func (a *apiKeyAuthProvider) Put(ctx context.Context, api string, queryParams map[string]interface{}, body []byte) (
 	*http.Response, error) {
 	return a.PutWithHeaders(ctx, api, queryParams, body, nil)
 }
 
-func (a *APIKeyAuthProvider) PutWithHeaders(ctx context.Context, path string, queryParams map[string]interface{}, body []byte,
+func (a *apiKeyAuthProvider) PutWithHeaders(ctx context.Context, path string, queryParams map[string]interface{}, body []byte,
 	headers map[string]string) (*http.Response, error) {
 	headers = setXApiKey(headers, a.apiKey)
 
 	return a.HTTP.PutWithHeaders(ctx, path, queryParams, body, headers)
 }
 
-func (a *APIKeyAuthProvider) Patch(ctx context.Context, path string, queryParams map[string]interface{}, body []byte) (
+func (a *apiKeyAuthProvider) Patch(ctx context.Context, path string, queryParams map[string]interface{}, body []byte) (
 	*http.Response, error) {
 	return a.PatchWithHeaders(ctx, path, queryParams, body, nil)
 }
 
-func (a *APIKeyAuthProvider) PatchWithHeaders(ctx context.Context, path string, queryParams map[string]interface{}, body []byte,
+func (a *apiKeyAuthProvider) PatchWithHeaders(ctx context.Context, path string, queryParams map[string]interface{}, body []byte,
 	headers map[string]string) (*http.Response, error) {
 	headers = setXApiKey(headers, a.apiKey)
 
 	return a.HTTP.PatchWithHeaders(ctx, path, queryParams, body, headers)
 }
 
-func (a *APIKeyAuthProvider) Delete(ctx context.Context, path string, body []byte) (*http.Response, error) {
+func (a *apiKeyAuthProvider) Delete(ctx context.Context, path string, body []byte) (*http.Response, error) {
 	return a.DeleteWithHeaders(ctx, path, body, nil)
 }
 
-func (a *APIKeyAuthProvider) DeleteWithHeaders(ctx context.Context, path string, body []byte, headers map[string]string) (
+func (a *apiKeyAuthProvider) DeleteWithHeaders(ctx context.Context, path string, body []byte, headers map[string]string) (
 	*http.Response, error) {
 	headers = setXApiKey(headers, a.apiKey)
 

--- a/pkg/gofr/service/basic_auth.go
+++ b/pkg/gofr/service/basic_auth.go
@@ -12,21 +12,21 @@ type BasicAuthConfig struct {
 }
 
 func (a *BasicAuthConfig) AddOption(h HTTP) HTTP {
-	return &BasicAuthProvider{
+	return &basicAuthProvider{
 		userName: a.UserName,
 		password: a.Password,
 		HTTP:     h,
 	}
 }
 
-type BasicAuthProvider struct {
+type basicAuthProvider struct {
 	userName string
 	password string
 
 	HTTP
 }
 
-func (ba *BasicAuthProvider) addAuthorizationHeader(headers map[string]string) error {
+func (ba *basicAuthProvider) addAuthorizationHeader(headers map[string]string) error {
 	decodedPassword, err := b64.StdEncoding.DecodeString(ba.password)
 	if err != nil {
 		return err
@@ -39,11 +39,11 @@ func (ba *BasicAuthProvider) addAuthorizationHeader(headers map[string]string) e
 	return nil
 }
 
-func (ba *BasicAuthProvider) Get(ctx context.Context, path string, queryParams map[string]interface{}) (*http.Response, error) {
+func (ba *basicAuthProvider) Get(ctx context.Context, path string, queryParams map[string]interface{}) (*http.Response, error) {
 	return ba.GetWithHeaders(ctx, path, queryParams, nil)
 }
 
-func (ba *BasicAuthProvider) GetWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
+func (ba *basicAuthProvider) GetWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
 	headers map[string]string) (*http.Response, error) {
 	err := ba.populateHeaders(headers)
 	if err != nil {
@@ -53,12 +53,12 @@ func (ba *BasicAuthProvider) GetWithHeaders(ctx context.Context, path string, qu
 	return ba.HTTP.GetWithHeaders(ctx, path, queryParams, headers)
 }
 
-func (ba *BasicAuthProvider) Post(ctx context.Context, path string, queryParams map[string]interface{},
+func (ba *basicAuthProvider) Post(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte) (*http.Response, error) {
 	return ba.PostWithHeaders(ctx, path, queryParams, body, nil)
 }
 
-func (ba *BasicAuthProvider) PostWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
+func (ba *basicAuthProvider) PostWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte, headers map[string]string) (*http.Response, error) {
 	err := ba.populateHeaders(headers)
 	if err != nil {
@@ -68,11 +68,11 @@ func (ba *BasicAuthProvider) PostWithHeaders(ctx context.Context, path string, q
 	return ba.HTTP.PostWithHeaders(ctx, path, queryParams, body, headers)
 }
 
-func (ba *BasicAuthProvider) Put(ctx context.Context, api string, queryParams map[string]interface{}, body []byte) (*http.Response, error) {
+func (ba *basicAuthProvider) Put(ctx context.Context, api string, queryParams map[string]interface{}, body []byte) (*http.Response, error) {
 	return ba.PutWithHeaders(ctx, api, queryParams, body, nil)
 }
 
-func (ba *BasicAuthProvider) PutWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
+func (ba *basicAuthProvider) PutWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte, headers map[string]string) (*http.Response, error) {
 	err := ba.populateHeaders(headers)
 	if err != nil {
@@ -82,12 +82,12 @@ func (ba *BasicAuthProvider) PutWithHeaders(ctx context.Context, path string, qu
 	return ba.HTTP.PutWithHeaders(ctx, path, queryParams, body, headers)
 }
 
-func (ba *BasicAuthProvider) Patch(ctx context.Context, path string, queryParams map[string]interface{},
+func (ba *basicAuthProvider) Patch(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte) (*http.Response, error) {
 	return ba.PatchWithHeaders(ctx, path, queryParams, body, nil)
 }
 
-func (ba *BasicAuthProvider) PatchWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
+func (ba *basicAuthProvider) PatchWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte, headers map[string]string) (*http.Response, error) {
 	err := ba.populateHeaders(headers)
 	if err != nil {
@@ -97,11 +97,11 @@ func (ba *BasicAuthProvider) PatchWithHeaders(ctx context.Context, path string, 
 	return ba.HTTP.PatchWithHeaders(ctx, path, queryParams, body, headers)
 }
 
-func (ba *BasicAuthProvider) Delete(ctx context.Context, path string, body []byte) (*http.Response, error) {
+func (ba *basicAuthProvider) Delete(ctx context.Context, path string, body []byte) (*http.Response, error) {
 	return ba.DeleteWithHeaders(ctx, path, body, nil)
 }
 
-func (ba *BasicAuthProvider) DeleteWithHeaders(ctx context.Context, path string, body []byte,
+func (ba *basicAuthProvider) DeleteWithHeaders(ctx context.Context, path string, body []byte,
 	headers map[string]string) (*http.Response, error) {
 	err := ba.populateHeaders(headers)
 	if err != nil {
@@ -111,7 +111,7 @@ func (ba *BasicAuthProvider) DeleteWithHeaders(ctx context.Context, path string,
 	return ba.HTTP.DeleteWithHeaders(ctx, path, body, headers)
 }
 
-func (ba *BasicAuthProvider) populateHeaders(headers map[string]string) error {
+func (ba *basicAuthProvider) populateHeaders(headers map[string]string) error {
 	if headers == nil {
 		headers = make(map[string]string)
 	}

--- a/pkg/gofr/service/basic_auth_test.go
+++ b/pkg/gofr/service/basic_auth_test.go
@@ -199,7 +199,7 @@ func checkAuthHeaders(r *http.Request, t *testing.T) {
 }
 
 func Test_addAuthorizationHeader_Error(t *testing.T) {
-	ba := &BasicAuthProvider{password: "invalid_password"}
+	ba := &basicAuthProvider{password: "invalid_password"}
 
 	headers := make(map[string]string)
 	err := ba.addAuthorizationHeader(headers)

--- a/pkg/gofr/service/circuit_breaker.go
+++ b/pkg/gofr/service/circuit_breaker.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// CircuitBreaker states.
+// circuitBreaker states.
 const (
 	ClosedState = iota
 	OpenState
@@ -20,14 +20,14 @@ var (
 	ErrUnexpectedCircuitBreakerResultType = errors.New("unexpected result type from circuit breaker")
 )
 
-// CircuitBreakerConfig holds the configuration for the CircuitBreaker.
+// CircuitBreakerConfig holds the configuration for the circuitBreaker.
 type CircuitBreakerConfig struct {
 	Threshold int           // Threshold represents the max no of retry before switching the circuit breaker state.
 	Interval  time.Duration // Interval represents the time interval duration between hitting the HealthURL
 }
 
-// CircuitBreaker represents a circuit breaker implementation.
-type CircuitBreaker struct {
+// circuitBreaker represents a circuit breaker implementation.
+type circuitBreaker struct {
 	mu           sync.RWMutex
 	state        int // ClosedState or OpenState
 	failureCount int
@@ -38,9 +38,11 @@ type CircuitBreaker struct {
 	HTTP
 }
 
-// NewCircuitBreaker creates a new CircuitBreaker instance based on the provided config.
-func NewCircuitBreaker(config CircuitBreakerConfig, h HTTP) *CircuitBreaker {
-	cb := &CircuitBreaker{
+// NewCircuitBreaker creates a new circuitBreaker instance based on the provided config.
+//
+//nolint:revive // We do not want anyone using the circuit breaker without initialization steps.
+func NewCircuitBreaker(config CircuitBreakerConfig, h HTTP) *circuitBreaker {
+	cb := &circuitBreaker{
 		state:     ClosedState,
 		threshold: config.Threshold,
 		interval:  config.Interval,
@@ -54,7 +56,7 @@ func NewCircuitBreaker(config CircuitBreakerConfig, h HTTP) *CircuitBreaker {
 }
 
 // executeWithCircuitBreaker executes the given function with circuit breaker protection.
-func (cb *CircuitBreaker) executeWithCircuitBreaker(ctx context.Context, f func(ctx context.Context) (*http.Response,
+func (cb *circuitBreaker) executeWithCircuitBreaker(ctx context.Context, f func(ctx context.Context) (*http.Response,
 	error)) (*http.Response, error) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
@@ -88,7 +90,7 @@ func (cb *CircuitBreaker) executeWithCircuitBreaker(ctx context.Context, f func(
 }
 
 // isOpen returns true if the circuit breaker is in the open state.
-func (cb *CircuitBreaker) isOpen() bool {
+func (cb *circuitBreaker) isOpen() bool {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 
@@ -96,14 +98,14 @@ func (cb *CircuitBreaker) isOpen() bool {
 }
 
 // healthCheck performs the health check for the circuit breaker.
-func (cb *CircuitBreaker) healthCheck(ctx context.Context) bool {
+func (cb *circuitBreaker) healthCheck(ctx context.Context) bool {
 	resp := cb.HealthCheck(ctx)
 
 	return resp.Status == serviceUp
 }
 
 // startHealthChecks initiates periodic health checks.
-func (cb *CircuitBreaker) startHealthChecks() {
+func (cb *circuitBreaker) startHealthChecks() {
 	ticker := time.NewTicker(cb.interval)
 
 	for range ticker.C {
@@ -118,19 +120,19 @@ func (cb *CircuitBreaker) startHealthChecks() {
 }
 
 // openCircuit transitions the circuit breaker to the open state.
-func (cb *CircuitBreaker) openCircuit() {
+func (cb *circuitBreaker) openCircuit() {
 	cb.state = OpenState
 	cb.lastChecked = time.Now()
 }
 
 // resetCircuit transitions the circuit breaker to the closed state.
-func (cb *CircuitBreaker) resetCircuit() {
+func (cb *circuitBreaker) resetCircuit() {
 	cb.state = ClosedState
 	cb.failureCount = 0
 }
 
 // handleFailure increments the failure count and opens the circuit if the threshold is reached.
-func (cb *CircuitBreaker) handleFailure() {
+func (cb *circuitBreaker) handleFailure() {
 	cb.failureCount++
 	if cb.failureCount > cb.threshold {
 		cb.openCircuit()
@@ -138,7 +140,7 @@ func (cb *CircuitBreaker) handleFailure() {
 }
 
 // resetFailureCount resets the failure count to zero.
-func (cb *CircuitBreaker) resetFailureCount() {
+func (cb *circuitBreaker) resetFailureCount() {
 	cb.failureCount = 0
 }
 
@@ -146,7 +148,7 @@ func (cb *CircuitBreakerConfig) AddOption(h HTTP) HTTP {
 	return NewCircuitBreaker(*cb, h)
 }
 
-func (cb *CircuitBreaker) tryCircuitRecovery() bool {
+func (cb *circuitBreaker) tryCircuitRecovery() bool {
 	if time.Since(cb.lastChecked) > cb.interval && cb.healthCheck(context.TODO()) {
 		cb.resetCircuit()
 		return true
@@ -155,7 +157,7 @@ func (cb *CircuitBreaker) tryCircuitRecovery() bool {
 	return false
 }
 
-func (cb *CircuitBreaker) handleCircuitBreakerResult(result interface{}, err error) (*http.Response, error) {
+func (cb *circuitBreaker) handleCircuitBreakerResult(result interface{}, err error) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +170,7 @@ func (cb *CircuitBreaker) handleCircuitBreakerResult(result interface{}, err err
 	return response, nil
 }
 
-func (cb *CircuitBreaker) doRequest(ctx context.Context, method, path string, queryParams map[string]interface{},
+func (cb *circuitBreaker) doRequest(ctx context.Context, method, path string, queryParams map[string]interface{},
 	body []byte, headers map[string]string) (*http.Response, error) {
 	if cb.isOpen() {
 		if !cb.tryCircuitRecovery() {
@@ -211,59 +213,59 @@ func (cb *CircuitBreaker) doRequest(ctx context.Context, method, path string, qu
 	return resp, err
 }
 
-func (cb *CircuitBreaker) GetWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
+func (cb *circuitBreaker) GetWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
 	headers map[string]string) (*http.Response, error) {
 	return cb.doRequest(ctx, http.MethodGet, path, queryParams, nil, headers)
 }
 
 // PostWithHeaders is a wrapper for doRequest with the POST method and headers.
-func (cb *CircuitBreaker) PostWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
+func (cb *circuitBreaker) PostWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte, headers map[string]string) (*http.Response, error) {
 	return cb.doRequest(ctx, http.MethodPost, path, queryParams, body, headers)
 }
 
 // PatchWithHeaders is a wrapper for doRequest with the PATCH method and headers.
-func (cb *CircuitBreaker) PatchWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
+func (cb *circuitBreaker) PatchWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte, headers map[string]string) (*http.Response, error) {
 	return cb.doRequest(ctx, http.MethodPatch, path, queryParams, body, headers)
 }
 
 // PutWithHeaders is a wrapper for doRequest with the PUT method and headers.
-func (cb *CircuitBreaker) PutWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
+func (cb *circuitBreaker) PutWithHeaders(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte, headers map[string]string) (*http.Response, error) {
 	return cb.doRequest(ctx, http.MethodPut, path, queryParams, body, headers)
 }
 
 // DeleteWithHeaders is a wrapper for doRequest with the DELETE method and headers.
-func (cb *CircuitBreaker) DeleteWithHeaders(ctx context.Context, path string, body []byte, headers map[string]string) (
+func (cb *circuitBreaker) DeleteWithHeaders(ctx context.Context, path string, body []byte, headers map[string]string) (
 	*http.Response, error) {
 	return cb.doRequest(ctx, http.MethodDelete, path, nil, body, headers)
 }
 
-func (cb *CircuitBreaker) Get(ctx context.Context, path string, queryParams map[string]interface{}) (*http.Response, error) {
+func (cb *circuitBreaker) Get(ctx context.Context, path string, queryParams map[string]interface{}) (*http.Response, error) {
 	return cb.doRequest(ctx, http.MethodGet, path, queryParams, nil, nil)
 }
 
 // Post is a wrapper for doRequest with the POST method and headers.
-func (cb *CircuitBreaker) Post(ctx context.Context, path string, queryParams map[string]interface{},
+func (cb *circuitBreaker) Post(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte) (*http.Response, error) {
 	return cb.doRequest(ctx, http.MethodPost, path, queryParams, body, nil)
 }
 
 // Patch is a wrapper for doRequest with the PATCH method and headers.
-func (cb *CircuitBreaker) Patch(ctx context.Context, path string, queryParams map[string]interface{},
+func (cb *circuitBreaker) Patch(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte) (*http.Response, error) {
 	return cb.doRequest(ctx, http.MethodPatch, path, queryParams, body, nil)
 }
 
 // Put is a wrapper for doRequest with the PUT method and headers.
-func (cb *CircuitBreaker) Put(ctx context.Context, path string, queryParams map[string]interface{},
+func (cb *circuitBreaker) Put(ctx context.Context, path string, queryParams map[string]interface{},
 	body []byte) (*http.Response, error) {
 	return cb.doRequest(ctx, http.MethodPut, path, queryParams, body, nil)
 }
 
 // Delete is a wrapper for doRequest with the DELETE method and headers.
-func (cb *CircuitBreaker) Delete(ctx context.Context, path string, body []byte) (
+func (cb *circuitBreaker) Delete(ctx context.Context, path string, body []byte) (
 	*http.Response, error) {
 	return cb.doRequest(ctx, http.MethodDelete, path, nil, body, nil)
 }


### PR DESCRIPTION
- The structs were exported unnecessarily, and are not to be used outside the package. Hence, made them unexported.

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

