### PR TITLE
add container in auth middleware

### DIFF
--- a/docs/advanced-guide/http-authentication/page.md
+++ b/docs/advanced-guide/http-authentication/page.md
@@ -52,7 +52,7 @@ func validateUser(c *container.Container, username, password string) bool {
 func main() { 
 	app := gofr.New() 
 
-	app.EnableBasicAuthWithFunc(validateUser) 
+	app.EnableBasicAuthWithValidator(validateUser) 
 
 	app.GET("/secure-data", func(c *gofr.Context) (interface{}, error) { 
 		// Handle access to secure data 
@@ -112,7 +112,7 @@ func main() {
 	// initialise gofr object
 	app := gofr.New()
 
-	app.EnableAPIKeyAuthWithFunc(apiKeyValidator)
+	app.EnableAPIKeyAuthWithValidator(apiKeyValidator)
 
 	app.GET("/customer", Customer)
 

--- a/docs/advanced-guide/http-authentication/page.md
+++ b/docs/advanced-guide/http-authentication/page.md
@@ -102,7 +102,7 @@ func main() {
 ```go
 package main
 
-func apiKeyValidator(apiKey string) bool {
+func apiKeyValidator(c *container.Container, apiKey string) bool {
 	validKeys := []string{"f0e1dffd-0ff0-4ac8-92a3-22d44a1464e4", "d7e4b46e-5b04-47b2-836c-2c7c91250f40"}
 
 	return slices.Contains(validKeys, apiKey)

--- a/docs/advanced-guide/http-authentication/page.md
+++ b/docs/advanced-guide/http-authentication/page.md
@@ -43,7 +43,7 @@ Use `EnableBasicAuthWithFunc(validationFunc)` to implement your own validation l
 The `validationFunc` takes the username and password as arguments and returns true if valid, false otherwise.
 
 ```go
-func validateUser(username string, password string) bool {
+func validateUser(c *container.Container, username, password string) bool {
 	// Implement your credential validation logic here 
 	// This example uses hardcoded credentials for illustration only   
 	return username == "john" && password == "doe123" 

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -355,15 +355,15 @@ func (a *App) EnableBasicAuthWithFunc(validateFunc func(username, password strin
 
 func (a *App) EnableBasicAuthWithValidator(validateFunc func(c *container.Container, username, password string) bool) {
 	a.httpServer.router.Use(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{
-		ValidateFuncWithDB: validateFunc, Container: a.container}))
+		ValidateFuncWithDatasources: validateFunc, Container: a.container}))
 }
 
 func (a *App) EnableAPIKeyAuth(apiKeys ...string) {
-	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{Keys: apiKeys}))
+	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{}, apiKeys...))
 }
 
 // Deprecated: EnableAPIKeyAuthWithFunc is deprecated and will be removed in future releases, users must use
-// EnableBasicAuthWithValidator as it has access to application datasources.
+// EnableAPIKeyAuthWithValidator as it has access to application datasources.
 func (a *App) EnableAPIKeyAuthWithFunc(validateFunc func(apiKey string) bool) {
 	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{
 		ValidateFunc: validateFunc,
@@ -371,10 +371,10 @@ func (a *App) EnableAPIKeyAuthWithFunc(validateFunc func(apiKey string) bool) {
 	}))
 }
 
-func (a *App) EnableAPIKeyAuthWitValidator(validateFunc func(c *container.Container, apiKey string) bool) {
+func (a *App) EnableAPIKeyAuthWithValidator(validateFunc func(c *container.Container, apiKey string) bool) {
 	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{
-		ValidateFuncWithDB: validateFunc,
-		Container:          a.container,
+		ValidateFuncWithDatasources: validateFunc,
+		Container:                   a.container,
 	}))
 }
 

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -347,8 +347,8 @@ func (a *App) EnableBasicAuth(credentials ...string) {
 	a.httpServer.router.Use(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{Users: users}))
 }
 
-func (a *App) EnableBasicAuthWithFunc(validateFunc func(username, password string) bool) {
-	a.httpServer.router.Use(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{ValidateFunc: validateFunc}))
+func (a *App) EnableBasicAuthWithFunc(validateFunc func(c *container.Container, username, password string) bool) {
+	a.httpServer.router.Use(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{ValidateFunc: validateFunc, Container: a.container}))
 }
 
 func (a *App) EnableAPIKeyAuth(apiKeys ...string) {

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -347,16 +347,35 @@ func (a *App) EnableBasicAuth(credentials ...string) {
 	a.httpServer.router.Use(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{Users: users}))
 }
 
-func (a *App) EnableBasicAuthWithFunc(validateFunc func(c *container.Container, username, password string) bool) {
+// Deprecated: EnableBasicAuthWithFunc is deprecated and will be removed in future releases, users must use
+// EnableBasicAuthWithValidator as it has access to application datasources.
+func (a *App) EnableBasicAuthWithFunc(validateFunc func(username, password string) bool) {
 	a.httpServer.router.Use(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{ValidateFunc: validateFunc, Container: a.container}))
 }
 
-func (a *App) EnableAPIKeyAuth(apiKeys ...string) {
-	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(nil, nil, apiKeys...))
+func (a *App) EnableBasicAuthWithValidator(validateFunc func(c *container.Container, username, password string) bool) {
+	a.httpServer.router.Use(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{
+		ValidateFuncWithDB: validateFunc, Container: a.container}))
 }
 
-func (a *App) EnableAPIKeyAuthWithFunc(validateFunc func(c *container.Container, apiKey string) bool) {
-	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(validateFunc, a.container))
+func (a *App) EnableAPIKeyAuth(apiKeys ...string) {
+	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{Keys: apiKeys}))
+}
+
+// Deprecated: EnableAPIKeyAuthWithFunc is deprecated and will be removed in future releases, users must use
+// EnableBasicAuthWithValidator as it has access to application datasources.
+func (a *App) EnableAPIKeyAuthWithFunc(validateFunc func(apiKey string) bool) {
+	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{
+		ValidateFunc: validateFunc,
+		Container:    a.container,
+	}))
+}
+
+func (a *App) EnableAPIKeyAuthWitValidator(validateFunc func(c *container.Container, apiKey string) bool) {
+	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{
+		ValidateFuncWithDB: validateFunc,
+		Container:          a.container,
+	}))
 }
 
 func (a *App) EnableOAuth(jwksEndpoint string, refreshInterval int) {

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -352,11 +352,11 @@ func (a *App) EnableBasicAuthWithFunc(validateFunc func(c *container.Container, 
 }
 
 func (a *App) EnableAPIKeyAuth(apiKeys ...string) {
-	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(nil, apiKeys...))
+	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(nil, nil, apiKeys...))
 }
 
-func (a *App) EnableAPIKeyAuthWithFunc(validator func(apiKey string) bool) {
-	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(validator))
+func (a *App) EnableAPIKeyAuthWithFunc(validateFunc func(c *container.Container, apiKey string) bool) {
+	a.httpServer.router.Use(middleware.APIKeyAuthMiddleware(validateFunc, a.container))
 }
 
 func (a *App) EnableOAuth(jwksEndpoint string, refreshInterval int) {

--- a/pkg/gofr/http/middleware/apikey_auth.go
+++ b/pkg/gofr/http/middleware/apikey_auth.go
@@ -10,10 +10,9 @@ import (
 
 // APIKeyAuthProvider represents a basic authentication provider.
 type APIKeyAuthProvider struct {
-	Keys               []string
-	ValidateFunc       func(apiKey string) bool
-	ValidateFuncWithDB func(c *container.Container, apiKey string) bool
-	Container          *container.Container
+	ValidateFunc                func(apiKey string) bool
+	ValidateFuncWithDatasources func(c *container.Container, apiKey string) bool
+	Container                   *container.Container
 }
 
 // APIKeyAuthMiddleware creates a middleware function that enforces API key authentication based on the provided API
@@ -57,12 +56,12 @@ func validateKey(provider APIKeyAuthProvider, authKey string, apiKeys ...string)
 		return false
 	}
 
-	if provider.ValidateFuncWithDB != nil && !provider.ValidateFuncWithDB(provider.Container, authKey) {
+	if provider.ValidateFuncWithDatasources != nil && !provider.ValidateFuncWithDatasources(provider.Container, authKey) {
 		return false
 	}
 
-	if !isPresent(authKey, apiKeys...) {
-		return false
+	if provider.ValidateFunc == nil && provider.ValidateFuncWithDatasources == nil {
+		return isPresent(authKey, apiKeys...)
 	}
 
 	return true

--- a/pkg/gofr/http/middleware/apikey_auth_test.go
+++ b/pkg/gofr/http/middleware/apikey_auth_test.go
@@ -56,9 +56,9 @@ func Test_ApiKeyAuthMiddleware(t *testing.T) {
 		req.Header.Set("X-API-KEY", tc.apiKey)
 
 		provider := APIKeyAuthProvider{
-			ValidateFunc:       tc.validatorFunc,
-			ValidateFuncWithDB: tc.validatorFuncWithDB,
-			Container:          nil,
+			ValidateFunc:                tc.validatorFunc,
+			ValidateFuncWithDatasources: tc.validatorFuncWithDB,
+			Container:                   nil,
 		}
 
 		wrappedHandler := APIKeyAuthMiddleware(provider, validKey1, validKey2)(testHandler)

--- a/pkg/gofr/http/middleware/basic_auth.go
+++ b/pkg/gofr/http/middleware/basic_auth.go
@@ -12,10 +12,10 @@ const credentialLength = 2
 
 // BasicAuthProvider represents a basic authentication provider.
 type BasicAuthProvider struct {
-	Users              map[string]string
-	ValidateFunc       func(username, password string) bool
-	ValidateFuncWithDB func(c *container.Container, username, password string) bool
-	Container          *container.Container
+	Users                       map[string]string
+	ValidateFunc                func(username, password string) bool
+	ValidateFuncWithDatasources func(c *container.Container, username, password string) bool
+	Container                   *container.Container
 }
 
 // BasicAuthMiddleware creates a middleware function that enforces basic authentication using the provided BasicAuthProvider.
@@ -66,7 +66,8 @@ func validateCredentials(provider BasicAuthProvider, credentials []string) bool 
 		return false
 	}
 
-	if provider.ValidateFuncWithDB != nil && !provider.ValidateFuncWithDB(provider.Container, credentials[0], credentials[1]) {
+	if provider.ValidateFuncWithDatasources != nil && !provider.ValidateFuncWithDatasources(provider.Container,
+		credentials[0], credentials[1]) {
 		return false
 	}
 

--- a/pkg/gofr/http/middleware/basic_auth.go
+++ b/pkg/gofr/http/middleware/basic_auth.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"net/http"
 	"strings"
+
+	"gofr.dev/pkg/gofr/container"
 )
 
 const credentialLength = 2
@@ -11,7 +13,8 @@ const credentialLength = 2
 // BasicAuthProvider represents a basic authentication provider.
 type BasicAuthProvider struct {
 	Users        map[string]string
-	ValidateFunc func(username, password string) bool
+	ValidateFunc func(c *container.Container, username, password string) bool
+	Container    *container.Container
 }
 
 // BasicAuthMiddleware creates a middleware function that enforces basic authentication using the provided BasicAuthProvider.
@@ -59,7 +62,7 @@ func BasicAuthMiddleware(basicAuthProvider BasicAuthProvider) func(handler http.
 
 func validateCredentials(provider BasicAuthProvider, credentials []string) bool {
 	if provider.ValidateFunc != nil {
-		if !provider.ValidateFunc(credentials[0], credentials[1]) {
+		if !provider.ValidateFunc(provider.Container, credentials[0], credentials[1]) {
 			return false
 		}
 	} else {

--- a/pkg/gofr/http/middleware/basic_auth_test.go
+++ b/pkg/gofr/http/middleware/basic_auth_test.go
@@ -53,7 +53,7 @@ func TestBasicAuthMiddleware(t *testing.T) {
 		{
 			name:               "false from validation Func with DB",
 			authHeader:         "Basic dXNlcjpwYXNzd29yZA==",
-			authProvider:       BasicAuthProvider{ValidateFuncWithDB: validationFuncWithDB},
+			authProvider:       BasicAuthProvider{ValidateFuncWithDatasources: validationFuncWithDB},
 			expectedStatusCode: http.StatusUnauthorized,
 		},
 		{

--- a/pkg/gofr/http/middleware/basic_auth_test.go
+++ b/pkg/gofr/http/middleware/basic_auth_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gofr.dev/pkg/gofr/container"
 )
 
 func TestBasicAuthMiddleware(t *testing.T) {
-	validationFunc := func(user, pass string) bool {
+	validationFunc := func(_ *container.Container, user, pass string) bool {
 		if user == "abc" && pass == "pass123" {
 			return true
 		}

--- a/pkg/gofr/http/middleware/basic_auth_test.go
+++ b/pkg/gofr/http/middleware/basic_auth_test.go
@@ -10,7 +10,15 @@ import (
 )
 
 func TestBasicAuthMiddleware(t *testing.T) {
-	validationFunc := func(_ *container.Container, user, pass string) bool {
+	validationFunc := func(user, pass string) bool {
+		if user == "abc" && pass == "pass123" {
+			return true
+		}
+
+		return false
+	}
+
+	validationFuncWithDB := func(_ *container.Container, user, pass string) bool {
 		if user == "abc" && pass == "pass123" {
 			return true
 		}
@@ -33,13 +41,19 @@ func TestBasicAuthMiddleware(t *testing.T) {
 		{
 			name:               "Valid Authorization with validation Func",
 			authHeader:         "Basic YWJjOnBhc3MxMjM=",
-			authProvider:       BasicAuthProvider{ValidateFunc: validationFunc},
+			authProvider:       BasicAuthProvider{Users: map[string]string{"abc": "pass123"}, ValidateFunc: validationFunc},
 			expectedStatusCode: http.StatusOK,
 		},
 		{
 			name:               "false from validation Func",
 			authHeader:         "Basic dXNlcjpwYXNzd29yZA==",
 			authProvider:       BasicAuthProvider{ValidateFunc: validationFunc},
+			expectedStatusCode: http.StatusUnauthorized,
+		},
+		{
+			name:               "false from validation Func with DB",
+			authHeader:         "Basic dXNlcjpwYXNzd29yZA==",
+			authProvider:       BasicAuthProvider{ValidateFuncWithDB: validationFuncWithDB},
 			expectedStatusCode: http.StatusUnauthorized,
 		},
 		{

--- a/pkg/gofr/http/middleware/oauth_test.go
+++ b/pkg/gofr/http/middleware/oauth_test.go
@@ -24,15 +24,14 @@ func TestOAuthSuccess(t *testing.T) {
 	server := httptest.NewServer(router)
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/test", http.NoBody)
-	req.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IklDbmFZdEwtSDExckl0WlJ4VVlLVElzbm"+
-		"5ybm1wWUp6cGFWRHVDRWN0Ukk9IiwidHlwIjoiSldUIn0.eyJhdWQiOiJzdGFnZS5rb3BzLmRldiIsImV4cCI6MTcxODc5MjQ2NiwiaWF0Ij"+
-		"oxNzEwMTUyNDY2LCJpc3MiOiJzdGFnZS5hdXRoLnpvcHNtYXJ0LmNvbSIsIm5hbWUiOiJSYWtzaGl0IFNpbmdoIiwib3JpZyI6IkdPT0dMRSI"+
-		"sInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vYS9BQ2c4b2NLSjVEREE0enJ1ekZsc1E5S3ZMakhEdGJPVF9o"+
-		"cFZ6MGhFTzhqU2wybTdNeWs9czk2LWMiLCJzdWIiOiJyYWtzaGl0LnNpbmdoQHpvcHNtYXJ0LmNvbSIsInN1Yi1pZCI6ImE2NTczZTFkLWFiZW"+
-		"EtNDg2My1hY2RiLTZjZjM2MjZhNDQxNCIsInR5cCI6InJlZnJlc2hfdG9rZW4ifQ.eoRVSFcyvbWk-fUSlACI4pWwHcuwjA1BbKlYA_aEJA6T"+
-		"BRcnM0HoaxL_GcF0Q-95Z6Medk9l5Fe-zuY4xmLX0XRnA9y9KEsXvyhxsmLJTV32C2kirDh6TR5FIep3EKV0VdWKJT6LziBjrCP-F0pKb34em"+
-		"Ua7gsyi5OnkX12_ZcGpQpSbL3mcZpEEGUmKijlg1VspK4G9dTmNSUXofxStokxacLwa3hiFfkd7vtegkF79bfWPVm0hlJDGDcU7szUaIyHjdW"+
-		"rlUGqQ0A8-8dYQ-Z1o5STZITcxvSv6SaZNo08r_szi-TDLXRhASP3ojEjFCqFBmPw9HPxHG4JmV3SX2A")
+	req.Header.Set("Authorization", "Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IjAwVFEwdlRpNVB1UnZscUZGY3dCeUc0WjBM"+
+		"dGREcUtJX0JWUFRrdnpleEUiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJzdGFnZS5rb3BzLmRldiIsImlhdCI6MTI1Nzg5NDAwMCwib3JpZyI6IkdP"+
+		"T0dMRSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vYS9BQ2c4b2NLSjVEREE0enJ1ekZsc1E5S3ZMakhEdG"+
+		"JPVF9ocFZ6MGhFTzhqU2wybTdNeWs9czk2LWMiLCJzdWIiOiJyYWtzaGl0LnNpbmdoQHpvcHNtYXJ0LmNvbSIsInN1Yi1pZCI6ImE2NTczZTFkL"+
+		"WFiZWEtNDg2My1hY2RiLTZjZjM2MjZhNDQxNCIsInR5cCI6InJlZnJlc2hfdG9rZW4ifQ.NkYSi6KJtGA3js9dcN3UqJWfeJdB88p7cxclrc6"+
+		"fxJODlCalsbbwIr3QL4AR9i0ucJjmoTIipCwpdM1IYDjCd-ilf2mTp11Wba31XoH--8YLI9Ju0wbpYhtF3wa00NF1Ijt48ze09IJ6QtE-etm"+
+		"AN8T7izsXbPeSrFiN3NVQU87eGxc3bEQhEsV5u3E6j8EdVDv8xbwisETY-N0mDftZp0w8UCkQ7MarOrA5IaXs2MHyCETy5y9QFd4djppH9oFo"+
+		"y5-AtEZqzyHKfGMlerjtJp8uOgFso9FycGuO0TFhR4AaZGVZxB072Hu-71tbx7atXp3zmDdkK_jkg5aVepoU_Q")
 
 	client := http.Client{}
 
@@ -274,14 +273,14 @@ func (m *MockProvider) GetWithHeaders(context.Context, string, map[string]interf
 	responseBody := map[string]interface{}{
 		"keys": []map[string]string{
 			{
-				"kid": "ICnaYtL-H11rItZRxUYKTIsnnrnmpYJzpaVDuCEctRI=",
-				"n": "m1_RTyr57vrdWV-u4yxOt1Vq-adbM0njVXa4nNMDG5hBEaIzkRaNzailyO38oa8byf0EAlqrpo7n4MdascXt5WzthSnG7" +
-					"kVa5r7BnPf4OLkvw9YmecytJNVwuM37Wk-53yqsDHqa7wHEhrIj-4zkB0ssN9ya2V_kZoCfICxBuWhlqry0H0jcdn4n84bbp4v" +
-					"b7JI9zcJ17iuIZcagzLHRxZ95wieP1bxxkcbDOg8lXeJYRTkAjiPwBnQqlMQlJXxIFq0Ow8qmRPtf-p5ZqJuR74LnZ5KxlrpTE-" +
-					"wx0pvvd0-dmESVbdLn6LR-Ww-jl96aKWX-QiZWROrlKeda5r1LZw",
-				"e":   "AQAB",
-				"use": "sig",
 				"kty": "RSA",
+				"use": "sig",
+				"kid": "00TQ0vTi5PuRvlqFFcwByG4Z0LtdDqKI_BVPTkvzexE",
+				"n": "0nb5fKw3xb4_NMkEh80jG0_HuKByBnTIRqPTX-xbtSEDTsev1O4oyl3az0UdebyimwqHSLPVFIitHnfhHsto0IycnL9omEm" +
+					"40YWEUxOqs5HJaFhZsKHZmxCUkYsb-nHhYm67sYiPkcBQrisWFJi4r48EyLv050D85MkhPiD3Iy0Q5m29U-Hf9CIfxy1MS8akJ" +
+					"uTnk8Ir4ajHN7ze33IOAjE1UPX1viZ6QSwbFPo0YrGf6vZq21cbhS6UD1JC-A_iFVdSGKzBAfFspQaAllifmaym6XK-q4mKqTW" +
+					"430zKlGCnQd3ddg3zmCe7KqpJ6aDVUQ0FS_K8GnOoWeScWEj0qw",
+				"e": "AQAB",
 			},
 		},
 	}


### PR DESCRIPTION
## Pull Request Template


**Description:**

-  Resolves issue #728 
-  Change the **validator func signature** in `basic auth` and `api key auth` middleware.

**Breaking Changes (if applicable):**

-   Earlier the validator func signature for **BasicAuthMiddleware** used to be :
```go
func(username, password string) bool {}
```

Updated to:
```go
func(c *container.Container, username, password string) bool {}
```

Similar change for **ApiKeyAuthMiddleware's** validator func signature


**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [ ] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

