### PR TITLE
Consistent methods' names across datasources that perform same task.

### DIFF
--- a/pkg/gofr/datasource/cassandra/cassandra.go
+++ b/pkg/gofr/datasource/cassandra/cassandra.go
@@ -90,7 +90,7 @@ func (c *Client) UseMetrics(metrics interface{}) {
 
 //nolint:exhaustive // We just want to take care of slice and struct in this case.
 func (c *Client) Query(dest any, stmt string, values ...any) error {
-	defer c.postProcess(&QueryLog{Query: stmt, Keyspace: c.config.Keyspace}, time.Now())
+	defer c.logQueryAndSendMetrics(&QueryLog{Query: stmt, Keyspace: c.config.Keyspace}, time.Now())
 
 	rvo := reflect.ValueOf(dest)
 	if rvo.Kind() != reflect.Ptr {
@@ -137,7 +137,7 @@ func (c *Client) Query(dest any, stmt string, values ...any) error {
 }
 
 func (c *Client) Exec(stmt string, values ...any) error {
-	defer c.postProcess(&QueryLog{Query: stmt, Keyspace: c.config.Keyspace}, time.Now())
+	defer c.logQueryAndSendMetrics(&QueryLog{Query: stmt, Keyspace: c.config.Keyspace}, time.Now())
 
 	return c.cassandra.session.query(stmt, values...).exec()
 }
@@ -149,7 +149,7 @@ func (c *Client) ExecCAS(dest any, stmt string, values ...any) (bool, error) {
 		err     error
 	)
 
-	defer c.postProcess(&QueryLog{Query: stmt, Keyspace: c.config.Keyspace}, time.Now())
+	defer c.logQueryAndSendMetrics(&QueryLog{Query: stmt, Keyspace: c.config.Keyspace}, time.Now())
 
 	rvo := reflect.ValueOf(dest)
 	if rvo.Kind() != reflect.Ptr {
@@ -291,7 +291,7 @@ func (*Client) getColumnsFromColumnsInfo(columns []gocql.ColumnInfo) []string {
 	return cols
 }
 
-func (c *Client) postProcess(ql *QueryLog, startTime time.Time) {
+func (c *Client) logQueryAndSendMetrics(ql *QueryLog, startTime time.Time) {
 	duration := time.Since(startTime).Milliseconds()
 
 	ql.Duration = duration

--- a/pkg/gofr/datasource/cassandra/cassandra_batch.go
+++ b/pkg/gofr/datasource/cassandra/cassandra_batch.go
@@ -16,7 +16,7 @@ func (c *Client) BatchQuery(name, stmt string, values ...any) error {
 }
 
 func (c *Client) ExecuteBatch(name string) error {
-	defer c.postProcess(&QueryLog{Query: "batch", Keyspace: c.config.Keyspace}, time.Now())
+	defer c.logQueryAndSendMetrics(&QueryLog{Query: "batch", Keyspace: c.config.Keyspace}, time.Now())
 
 	b, ok := c.cassandra.batches[name]
 	if !ok {
@@ -27,7 +27,7 @@ func (c *Client) ExecuteBatch(name string) error {
 }
 
 func (c *Client) ExecuteBatchCAS(name string, dest ...any) (bool, error) {
-	defer c.postProcess(&QueryLog{Query: "batch", Keyspace: c.config.Keyspace}, time.Now())
+	defer c.logQueryAndSendMetrics(&QueryLog{Query: "batch", Keyspace: c.config.Keyspace}, time.Now())
 
 	b, ok := c.cassandra.batches[name]
 	if !ok {

--- a/pkg/gofr/datasource/file/ftp/fs.go
+++ b/pkg/gofr/datasource/file/ftp/fs.go
@@ -389,4 +389,6 @@ func (f *fileSystem) processLog(fl *FileLog, startTime time.Time) {
 	fl.Duration = duration
 
 	f.logger.Debug(fl)
+
+	// TODO : Implement metrics
 }

--- a/pkg/gofr/datasource/redis/hook.go
+++ b/pkg/gofr/datasource/redis/hook.go
@@ -64,7 +64,7 @@ func (ql *QueryLog) String() string {
 }
 
 // logQuery logs the Redis query information.
-func (r *redisHook) logQuery(start time.Time, query string, args ...interface{}) {
+func (r *redisHook) logQueryAndSendMetrics(start time.Time, query string, args ...interface{}) {
 	duration := time.Since(start).Milliseconds()
 
 	r.logger.Debug(&QueryLog{
@@ -87,7 +87,7 @@ func (r *redisHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 	return func(ctx context.Context, cmd redis.Cmder) error {
 		start := time.Now()
 		err := next(ctx, cmd)
-		r.logQuery(start, cmd.Name(), cmd.Args()...)
+		r.logQueryAndSendMetrics(start, cmd.Name(), cmd.Args()...)
 
 		return err
 	}
@@ -98,7 +98,7 @@ func (r *redisHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pr
 	return func(ctx context.Context, cmds []redis.Cmder) error {
 		start := time.Now()
 		err := next(ctx, cmds)
-		r.logQuery(start, "pipeline", cmds[:len(cmds)-1])
+		r.logQueryAndSendMetrics(start, "pipeline", cmds[:len(cmds)-1])
 
 		return err
 	}

--- a/pkg/gofr/datasource/sql/db.go
+++ b/pkg/gofr/datasource/sql/db.go
@@ -44,7 +44,7 @@ func clean(query string) string {
 	return query
 }
 
-func (d *DB) logQuery(start time.Time, queryType, query string, args ...interface{}) {
+func (d *DB) logQueryAndSendMetrics(start time.Time, queryType, query string, args ...interface{}) {
 	duration := time.Since(start).Milliseconds()
 
 	d.logger.Debug(&Log{
@@ -66,12 +66,12 @@ func getOperationType(query string) string {
 }
 
 func (d *DB) Query(query string, args ...interface{}) (*sql.Rows, error) {
-	defer d.logQuery(time.Now(), "Query", query, args...)
+	defer d.logQueryAndSendMetrics(time.Now(), "Query", query, args...)
 	return d.DB.Query(query, args...)
 }
 
 func (d *DB) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	defer d.logQuery(time.Now(), "QueryContext", query, args...)
+	defer d.logQueryAndSendMetrics(time.Now(), "QueryContext", query, args...)
 	return d.DB.QueryContext(ctx, query, args...)
 }
 
@@ -80,27 +80,27 @@ func (d *DB) Dialect() string {
 }
 
 func (d *DB) QueryRow(query string, args ...interface{}) *sql.Row {
-	defer d.logQuery(time.Now(), "QueryRow", query, args...)
+	defer d.logQueryAndSendMetrics(time.Now(), "QueryRow", query, args...)
 	return d.DB.QueryRow(query, args...)
 }
 
 func (d *DB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
-	defer d.logQuery(time.Now(), "QueryRowContext", query, args...)
+	defer d.logQueryAndSendMetrics(time.Now(), "QueryRowContext", query, args...)
 	return d.DB.QueryRowContext(ctx, query, args...)
 }
 
 func (d *DB) Exec(query string, args ...interface{}) (sql.Result, error) {
-	defer d.logQuery(time.Now(), "Exec", query, args...)
+	defer d.logQueryAndSendMetrics(time.Now(), "Exec", query, args...)
 	return d.DB.Exec(query, args...)
 }
 
 func (d *DB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	defer d.logQuery(time.Now(), "ExecContext", query, args...)
+	defer d.logQueryAndSendMetrics(time.Now(), "ExecContext", query, args...)
 	return d.DB.ExecContext(ctx, query, args...)
 }
 
 func (d *DB) Prepare(query string) (*sql.Stmt, error) {
-	defer d.logQuery(time.Now(), "Prepare", query)
+	defer d.logQueryAndSendMetrics(time.Now(), "Prepare", query)
 	return d.DB.Prepare(query)
 }
 
@@ -128,7 +128,7 @@ type Tx struct {
 	metrics Metrics
 }
 
-func (t *Tx) logQuery(start time.Time, queryType, query string, args ...interface{}) {
+func (t *Tx) logQueryAndSendMetrics(start time.Time, queryType, query string, args ...interface{}) {
 	duration := time.Since(start).Milliseconds()
 
 	t.logger.Debug(&Log{
@@ -143,42 +143,42 @@ func (t *Tx) logQuery(start time.Time, queryType, query string, args ...interfac
 }
 
 func (t *Tx) Query(query string, args ...interface{}) (*sql.Rows, error) {
-	defer t.logQuery(time.Now(), "TxQuery", query, args...)
+	defer t.logQueryAndSendMetrics(time.Now(), "TxQuery", query, args...)
 	return t.Tx.Query(query, args...)
 }
 
 func (t *Tx) QueryRow(query string, args ...interface{}) *sql.Row {
-	defer t.logQuery(time.Now(), "TxQueryRow", query, args...)
+	defer t.logQueryAndSendMetrics(time.Now(), "TxQueryRow", query, args...)
 	return t.Tx.QueryRow(query, args...)
 }
 
 func (t *Tx) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
-	defer t.logQuery(time.Now(), "TxQueryRowContext", query, args...)
+	defer t.logQueryAndSendMetrics(time.Now(), "TxQueryRowContext", query, args...)
 	return t.Tx.QueryRowContext(ctx, query, args...)
 }
 
 func (t *Tx) Exec(query string, args ...interface{}) (sql.Result, error) {
-	defer t.logQuery(time.Now(), "TxExec", query, args...)
+	defer t.logQueryAndSendMetrics(time.Now(), "TxExec", query, args...)
 	return t.Tx.Exec(query, args...)
 }
 
 func (t *Tx) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	defer t.logQuery(time.Now(), "TxExecContext", query, args...)
+	defer t.logQueryAndSendMetrics(time.Now(), "TxExecContext", query, args...)
 	return t.Tx.ExecContext(ctx, query, args...)
 }
 
 func (t *Tx) Prepare(query string) (*sql.Stmt, error) {
-	defer t.logQuery(time.Now(), "TxPrepare", query)
+	defer t.logQueryAndSendMetrics(time.Now(), "TxPrepare", query)
 	return t.Tx.Prepare(query)
 }
 
 func (t *Tx) Commit() error {
-	defer t.logQuery(time.Now(), "TxCommit", "COMMIT")
+	defer t.logQueryAndSendMetrics(time.Now(), "TxCommit", "COMMIT")
 	return t.Tx.Commit()
 }
 
 func (t *Tx) Rollback() error {
-	defer t.logQuery(time.Now(), "TxRollback", "ROLLBACK")
+	defer t.logQueryAndSendMetrics(time.Now(), "TxRollback", "ROLLBACK")
 	return t.Tx.Rollback()
 }
 


### PR DESCRIPTION
Closes #906 

There is one specific function that is common across all datasources that is used to log the debug level logs and send metrics across the datasources. I have changed their names to one consistent name.

NOTE: FileSystem's methods' naming has not been modified, as there are open pull request on the it's implementation right now. Changing function naming can cause errors and failure in whichever codes merges afterwards. 