### PR TITLE
Making Traces configurable to improve performance

### DIFF
--- a/examples/http-server/configs/.env
+++ b/examples/http-server/configs/.env
@@ -1,14 +1,3 @@
 APP_NAME=sample-api
 HTTP_PORT=9000
 
-REDIS_HOST=localhost
-REDIS_PORT=2002
-
-DB_HOST=localhost
-DB_USER=root
-DB_PASSWORD=password
-DB_NAME=test
-DB_PORT=2001
-DB_DIALECT=mysql
-
-TRACE_EXPORTER=gofr

--- a/examples/http-server/configs/.env
+++ b/examples/http-server/configs/.env
@@ -1,3 +1,12 @@
 APP_NAME=sample-api
 HTTP_PORT=9000
 
+REDIS_HOST=localhost
+REDIS_PORT=2002
+
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=password
+DB_NAME=test
+DB_PORT=2001
+DB_DIALECT=mysql

--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -33,6 +33,8 @@ func main() {
 }
 
 func HelloHandler(c *gofr.Context) (interface{}, error) {
+	defer c.Trace("HelloWorld").End()
+
 	name := c.Param("name")
 	if name == "" {
 		c.Log("Name came empty")

--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -18,7 +18,7 @@ func main() {
 	// Create a new application
 	a := gofr.New()
 
-	//HTTP service with default health check endpoint
+	// HTTP service with default health check endpoint
 	a.AddHTTPService("anotherService", "http://localhost:9000")
 
 	// Add all the routes
@@ -77,7 +77,7 @@ func TraceHandler(c *gofr.Context) (interface{}, error) {
 	}
 	wg.Wait()
 
-	//Call to Another service
+	// Call to Another service
 	resp, err := c.GetHTTPService("anotherService").Get(c, "redis", nil)
 	if err != nil {
 		return nil, err

--- a/examples/http-server/main_test.go
+++ b/examples/http-server/main_test.go
@@ -39,11 +39,12 @@ func TestIntegration_SimpleAPIServer(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		req, _ := http.NewRequest(http.MethodGet, host+tc.path, nil)
+		req, _ := http.NewRequest(http.MethodGet, host+tc.path, http.NoBody)
 		req.Header.Set("content-type", "application/json")
 
 		c := http.Client{}
 		resp, err := c.Do(req)
+		defer resp.Body.Close()
 
 		var data = struct {
 			Data interface{} `json:"data"`
@@ -93,7 +94,7 @@ func TestIntegration_SimpleAPIServer_Errors(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		req, _ := http.NewRequest(http.MethodGet, host+tc.path, nil)
+		req, _ := http.NewRequest(http.MethodGet, host+tc.path, http.NoBody)
 		req.Header.Set("content-type", "application/json")
 
 		c := http.Client{}
@@ -126,11 +127,11 @@ func TestIntegration_SimpleAPIServer_Health(t *testing.T) {
 		statusCode int
 	}{
 		{"health handler", "/.well-known/health", http.StatusOK}, // Health check should be added by the framework.
-		{"favicon handler", "/favicon.ico", http.StatusOK},       //Favicon should be added by the framework.
+		{"favicon handler", "/favicon.ico", http.StatusOK},       // Favicon should be added by the framework.
 	}
 
 	for i, tc := range tests {
-		req, _ := http.NewRequest(http.MethodGet, host+tc.path, nil)
+		req, _ := http.NewRequest(http.MethodGet, host+tc.path, http.NoBody)
 		req.Header.Set("content-type", "application/json")
 
 		c := http.Client{}

--- a/examples/http-server/main_test.go
+++ b/examples/http-server/main_test.go
@@ -44,7 +44,6 @@ func TestIntegration_SimpleAPIServer(t *testing.T) {
 
 		c := http.Client{}
 		resp, err := c.Do(req)
-		defer resp.Body.Close()
 
 		var data = struct {
 			Data interface{} `json:"data"`
@@ -67,6 +66,9 @@ func TestIntegration_SimpleAPIServer(t *testing.T) {
 }
 
 func TestIntegration_SimpleAPIServer_Errors(t *testing.T) {
+	go main()
+	time.Sleep(100 * time.Millisecond)
+
 	tests := []struct {
 		desc       string
 		path       string
@@ -94,7 +96,7 @@ func TestIntegration_SimpleAPIServer_Errors(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		req, _ := http.NewRequest(http.MethodGet, host+tc.path, http.NoBody)
+		req, err := http.NewRequest(http.MethodGet, host+tc.path, nil)
 		req.Header.Set("content-type", "application/json")
 
 		c := http.Client{}
@@ -121,6 +123,8 @@ func TestIntegration_SimpleAPIServer_Errors(t *testing.T) {
 }
 
 func TestIntegration_SimpleAPIServer_Health(t *testing.T) {
+	go main()
+	time.Sleep(100 * time.Millisecond)
 	tests := []struct {
 		desc       string
 		path       string
@@ -131,7 +135,7 @@ func TestIntegration_SimpleAPIServer_Health(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		req, _ := http.NewRequest(http.MethodGet, host+tc.path, http.NoBody)
+		req, _ := http.NewRequest(http.MethodGet, host+tc.path, nil)
 		req.Header.Set("content-type", "application/json")
 
 		c := http.Client{}

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -384,17 +384,6 @@ func (a *App) Migrate(migrationsMap map[int64]migration.Migrate) {
 }
 
 func (a *App) initTracer() {
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(a.container.GetAppName()),
-		)),
-		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(traceRatio))),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
-	otel.SetErrorHandler(&otelErrorHandler{logger: a.container.Logger})
-
 	traceExporter := a.Config.Get("TRACE_EXPORTER")
 	tracerURL := a.Config.Get("TRACER_URL")
 
@@ -405,6 +394,17 @@ func (a *App) initTracer() {
 	if !isValidConfig(a.Logger(), traceExporter, tracerURL, tracerHost, tracerPort) {
 		return
 	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithResource(resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceNameKey.String(a.container.GetAppName()),
+		)),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(traceRatio))),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	otel.SetErrorHandler(&otelErrorHandler{logger: a.container.Logger})
 
 	exporter, err := a.getExporter(traceExporter, tracerHost, tracerPort, tracerURL)
 

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -39,7 +39,7 @@ const (
 	shutDownTimeout        = 30 * time.Second
 	gofrTraceExporter      = "gofr"
 	gofrTracerURL          = "https://tracer.gofr.dev"
-	traceRatio             = 0.1
+	fullTrace              = 1
 )
 
 // App is the main application in the GoFr framework.
@@ -386,6 +386,11 @@ func (a *App) Migrate(migrationsMap map[int64]migration.Migrate) {
 func (a *App) initTracer() {
 	traceExporter := a.Config.Get("TRACE_EXPORTER")
 	tracerURL := a.Config.Get("TRACER_URL")
+
+	traceRatio, _ := strconv.ParseFloat(a.Config.Get("TRACER_RATIO"), 64)
+	if traceRatio == 0 {
+		traceRatio = fullTrace
+	}
 
 	// deprecated : tracer_host and tracer_port are deprecated and will be removed in upcoming versions.
 	tracerHost := a.Config.Get("TRACER_HOST")

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -39,6 +39,7 @@ const (
 	shutDownTimeout        = 30 * time.Second
 	gofrTraceExporter      = "gofr"
 	gofrTracerURL          = "https://tracer.gofr.dev"
+	traceRatio             = 0.1
 )
 
 // App is the main application in the GoFr framework.
@@ -388,6 +389,7 @@ func (a *App) initTracer() {
 			semconv.SchemaURL,
 			semconv.ServiceNameKey.String(a.container.GetAppName()),
 		)),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(traceRatio))),
 	)
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))

--- a/pkg/gofr/http/middleware/config.go
+++ b/pkg/gofr/http/middleware/config.go
@@ -33,7 +33,7 @@ func GetConfigs(c config.Config) map[string]string {
 
 	for _, v := range allowTracers {
 		if val := c.Get(v); val != "" {
-			middlewareConfigs[convertHeaderNames(v)] = val
+			middlewareConfigs[v] = val
 		}
 	}
 

--- a/pkg/gofr/http/middleware/config.go
+++ b/pkg/gofr/http/middleware/config.go
@@ -20,7 +20,18 @@ func GetConfigs(c config.Config) map[string]string {
 		"ACCESS_CONTROL_MAX_AGE",
 	}
 
+	allowTracers := []string{
+		"TRACE_EXPORTER",
+		"TRACER_URL",
+	}
+
 	for _, v := range allowedCORSHeaders {
+		if val := c.Get(v); val != "" {
+			middlewareConfigs[convertHeaderNames(v)] = val
+		}
+	}
+
+	for _, v := range allowTracers {
 		if val := c.Get(v); val != "" {
 			middlewareConfigs[convertHeaderNames(v)] = val
 		}

--- a/pkg/gofr/http/middleware/logger_test.go
+++ b/pkg/gofr/http/middleware/logger_test.go
@@ -141,15 +141,15 @@ func testUnknownPanicHandler(w http.ResponseWriter, _ *http.Request) {
 
 func TestRequestLog_PrettyPrint(t *testing.T) {
 	rl := &RequestLog{
-		TraceID:      "7e5c0e9a58839071d4d006dd1d0f4f3a",
-		SpanID:       "b19d9aa6323b29bb",
-		StartTime:    "2024-04-16T13:34:35.761893+05:30",
-		ResponseTime: 1432,
-		Method:       "GET",
-		UserAgent:    "",
-		IP:           "[::1]:59614",
-		URI:          "/test",
-		Response:     200,
+		CorrelationID: "7e5c0e9a58839071d4d006dd1d0f4f3a",
+		SpanID:        "b19d9aa6323b29bb",
+		StartTime:     "2024-04-16T13:34:35.761893+05:30",
+		ResponseTime:  1432,
+		Method:        "GET",
+		UserAgent:     "",
+		IP:            "[::1]:59614",
+		URI:           "/test",
+		Response:      200,
 	}
 	w := new(bytes.Buffer)
 	rl.PrettyPrint(w)

--- a/pkg/gofr/http_server.go
+++ b/pkg/gofr/http_server.go
@@ -28,6 +28,7 @@ func newHTTPServer(c *container.Container, port int, middlewareConfigs map[strin
 	if middlewareConfigs != nil {
 		traceExporter, validexporter := middlewareConfigs["TRACE_EXPORTER"]
 		_, validurl := middlewareConfigs["TRACE_URL"]
+
 		if !validurl {
 			if traceExporter == "gofr" {
 				validurl = true

--- a/pkg/gofr/http_server.go
+++ b/pkg/gofr/http_server.go
@@ -26,8 +26,13 @@ func newHTTPServer(c *container.Container, port int, middlewareConfigs map[strin
 	wsManager := websocket.New()
 
 	if middlewareConfigs != nil {
-		_, validexporter := middlewareConfigs["TRACE_EXPORTER"]
+		traceExporter, validexporter := middlewareConfigs["TRACE_EXPORTER"]
 		_, validurl := middlewareConfigs["TRACE_URL"]
+		if !validurl {
+			if traceExporter == "gofr" {
+				validurl = true
+			}
+		}
 
 		if validexporter && validurl {
 			r.Use(middleware.Tracer)


### PR DESCRIPTION
**Description:**

-   Idea is to make traces configurable to avoid unnecessary overhead when configs of traces are not provided by the user.
-   This solves the performance of GoFr while handling such request.
-   This PR also introduces sampling to allow user to set the level of tracing they require through the configs.
-    For requests with tracing disabled, correlation id is generated through `github.com/google/uuid`

**Checklist:**

-   [ ] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [ ] All new code is covered by unit tests.
-   [ ] This PR does not decrease the overall code coverage.
-   [ ] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

