### PR TITLE
Revert request_timeout default value

### DIFF
--- a/docs/references/configs/page.md
+++ b/docs/references/configs/page.md
@@ -249,6 +249,5 @@ This document lists all the configuration options supported by the Gofr framewor
 
 - Name: REQUEST_TIMEOUT
 - Description: Set the request timeouts (in seconds) for HTTP server.
-- Default Value: 5
 
 {% endtable %}

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -249,7 +249,7 @@ func (a *App) add(method, pattern string, h Handler) {
 	a.httpServer.router.Add(method, pattern, handler{
 		function:       h,
 		container:      a.container,
-		requestTimeout: a.Config.GetOrDefault("REQUEST_TIMEOUT", "5"),
+		requestTimeout: a.Config.Get("REQUEST_TIMEOUT"),
 	})
 }
 

--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -38,6 +38,7 @@ type handler struct {
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := newContext(gofrHTTP.NewResponder(w, r.Method), gofrHTTP.NewRequest(r), h.container)
+
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc


### PR DESCRIPTION
Removed default value of 5 sec for REQUEST_TIMEOUT. Now, it will be configured only when user specifies this in the env configs.

Closes: #698