### PR TITLE
En/headers support

### DIFF
--- a/docs/references/context/page.md
+++ b/docs/references/context/page.md
@@ -82,6 +82,13 @@ parts of the request.
     values := ctx.Request.Params("category")
     // values = []string{"books", "electronics", "tech"}
   ```
+  
+- `Header(string)` - to access the value of a specific request header.
+  ```go
+    // Example: Request contains the header: Content-Type: application/json
+   contentType := ctx.Request.Header("Content-Type")
+   // contentType = "application/json"
+  ```
 
 ## Accessing dependencies
 

--- a/pkg/gofr/cmd/request.go
+++ b/pkg/gofr/cmd/request.go
@@ -96,6 +96,8 @@ func (r *Request) Params(key string) []string {
 	return strings.Split(value, ",")
 }
 
+func (*Request) Header(string) string { return "" }
+
 func (r *Request) Bind(i interface{}) error {
 	// pointer to struct - addressable
 	ps := reflect.ValueOf(i)

--- a/pkg/gofr/cron.go
+++ b/pkg/gofr/cron.go
@@ -390,3 +390,5 @@ func (noopRequest) Bind(interface{}) error {
 func (noopRequest) Params(string) []string {
 	return nil
 }
+
+func (noopRequest) Header(string) string { return "" }

--- a/pkg/gofr/datasource/pubsub/message.go
+++ b/pkg/gofr/datasource/pubsub/message.go
@@ -113,3 +113,5 @@ func (*Message) HostName() string {
 func (*Message) Params(string) []string {
 	return nil
 }
+
+func (*Message) Header(string) string { return "" }

--- a/pkg/gofr/http/request.go
+++ b/pkg/gofr/http/request.go
@@ -53,6 +53,11 @@ func (r *Request) PathParam(key string) string {
 	return r.pathParams[key]
 }
 
+// Header returns the value associated with the `key`, from the request headers.
+func (r *Request) Header(key string) string {
+	return r.req.Header.Get(strings.ToLower(key))
+}
+
 // Bind parses the request body and binds it to the provided interface.
 func (r *Request) Bind(i interface{}) error {
 	v := r.req.Header.Get("content-type")

--- a/pkg/gofr/http/request_test.go
+++ b/pkg/gofr/http/request_test.go
@@ -272,3 +272,21 @@ func TestBind_FormURLEncoded(t *testing.T) {
 		t.Errorf("Bind error. Got: %v", x)
 	}
 }
+
+func TestHeader(t *testing.T) {
+	// Create a new HTTP request with headers
+	httpReq := httptest.NewRequest(http.MethodGet, "/abc", http.NoBody)
+	httpReq.Header.Set("random-header", "abc123")
+
+	// Create a GoFr Request from the HTTP request
+	req := NewRequest(httpReq)
+
+	if req.Header("random-header") != "abc123" {
+		t.Error("Failed to retrieve the random-header")
+	}
+
+	// Test a header that doesn't exist
+	if req.Header("Non-Existent-Header") != "" {
+		t.Error("Expected an empty string for a non-existent header")
+	}
+}

--- a/pkg/gofr/request.go
+++ b/pkg/gofr/request.go
@@ -14,4 +14,5 @@ type Request interface {
 	Bind(interface{}) error
 	HostName() string
 	Params(string) []string
+	Header(string) string
 }

--- a/pkg/gofr/websocket/websocket.go
+++ b/pkg/gofr/websocket/websocket.go
@@ -141,3 +141,5 @@ func (ws *Manager) CloseConnection(connID string) {
 func (*Connection) Params(string) []string {
 	return nil
 }
+
+func (*Connection) Header(string) string { return "" }


### PR DESCRIPTION



**Description:**

-   Resolves #1209 
-   Add **Header(key string)** method on the request interface to access the value of a specific request header

### Example:
 ```go
    // Example: Request contains the header: Content-Type: application/json
   contentType := ctx.Request.Header("Content-Type")
   // contentType = "application/json"
  ```


**Checklist:**

-   [ ] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [ ] All new code is covered by unit tests.
-   [ ] This PR does not decrease the overall code coverage.
-   [ ] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

