### PR TITLE
Add support for profilling endpoints.

### DIFF
--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -85,6 +85,10 @@ func New() *App {
 
 	app.httpServer = newHTTPServer(app.container, port, middleware.GetConfigs(app.Config))
 
+	if app.Config.Get("APP_ENV") == "DEBUG" {
+		app.httpServer.RegisterProfillingRoutes()
+	}
+
 	// GRPC Server
 	port, err = strconv.Atoi(app.Config.Get("GRPC_PORT"))
 	if err != nil || port <= 0 {

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -86,10 +86,10 @@ func New() *App {
 	app.httpServer = newHTTPServer(app.container, port, middleware.GetConfigs(app.Config))
 
 	if app.Config.Get("APP_ENV") == "DEBUG" {
-		app.httpServer.RegisterProfillingRoutes()
+		app.httpServer.RegisterProfilingRoutes()
 	}
 
-	// GRPC Server
+	// gRPC Server
 	port, err = strconv.Atoi(app.Config.Get("GRPC_PORT"))
 	if err != nil || port <= 0 {
 		port = defaultGRPCPort

--- a/pkg/gofr/httpServer.go
+++ b/pkg/gofr/httpServer.go
@@ -38,11 +38,12 @@ func newHTTPServer(c *container.Container, port int, middlewareConfigs map[strin
 }
 
 func (s *httpServer) RegisterProfillingRoutes() {
-	s.router.HandleFunc("/debug/pprof/", pprof.Index)
 	s.router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	s.router.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	s.router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	s.router.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	s.router.NewRoute().Methods(http.MethodGet).PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
 }
 
 func (s *httpServer) Run(c *container.Container) {

--- a/pkg/gofr/httpServer.go
+++ b/pkg/gofr/httpServer.go
@@ -37,7 +37,7 @@ func newHTTPServer(c *container.Container, port int, middlewareConfigs map[strin
 	}
 }
 
-func (s *httpServer) RegisterProfillingRoutes() {
+func (s *httpServer) RegisterProfilingRoutes() {
 	s.router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	s.router.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	s.router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)

--- a/pkg/gofr/httpServer.go
+++ b/pkg/gofr/httpServer.go
@@ -3,6 +3,7 @@ package gofr
 import (
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"gofr.dev/pkg/gofr/container"
@@ -34,6 +35,14 @@ func newHTTPServer(c *container.Container, port int, middlewareConfigs map[strin
 		port:   port,
 		ws:     wsManager,
 	}
+}
+
+func (s *httpServer) RegisterProfillingRoutes() {
+	s.router.HandleFunc("/debug/pprof/", pprof.Index)
+	s.router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	s.router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	s.router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	s.router.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }
 
 func (s *httpServer) Run(c *container.Container) {

--- a/pkg/gofr/httpServer_test.go
+++ b/pkg/gofr/httpServer_test.go
@@ -64,7 +64,7 @@ func TestRegisterProfillingRoutes(t *testing.T) {
 		port:   8080,
 	}
 
-	server.RegisterProfillingRoutes()
+	server.RegisterProfilingRoutes()
 
 	server.Run(c)
 

--- a/pkg/gofr/httpServer_test.go
+++ b/pkg/gofr/httpServer_test.go
@@ -3,6 +3,8 @@ package gofr
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -50,4 +52,36 @@ func TestRun_ServerStartsListening(t *testing.T) {
 	assert.Equal(t, resp.StatusCode, http.StatusOK, "TEST Failed.\n")
 
 	resp.Body.Close()
+}
+
+func TestRegisterProfillingRoutes(t *testing.T) {
+	c := &container.Container{
+		Logger: logging.NewLogger(logging.INFO),
+	}
+
+	server := &httpServer{
+		router: gofrHTTP.NewRouter(),
+		port:   8080,
+	}
+
+	server.RegisterProfillingRoutes()
+
+	server.Run(c)
+
+	// Test if the expected handlers are registered for the pprof endpoints
+	expectedRoutes := []string{
+		"/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/symbol",
+	}
+
+	serverURL := "http://localhost:" + strconv.Itoa(8000)
+
+	for _, route := range expectedRoutes {
+		r := httptest.NewRequest(http.MethodGet, serverURL+route, http.NoBody)
+		rr := httptest.NewRecorder()
+		server.router.ServeHTTP(rr, r)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	}
 }


### PR DESCRIPTION
## Pull Request Template


**Description:**

-   Closes issue #772 
- The profilling endpoints will be automatically enabled when the `APP_ENV` is set to `DEBUG`

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

