### PR TITLE
Fix intermittent fail for container and MQTT tests

### DIFF
--- a/pkg/gofr/container/container_test.go
+++ b/pkg/gofr/container/container_test.go
@@ -164,7 +164,7 @@ func TestContainer_Close(t *testing.T) {
 	mockDB.EXPECT().Close().Return(nil)
 	mockRedis.EXPECT().Close().Return(nil)
 
-	c := NewContainer(config.NewMockConfig(map[string]string{}))
+	c := NewContainer(config.NewMockConfig(nil))
 	c.SQL = mockDB
 	c.Redis = mockRedis
 	c.PubSub = mockPubSub

--- a/pkg/gofr/container/container_test.go
+++ b/pkg/gofr/container/container_test.go
@@ -159,16 +159,15 @@ func TestContainer_Close(t *testing.T) {
 
 	mockDB := NewMockDB(controller)
 	mockRedis := NewMockRedis(controller)
+	mockPubSub := &MockPubSub{}
 
 	mockDB.EXPECT().Close().Return(nil)
 	mockRedis.EXPECT().Close().Return(nil)
 
-	configs := map[string]string{
-		"PUBSUB_BACKEND": "MQTT",
-	}
-	c := NewContainer(config.NewMockConfig(configs))
+	c := NewContainer(config.NewMockConfig(map[string]string{}))
 	c.SQL = mockDB
 	c.Redis = mockRedis
+	c.PubSub = mockPubSub
 
 	assert.NotNil(t, c.PubSub)
 

--- a/pkg/gofr/datasource/pubsub/mqtt/mqtt.go
+++ b/pkg/gofr/datasource/pubsub/mqtt/mqtt.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	publicBroker  = "broker.hivemq.com"
+	publicBroker  = "broker.emqx.io"
 	messageBuffer = 10
 )
 
@@ -79,7 +79,7 @@ func New(config *Config, logger Logger, metrics Metrics) *MQTT {
 	if token := client.Connect(); token.Wait() && token.Error() != nil {
 		logger.Errorf("could not connect to MQTT at '%v:%v', error: %v", config.Hostname, config.Port, token.Error())
 
-		return &MQTT{Client: client, config: config, logger: logger}
+		return &MQTT{Client: client, config: config, logger: logger, mu: mu, metrics: metrics}
 	}
 
 	logger.Infof("connected to MQTT at '%v:%v' with clientID '%v'", config.Hostname, config.Port, options.ClientID)
@@ -104,7 +104,7 @@ func getDefaultClient(config *Config, logger Logger, metrics Metrics) *MQTT {
 	if token := client.Connect(); token.Wait() && token.Error() != nil {
 		logger.Errorf("could not connect to MQTT at '%v:%v', error: %v", config.Hostname, config.Port, token.Error())
 
-		return &MQTT{Client: client, config: config, logger: logger}
+		return &MQTT{Client: client, config: config, logger: logger, mu: new(sync.RWMutex), metrics: metrics}
 	}
 
 	config.Hostname = host


### PR DESCRIPTION
Closes #790 

- Used mock Pubsub for container tests as an actual connection to MQTT was not required
- Changed the public broker from HiveMQ to EQMX for more stable connections