### PR TITLE
add entity already exists error

### DIFF
--- a/pkg/gofr/http/errors.go
+++ b/pkg/gofr/http/errors.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const alreadyExistsMessage = "entity already exists"
+
 // ErrorEntityNotFound represents an error for when an entity is not found in the system.
 type ErrorEntityNotFound struct {
 	Name  string
@@ -20,6 +22,19 @@ func (e ErrorEntityNotFound) Error() string {
 
 func (e ErrorEntityNotFound) StatusCode() int {
 	return http.StatusNotFound
+}
+
+// ErrorEntityAlreadyExist represents an error for when entity is already present in the storage and we are trying to make duplicate entry.
+type ErrorEntityAlreadyExist struct {
+}
+
+func (e ErrorEntityAlreadyExist) Error() string {
+	// For ex: "No entity found with id: 2"
+	return alreadyExistsMessage
+}
+
+func (e ErrorEntityAlreadyExist) StatusCode() int {
+	return http.StatusConflict
 }
 
 // ErrorInvalidParam represents an error for invalid parameter values.

--- a/pkg/gofr/http/errors.go
+++ b/pkg/gofr/http/errors.go
@@ -29,7 +29,6 @@ type ErrorEntityAlreadyExist struct {
 }
 
 func (e ErrorEntityAlreadyExist) Error() string {
-	// For ex: "No entity found with id: 2"
 	return alreadyExistsMessage
 }
 

--- a/pkg/gofr/http/errors_test.go
+++ b/pkg/gofr/http/errors_test.go
@@ -25,6 +25,19 @@ func TestErrorEntityNotFound_StatusCode(t *testing.T) {
 	assert.Equal(t, expectedCode, err.StatusCode(), "TEST Failed.\n")
 }
 
+func TestErrorEntityAlreadyExist(t *testing.T) {
+	err := ErrorEntityAlreadyExist{}
+
+	assert.Equal(t, alreadyExistsMessage, err.Error(), "TEST Failed.\n")
+}
+
+func TestErrorEntityAlreadyExist_StatusCode(t *testing.T) {
+	err := ErrorEntityAlreadyExist{}
+	expectedCode := http.StatusConflict
+
+	assert.Equal(t, expectedCode, err.StatusCode(), "TEST Failed.\n")
+}
+
 func TestErrorInvalidParam(t *testing.T) {
 	tests := []struct {
 		desc        string


### PR DESCRIPTION
## Pull Request Template


**Description:**

-   Adds a new error `ErrorEntityAlreadyExists` to http errors.

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

