### PR TITLE
Create error for request timeout

### DIFF
--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -76,18 +76,17 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case <-c.Context.Done():
 		// If the context's deadline has been exceeded, return a timeout error response
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			http.Error(w, "Request timed out", http.StatusRequestTimeout)
-			return
+			err = gofrHTTP.ErrorRequestTimeout{}
 		}
 	case <-done:
 		if websocket.IsWebSocketUpgrade(r) {
 			// Do not respond with HTTP headers since this is a WebSocket request
 			return
 		}
-
-		// Handler function completed
-		c.responder.Respond(result, err)
 	}
+
+	// Handler function completed
+	c.responder.Respond(result, err)
 }
 
 func healthHandler(c *Context) (interface{}, error) {

--- a/pkg/gofr/handler_test.go
+++ b/pkg/gofr/handler_test.go
@@ -76,7 +76,8 @@ func TestHandler_ServeHTTP_Timeout(t *testing.T) {
 	h.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusRequestTimeout, w.Code, "TestHandler_ServeHTTP_Timeout Failed")
-	assert.Equal(t, "Request timed out\n", w.Body.String(), "TestHandler_ServeHTTP_Timeout Failed")
+
+	assert.Contains(t, w.Body.String(), "request timed out", "TestHandler_ServeHTTP_Timeout Failed")
 }
 
 func TestHandler_faviconHandlerError(t *testing.T) {

--- a/pkg/gofr/http/errors.go
+++ b/pkg/gofr/http/errors.go
@@ -72,3 +72,14 @@ func (e ErrorInvalidRoute) Error() string {
 func (e ErrorInvalidRoute) StatusCode() int {
 	return http.StatusNotFound
 }
+
+// ErrorRequestTimeout represents an error for request which timed out.
+type ErrorRequestTimeout struct{}
+
+func (e ErrorRequestTimeout) Error() string {
+	return "request timed out"
+}
+
+func (e ErrorRequestTimeout) StatusCode() int {
+	return http.StatusRequestTimeout
+}

--- a/pkg/gofr/http/errors_test.go
+++ b/pkg/gofr/http/errors_test.go
@@ -95,3 +95,11 @@ func TestErrorInvalidRoute(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, err.StatusCode(), "TEST Failed.\n")
 }
+
+func Test_ErrorRequestTimeout(t *testing.T) {
+	err := ErrorRequestTimeout{}
+
+	assert.Equal(t, "request timed out", err.Error(), "TEST Failed.\n")
+
+	assert.Equal(t, http.StatusRequestTimeout, err.StatusCode(), "TEST Failed.\n")
+}


### PR DESCRIPTION
Error for request timeout was coming in text format instead of json body. Created a new error type `ErrorRequestTimeout` to fix this.

**Before**:
```text
Request timed out
```

**Now**:
```json
{
    "error": {
        "message": "request timed out"
    }
}
```