### PR TITLE
WIP | ISSUE-1183 | refactor: add context support

### DIFF
--- a/pkg/gofr/migration/datasource.go
+++ b/pkg/gofr/migration/datasource.go
@@ -1,6 +1,10 @@
 package migration
 
-import "gofr.dev/pkg/gofr/container"
+import (
+	"context"
+
+	"gofr.dev/pkg/gofr/container"
+)
 
 type Datasource struct {
 	// TODO Logger should not be embedded rather it should be a field.
@@ -17,22 +21,22 @@ type Datasource struct {
 
 // It is a base implementation for migration manager, on this other database drivers have been wrapped.
 
-func (*Datasource) checkAndCreateMigrationTable(*container.Container) error {
+func (*Datasource) checkAndCreateMigrationTable(context.Context, *container.Container) error {
 	return nil
 }
 
-func (*Datasource) getLastMigration(*container.Container) int64 {
+func (*Datasource) getLastMigration(context.Context, *container.Container) int64 {
 	return 0
 }
 
-func (*Datasource) beginTransaction(*container.Container) transactionData {
+func (*Datasource) beginTransaction(context.Context, *container.Container) transactionData {
 	return transactionData{}
 }
 
-func (*Datasource) commitMigration(c *container.Container, data transactionData) error {
+func (*Datasource) commitMigration(ctx context.Context, c *container.Container, data transactionData) error {
 	c.Infof("Migration %v ran successfully", data.MigrationNumber)
 
 	return nil
 }
 
-func (*Datasource) rollback(*container.Container, transactionData) {}
+func (*Datasource) rollback(context.Context, *container.Container, transactionData) {}

--- a/pkg/gofr/migration/interface.go
+++ b/pkg/gofr/migration/interface.go
@@ -66,11 +66,11 @@ type Mongo interface {
 // keeping the migrator interface unexported as, right now it is not being implemented directly, by the externalDB drivers.
 // keeping the implementations for externalDB at one place such that if any change in migration logic, we would change directly here.
 type migrator interface {
-	checkAndCreateMigrationTable(c *container.Container) error
-	getLastMigration(c *container.Container) int64
+	checkAndCreateMigrationTable(ctx context.Context, c *container.Container) error
+	getLastMigration(ctx context.Context, c *container.Container) int64
 
-	beginTransaction(c *container.Container) transactionData
+	beginTransaction(ctx context.Context, c *container.Container) transactionData
 
-	commitMigration(c *container.Container, data transactionData) error
-	rollback(c *container.Container, data transactionData)
+	commitMigration(ctx context.Context, c *container.Container, data transactionData) error
+	rollback(ctx context.Context, c *container.Container, data transactionData)
 }


### PR DESCRIPTION
### Issue
Closes: https://github.com/gofr-dev/gofr/issues/1183


**Description:**

- Refactored the migrator interface to include context.Context as the first parameter in all methods for improved control over cancellations and timeouts.
- Updated the Run function and related migrator implementations (sqlMigrator and others) to align with the new interface.
- Enhanced error handling, logging, and context propagation throughout the migration flow.
- This PR addresses internal design improvements to ensure better scalability and maintainability.


**Breaking Changes (if applicable):**

- The migrator interface has changed, requiring all methods to accept context.Context as the first parameter.
- Any custom implementations of the migrator interface must be updated to conform to the new signature.
- Users relying on the previous interface in their custom implementations may experience compilation errors until updated.

**Additional Information:**

-   This PR does not introduce any new external dependencies.

**Checklist:**

-   [ ] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [ ] All new code is covered by unit tests.
-   [ ] This PR does not decrease the overall code coverage.
-   [ ] I have reviewed the code comments and documentation for clarity.


