### PR TITLE
Release v1.16.1

### DIFF
--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -408,6 +408,11 @@ func (a *App) initTracer() {
 }
 
 func isValidConfig(logger logging.Logger, name, url, host, port string) bool {
+	if url == "" && name == "" {
+		logger.Debug("tracing is disabled, as configs are not provided")
+		return false
+	}
+
 	if url != "" && name == "" {
 		logger.Error("missing TRACE_EXPORTER config, should be provided with TRACER_URL to enable tracing")
 		return false

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -350,6 +350,7 @@ func Test_initTracer(t *testing.T) {
 		config             config.Config
 		expectedLogMessage string
 	}{
+		{"tracing disabled", config.NewMockConfig(nil), "tracing is disabled"},
 		{"zipkin exporter", mockConfig1, "Exporting traces to zipkin at http://localhost:2005/api/v2/spans"},
 		{"zipkin exporter with authkey", mockConfig2, "Exporting traces to zipkin at http://localhost:2005/api/v2/spans"},
 		{"jaeger exporter", mockConfig3, "Exporting traces to jaeger at localhost:4317"},

--- a/pkg/gofr/migration/migration.go
+++ b/pkg/gofr/migration/migration.go
@@ -36,6 +36,7 @@ func Run(migrationsMap map[int64]Migrate, c *container.Container) {
 	sortkeys.Int64s(keys)
 
 	ds, mg, ok := getMigrator(c)
+	ds.Logger = c.Logger
 
 	// Returning with an error log as migration would eventually fail as No databases are initialized.
 	// Pub/Sub is considered as initialized if its configurations are given.

--- a/pkg/gofr/migration/migration_test.go
+++ b/pkg/gofr/migration/migration_test.go
@@ -81,6 +81,8 @@ func TestMigrationRunClickhouseSuccess(t *testing.T) {
 					return err
 				}
 
+				d.Logger.Infof("Clickhouse Migration Ran Successfully")
+
 				return nil
 			}},
 		}
@@ -97,6 +99,7 @@ func TestMigrationRunClickhouseSuccess(t *testing.T) {
 	})
 
 	assert.Contains(t, logs, "Migration 1 ran successfully")
+	assert.Contains(t, logs, "Clickhouse Migration Ran Successfully")
 }
 
 func TestMigrationRunClickhouseMigrationFailure(t *testing.T) {

--- a/pkg/gofr/version/version.go
+++ b/pkg/gofr/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Framework = "v1.16.0"
+const Framework = "v1.16.1"


### PR DESCRIPTION
# Release v1.16.1

## 🐞 Fixes
- Resolved DB migrations panic in logging
App was panicking while logging with migrations datasource, as the logger was `nil`. Now, populated the logger, hence fixing the panic.
- Removed unnecessary error log for tracing
`{"level":"ERROR","time":"2024-08-06T17:47:56.714963+05:30","message":"unsupported TRACE_EXPORTER: ","gofrVersion":"v1.16.0"}`
The above log was coming out even even tracing configs (TRACE_EXPORTER, TRACER_URL) weren't provided, and since tracing is optional feature, removed error log if configs aren't given.