### PR TITLE
Fix error logs for shutdown

### DIFF
--- a/pkg/gofr/http_server.go
+++ b/pkg/gofr/http_server.go
@@ -2,6 +2,7 @@ package gofr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -75,7 +76,11 @@ func (s *httpServer) Run(c *container.Container) {
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	c.Error(s.srv.ListenAndServe())
+	err := s.srv.ListenAndServe()
+
+	if !errors.Is(err, http.ErrServerClosed) {
+		c.Errorf("error while listening to http server, err: %v", err)
+	}
 }
 
 func (s *httpServer) Shutdown(ctx context.Context) error {

--- a/pkg/gofr/metrics_server.go
+++ b/pkg/gofr/metrics_server.go
@@ -2,6 +2,7 @@ package gofr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -29,7 +30,11 @@ func (m *metricServer) Run(c *container.Container) {
 			ReadHeaderTimeout: 5 * time.Second,
 		}
 
-		c.Error(m.srv.ListenAndServe())
+		err := m.srv.ListenAndServe()
+
+		if !errors.Is(err, http.ErrServerClosed) {
+			c.Errorf("error while listening to metrics server, err: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
- For forceful shutdown, these error logs were coming up everytime:
  <img width="370" alt="Screenshot 2024-07-30 at 5 52 50 PM" src="https://github.com/user-attachments/assets/a5ad9554-b325-411f-a556-89d91eeb3ee0">

- The error was coming from ListenAndServe method when the server is shutting down.

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.