### PR TITLE
refactor: reduce cognitive complexity

### DIFF
--- a/pkg/gofr/cmd/request.go
+++ b/pkg/gofr/cmd/request.go
@@ -109,19 +109,20 @@ func (r *Request) Bind(i interface{}) error {
 	for k, v := range r.params {
 		f := s.FieldByName(k)
 		// A Value can be changed only if it is addressable and not unexported struct field
-		if f.IsValid() && f.CanSet() {
-			//nolint:exhaustive // no need to add other cases
-			switch f.Kind() {
-			case reflect.String:
-				f.SetString(v)
-			case reflect.Bool:
-				if v == trueString {
-					f.SetBool(true)
-				}
-			case reflect.Int:
-				n, _ := strconv.Atoi(v)
-				f.SetInt(int64(n))
+		if !f.IsValid() || !f.CanSet() {
+			continue
+		}
+		//nolint:exhaustive // no need to add other cases
+		switch f.Kind() {
+		case reflect.String:
+			f.SetString(v)
+		case reflect.Bool:
+			if v == trueString {
+				f.SetBool(true)
 			}
+		case reflect.Int:
+			n, _ := strconv.Atoi(v)
+			f.SetInt(int64(n))
 		}
 	}
 

--- a/pkg/gofr/cmd/request.go
+++ b/pkg/gofr/cmd/request.go
@@ -101,23 +101,26 @@ func (r *Request) Bind(i interface{}) error {
 	ps := reflect.ValueOf(i)
 	// struct
 	s := ps.Elem()
-	if s.Kind() == reflect.Struct {
-		for k, v := range r.params {
-			f := s.FieldByName(k)
-			// A Value can be changed only if it is addressable and not unexported struct field
-			if f.IsValid() && f.CanSet() {
-				//nolint:exhaustive // no need to add other cases
-				switch f.Kind() {
-				case reflect.String:
-					f.SetString(v)
-				case reflect.Bool:
-					if v == trueString {
-						f.SetBool(true)
-					}
-				case reflect.Int:
-					n, _ := strconv.Atoi(v)
-					f.SetInt(int64(n))
+
+	if s.Kind() != reflect.Struct {
+		return nil
+	}
+
+	for k, v := range r.params {
+		f := s.FieldByName(k)
+		// A Value can be changed only if it is addressable and not unexported struct field
+		if f.IsValid() && f.CanSet() {
+			//nolint:exhaustive // no need to add other cases
+			switch f.Kind() {
+			case reflect.String:
+				f.SetString(v)
+			case reflect.Bool:
+				if v == trueString {
+					f.SetBool(true)
 				}
+			case reflect.Int:
+				n, _ := strconv.Atoi(v)
+				f.SetInt(int64(n))
 			}
 		}
 	}


### PR DESCRIPTION
## Pull Request Template

**Description:**

- Reduce Request.Bind cognitive complexity to 12
- Closes #998 
- Previously the reflect.Struct check was nested, increasing the Cognitive Complexity to 16. Refactoring the code to check this beforehand makes the Cognitive Complexity 12
- Functionality is kept same

**Checklist:**

- [x] I have formatted my code using `goimport` and `golangci-lint`.
- [x] All new code is covered by unit tests.
- [x] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.