### PR TITLE
Fail app if error in config files

### DIFF
--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -20,6 +22,7 @@ type logger interface {
 	Warnf(format string, a ...interface{})
 	Infof(format string, a ...interface{})
 	Debugf(format string, a ...interface{})
+	Fatalf(format string, a ...interface{})
 }
 
 func NewEnvFile(configFolder string, logger logger) Config {
@@ -38,33 +41,28 @@ func (e *EnvLoader) read(folder string) {
 
 	err := godotenv.Load(defaultFile)
 	if err != nil {
-		e.logger.Warnf("Failed to load config from file: %v, Err: %v", defaultFile, err)
+		if errors.Is(err, fs.ErrNotExist) {
+			e.logger.Warnf("Failed to load config from file: %v, Err: %v", defaultFile, err)
+		} else {
+			e.logger.Fatalf("Failed to load config from file: %v, Err: %v", defaultFile, err)
+		}
 	} else {
 		e.logger.Infof("Loaded config from file: %v", defaultFile)
 	}
 
-	switch env {
-	case "":
-		// If 'APP_ENV' is not set, then GoFr will read '.env' from configs directory, and then it will be overwritten
-		// by configs present in file '.local.env'
-		err = godotenv.Overload(overrideFile)
-		if err != nil {
-			e.logger.Debugf("Failed to load config from file: %v, Err: %v", overrideFile, err)
-		} else {
-			e.logger.Infof("Loaded config from file: %v", overrideFile)
-		}
-
-	default:
+	if env != "" {
 		// If 'APP_ENV' is set to x, then GoFr will read '.env' from configs directory, and then it will be overwritten
 		// by configs present in file '.x.env'
 		overrideFile = fmt.Sprintf("%s/.%s.env", folder, env)
+	}
 
-		err = godotenv.Overload(overrideFile)
-		if err != nil {
-			e.logger.Warnf("Failed to load config from file: %v, Err: %v", overrideFile, err)
-		} else {
-			e.logger.Infof("Loaded config from file: %v", overrideFile)
+	err = godotenv.Overload(overrideFile)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			e.logger.Fatalf("Failed to load config from file: %v, Err: %v", overrideFile, err)
 		}
+	} else {
+		e.logger.Infof("Loaded config from file: %v", overrideFile)
 	}
 }
 

--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -41,11 +41,11 @@ func (e *EnvLoader) read(folder string) {
 
 	err := godotenv.Load(defaultFile)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			e.logger.Warnf("Failed to load config from file: %v, Err: %v", defaultFile, err)
-		} else {
+		if !errors.Is(err, fs.ErrNotExist) {
 			e.logger.Fatalf("Failed to load config from file: %v, Err: %v", defaultFile, err)
 		}
+
+		e.logger.Warnf("Failed to load config from file: %v, Err: %v", defaultFile, err)
 	} else {
 		e.logger.Infof("Loaded config from file: %v", defaultFile)
 	}

--- a/pkg/gofr/config/godotenv_test.go
+++ b/pkg/gofr/config/godotenv_test.go
@@ -99,20 +99,23 @@ func Test_EnvFailureWithHyphen(t *testing.T) {
 
 	logger := logging.NewMockLogger(logging.DEBUG)
 
-	err := createConfigsDirectory()
-	if err != nil {
-		t.Error(err)
+	configFiles := []string{".env", ".local.env"}
+
+	for _, file := range configFiles {
+		err := createConfigsDirectory()
+		if err != nil {
+			t.Error(err)
+		}
+
+		createEnvFile(t, file, envData)
+
+		env := NewEnvFile("configs", logger)
+
+		assert.Equal(t, "test", env.GetOrDefault("KEY-WITH-HYPHEN", "test"), "TEST Failed.\n godotenv failure with hyphen")
+		assert.Equal(t, "", env.Get("UNABLE_TO_LOAD"), "TEST Failed.\n godotenv failure with hyphen")
+
+		os.RemoveAll("configs")
 	}
-
-	// Call the function to create the .env file
-	createEnvFile(t, ".env", envData)
-
-	defer os.RemoveAll("configs")
-
-	env := NewEnvFile("configs", logger)
-
-	assert.Equal(t, "test", env.GetOrDefault("KEY-WITH-HYPHEN", "test"), "TEST Failed.\n godotenv failure with hyphen")
-	assert.Equal(t, "", env.Get("UNABLE_TO_LOAD"), "TEST Failed.\n godotenv failure with hyphen")
 }
 
 func createEnvFile(t *testing.T, fileName string, envData map[string]string) {

--- a/pkg/gofr/config/godotenv_test.go
+++ b/pkg/gofr/config/godotenv_test.go
@@ -99,22 +99,22 @@ func Test_EnvFailureWithHyphen(t *testing.T) {
 
 	logger := logging.NewMockLogger(logging.DEBUG)
 
+	err := createConfigsDirectory()
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer os.RemoveAll("configs")
+
 	configFiles := []string{".env", ".local.env"}
 
 	for _, file := range configFiles {
-		err := createConfigsDirectory()
-		if err != nil {
-			t.Error(err)
-		}
-
 		createEnvFile(t, file, envData)
 
 		env := NewEnvFile("configs", logger)
 
 		assert.Equal(t, "test", env.GetOrDefault("KEY-WITH-HYPHEN", "test"), "TEST Failed.\n godotenv failure with hyphen")
 		assert.Equal(t, "", env.Get("UNABLE_TO_LOAD"), "TEST Failed.\n godotenv failure with hyphen")
-
-		os.RemoveAll("configs")
 	}
 }
 

--- a/pkg/gofr/config/godotenv_test.go
+++ b/pkg/gofr/config/godotenv_test.go
@@ -121,15 +121,15 @@ func Test_EnvFailureWithHyphen(t *testing.T) {
 func createEnvFile(t *testing.T, fileName string, envData map[string]string) {
 	t.Helper()
 
-	// Create or open the .env file for writing
+	// Create or open the env file for writing
 	envFile, err := os.Create("configs/" + fileName)
 	if err != nil {
-		t.Fatalf("error creating .env file: %v", err)
+		t.Fatalf("error creating %s file: %v", fileName, err)
 	}
 
 	defer envFile.Close()
 
-	// Write data to the .env file
+	// Write data to the env file
 	for key, value := range envData {
 		_, err := fmt.Fprintf(envFile, "%s=%s\n", key, value)
 		if err != nil {


### PR DESCRIPTION
- Fail app start in case of any error in `.env` or `.<APP_ENV>.env` files.
- Closes: #852

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.