### PR TITLE
change MkDirAll to ModePerm

### DIFF
--- a/pkg/gofr/file/zip.go
+++ b/pkg/gofr/file/zip.go
@@ -61,7 +61,7 @@ func (z *Zip) CreateLocalCopies(dest string) error {
 		destPath := filepath.Join(dest, zf.name)
 
 		if zf.isDir {
-			err := os.MkdirAll(destPath, os.ModeDir)
+			err := os.MkdirAll(destPath, os.ModePerm)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Changed MkDirAll file permissions to `os.ModePerm` or (0777) from os.ModeDir(d)

Closes #971 