### PR TITLE
Introducing GoFr Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ GoFr is an opinionated microservice development framework.</b></p>
 <a href="https://goreportcard.com/report/gofr.dev"><img src="https://goreportcard.com/badge/gofr.dev"></a>
 <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"></a>
 <a href="https://discord.gg/wsaSkQTdgq"><img src="https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat" /></a>
+<a href="https://gurubase.io/g/gofr"><img src="https://img.shields.io/badge/Gurubase-Ask%20GoFr%20Guru-006BFF" /></a>
 </div>
 
 Listed in [CNCF Landscape](https://landscape.cncf.io/?selected=go-fr).


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [GoFr Guru](https://gurubase.io/g/gofr) to Gurubase. GoFr Guru uses the data from this repo and data from the [docs](https://gofr.dev/) to answer questions by leveraging the LLM.

In this PR, I showcased the "GoFr Guru", which highlights that GoFr now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable GoFr Guru in Gurubase, just let me know that's totally fine.