### PR TITLE
Release v1.27.1

### DIFF
--- a/pkg/gofr/datasource/pubsub/google/google_test.go
+++ b/pkg/gofr/datasource/pubsub/google/google_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"gofr.dev/pkg/gofr/datasource/pubsub"
 	"gofr.dev/pkg/gofr/logging"
 	"gofr.dev/pkg/gofr/testutil"
 )
@@ -174,9 +175,9 @@ func Test_validateConfigs(t *testing.T) {
 }
 
 func TestGoogleClient_CloseReturnsError(t *testing.T) {
-	// client already present
 	g := &googleClient{
-		client: getGoogleClient(t),
+		client:      getGoogleClient(t),
+		receiveChan: make(map[string]chan *pubsub.Message),
 	}
 
 	err := g.Close()
@@ -184,7 +185,7 @@ func TestGoogleClient_CloseReturnsError(t *testing.T) {
 	require.NoError(t, err)
 
 	// client empty
-	g = &googleClient{}
+	g = &googleClient{receiveChan: make(map[string]chan *pubsub.Message)}
 
 	err = g.Close()
 

--- a/pkg/gofr/version/version.go
+++ b/pkg/gofr/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Framework = "v1.27.0"
+const Framework = "v1.27.1"


### PR DESCRIPTION
# Release v1.27.1

##  🛠️ Fixes
### Fix Google Pubsub Panic
The callback function for the Google client Subscribe function was configured to fetch one message per Subscribe call. Still, at times the message was being sent to a closed channel causing unexpected behaviour. Fixed the issue of receiving messages on a channel that closes only on application shutdown.