### PR TITLE
use defer to close span and add TODO

### DIFF
--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -60,7 +60,7 @@ func TraceHandler(c *gofr.Context) (interface{}, error) {
 
 	span2 := c.Trace("some-sample-work")
 	<-time.After(time.Millisecond * 1) //nolint:wsl    // Waiting for 1ms to simulate workload
-	span2.End()
+	defer span2.End()
 
 	// Ping redis 5 times concurrently and wait.
 	count := 5

--- a/pkg/gofr/context.go
+++ b/pkg/gofr/context.go
@@ -45,6 +45,10 @@ Developer Note: If you chain methods in a defer statement, everything except the
 func (c *Context) Trace(name string) trace.Span {
 	tr := otel.GetTracerProvider().Tracer("gofr-context")
 	ctx, span := tr.Start(c.Context, name)
+	// TODO: If we don't close the span using `defer` and run the http-server example by hitting `/trace` endpoint, we are
+	// getting incomplete redis spans when viewing the trace using correlationID. If we remove assigning the ctx to GoFr
+	// context then spans are coming correct but then parent-child span relationship is being hindered.
+
 	c.Context = ctx
 
 	return span


### PR DESCRIPTION
## Pull Request Template


**Description:**

-   Use `defer` to close span in `http-server` example **/trace** endpoint to avoid unwanted spans behaviour.
- Add `TODO` for further work needed to permanently fix the incomplete redis spans. 


### Updated Result using defer to close spans:

<img width="1377" alt="Screenshot 2024-06-05 at 9 46 21 AM" src="https://github.com/gofr-dev/gofr/assets/55635734/1ab01e6b-6d48-4e2f-b26b-9cc3263663f8">


-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

