### PR TITLE
Support custom tracer url

### DIFF
--- a/docs/references/configs/page.md
+++ b/docs/references/configs/page.md
@@ -72,12 +72,19 @@ This document lists all the configuration options supported by the GoFr framewor
 
 -  TRACER_HOST
 -  Hostname of the tracing collector. Required if TRACE_EXPORTER is set to zipkin or jaeger.
+-  **DEPRECATED**
 
 ---
 
 -  TRACER_PORT
 -  Port of the tracing collector. Required if TRACE_EXPORTER is set to zipkin or jaeger.
 -  9411
+-  **DEPRECATED**
+
+---
+
+-  TRACER_URL
+-  URL of the trace collector. Required if TRACE_EXPORTER is set to zipkin or jaeger.
 
 ---
 

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -363,7 +363,7 @@ func (a *App) getExporter(name, host, port, url string) (sdktrace.SpanExporter, 
 		exporter, err = zipkin.New(url, opts...)
 	case gofrTraceExporter:
 		if url == "" {
-			url = gofrTracerURL + "/api/spans"
+			url = "https://tracer-api.gofr.dev/api/spans"
 		}
 
 		a.container.Logf("Exporting traces to GoFr at %s", gofrTracerURL)

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -303,6 +303,10 @@ func (a *App) initTracer() {
 	tracerHost := a.Config.Get("TRACER_HOST")
 	tracerPort := a.Config.GetOrDefault("TRACER_PORT", "9411")
 
+	if tracerURL == "" && tracerHost != "" && tracerPort != "" {
+		a.Logger().Warn("TRACER_HOST and TRACER_PORT are deprecated, use TRACER_URL instead")
+	}
+
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -351,15 +351,27 @@ func Test_initTracer(t *testing.T) {
 		"TRACER_AUTH_KEY": "valid-token",
 	})
 
+	mockConfig6 := config.NewMockConfig(map[string]string{
+		"TRACE_EXPORTER": "zipkin",
+		"TRACER_URL":     "https://tracer-service.dev",
+	})
+
+	mockConfig7 := config.NewMockConfig(map[string]string{
+		"TRACE_EXPORTER": "jaeger",
+		"TRACER_URL":     "https://tracer-service.dev",
+	})
+
 	tests := []struct {
 		desc               string
 		config             config.Config
 		expectedLogMessage string
 	}{
-		{"zipkin exporter", mockConfig1, "Exporting traces to zipkin."},
-		{"zipkin exporter with auth", mockConfig4, "Exporting traces to zipkin."},
-		{"jaeger exporter", mockConfig2, "Exporting traces to jaeger."},
-		{"jaeger exporter with auth", mockConfig5, "Exporting traces to jaeger."},
+		{"zipkin exporter", mockConfig1, "Exporting traces to zipkin at http://localhost:2005/api/v2/spans"},
+		{"zipkin exporter with auth", mockConfig4, "Exporting traces to zipkin at http://localhost:2005/api/v2/spans"},
+		{"zipkin exporter with custom tracer url", mockConfig6, "Exporting traces to zipkin at https://tracer-service.dev"},
+		{"jaeger exporter", mockConfig2, "Exporting traces to jaeger at localhost:2005"},
+		{"jaeger exporter with auth", mockConfig5, "Exporting traces to jaeger at localhost:2005"},
+		{"jaeger exporter custom tracer url", mockConfig7, "Exporting traces to jaeger at https://tracer-service.dev"},
 		{"gofr exporter", mockConfig3, "Exporting traces to GoFr at https://tracer.gofr.dev"},
 	}
 


### PR DESCRIPTION
- Provided support for custom tracer URL, using the config `TRACER_URL`
- Deprecated `TRACER_HOST` and `TRACER_PORT`

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

