### PR TITLE
Decrease log level for 4xx HTTP errors : alternative option

### DIFF
--- a/docs/advanced-guide/gofr-errors/page.md
+++ b/docs/advanced-guide/gofr-errors/page.md
@@ -44,6 +44,8 @@ dbErr2 := datasource.ErrorDB{Message : "database connection timed out!"}
 GoFr's error structs implements an interface with `Error() string` and `StatusCode() int` methods, users can override the 
 status code by implementing it for their custom error.
 
+You can optionally define a log level for your error with the `LogLevel() logging.Level` methods
+
 #### Usage:
 ```go
 type customError struct {
@@ -56,5 +58,9 @@ func (c customError) Error() string {
 
 func (c customError) StatusCode() int {
 	return http.StatusMethodNotAllowed
+}
+
+func (c customError) LogLevel() logging.Level {
+	return logging.WARN
 }
 ```

--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -158,28 +158,21 @@ func (h handler) logError(traceID string, err error) {
 	}
 }
 
-// Helper function to check if the error is one of the known HTTP Error types.
+//nolint:govet // We are using this function to check if the error is of type HTTP error.
 func isHTTPError(err error) bool {
-	var (
-		entityNotFoundError     gofrHTTP.ErrorEntityNotFound
-		entityAlreadyExistError gofrHTTP.ErrorEntityAlreadyExist
-		invalidParamError       gofrHTTP.ErrorInvalidParam
-		missingParamError       gofrHTTP.ErrorMissingParam
-		invalidRouteError       gofrHTTP.ErrorInvalidRoute
-		requestTimeoutError     gofrHTTP.ErrorRequestTimeout
-	)
-
-	switch {
-	case errors.Is(err, entityNotFoundError),
-		errors.Is(err, entityAlreadyExistError),
-		errors.Is(err, invalidParamError),
-		errors.Is(err, missingParamError),
-		errors.Is(err, invalidRouteError),
-		errors.Is(err, requestTimeoutError):
-		return true
-	default:
-		return false
+	httpErrors := []error{
+		&gofrHTTP.ErrorEntityAlreadyExist{},
+		&gofrHTTP.ErrorEntityNotFound{},
+		&gofrHTTP.ErrorInvalidParam{},
+		&gofrHTTP.ErrorMissingParam{},
 	}
+	for _, knownErr := range httpErrors {
+		if errors.As(err, &knownErr) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func handleWebSocketUpgrade(r *http.Request) {

--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -150,7 +150,6 @@ func (h handler) logError(traceID string, err error) {
 	if err != nil {
 		errorLog := &ErrorLogEntry{TraceID: traceID, Error: err.Error()}
 
-		// Check if the error is one of the known types
 		if isHTTPError(err) {
 			h.container.Logger.Info(errorLog)
 		} else {
@@ -161,24 +160,26 @@ func (h handler) logError(traceID string, err error) {
 
 // Helper function to check if the error is one of the known HTTP Error types.
 func isHTTPError(err error) bool {
-	// Define all known error types explicitly
+	var (
+		entityNotFoundError     gofrHTTP.ErrorEntityNotFound
+		entityAlreadyExistError gofrHTTP.ErrorEntityAlreadyExist
+		invalidParamError       gofrHTTP.ErrorInvalidParam
+		missingParamError       gofrHTTP.ErrorMissingParam
+		invalidRouteError       gofrHTTP.ErrorInvalidRoute
+		requestTimeoutError     gofrHTTP.ErrorRequestTimeout
+	)
+
 	switch {
-	case isSpecificError[*gofrHTTP.ErrorEntityNotFound](err),
-		isSpecificError[*gofrHTTP.ErrorEntityAlreadyExist](err),
-		isSpecificError[*gofrHTTP.ErrorInvalidParam](err),
-		isSpecificError[*gofrHTTP.ErrorMissingParam](err),
-		isSpecificError[*gofrHTTP.ErrorInvalidRoute](err),
-		isSpecificError[*gofrHTTP.ErrorRequestTimeout](err):
+	case errors.Is(err, entityNotFoundError),
+		errors.Is(err, entityAlreadyExistError),
+		errors.Is(err, invalidParamError),
+		errors.Is(err, missingParamError),
+		errors.Is(err, invalidRouteError),
+		errors.Is(err, requestTimeoutError):
 		return true
 	default:
 		return false
 	}
-}
-
-// Generic function to match a specific error type using errors.As.
-func isSpecificError[T any](err error) bool {
-	var target T
-	return errors.As(err, &target)
 }
 
 func handleWebSocketUpgrade(r *http.Request) {

--- a/pkg/gofr/handler_test.go
+++ b/pkg/gofr/handler_test.go
@@ -36,6 +36,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			`{}`},
 		{"method is get, data is mil, error is not nil", http.MethodGet, nil, errTest, http.StatusInternalServerError,
 			`{"error":{"message":"some error"}}`},
+		{"method is get, data is mil, error is http error", http.MethodGet, nil, gofrHTTP.ErrorEntityNotFound{}, http.StatusNotFound,
+			`{"error":{"message":"No entity found with : "}}`},
 		{"method is post, data is nil and error is nil", http.MethodPost, "Created", nil, http.StatusCreated,
 			`{"data":"Created"}`},
 		{"method is delete, data is nil and error is nil", http.MethodDelete, nil, nil, http.StatusNoContent,

--- a/pkg/gofr/http/errors.go
+++ b/pkg/gofr/http/errors.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"gofr.dev/pkg/gofr/logging"
 )
 
 const alreadyExistsMessage = "entity already exists"
@@ -24,9 +26,12 @@ func (ErrorEntityNotFound) StatusCode() int {
 	return http.StatusNotFound
 }
 
-// ErrorEntityAlreadyExist represents an error for when entity is already present in the storage and we are trying to make duplicate entry.
-type ErrorEntityAlreadyExist struct {
+func (ErrorEntityNotFound) LogLevel() logging.Level {
+	return logging.INFO
 }
+
+// ErrorEntityAlreadyExist represents an error for when entity is already present in the storage and we are trying to make duplicate entry.
+type ErrorEntityAlreadyExist struct{}
 
 func (ErrorEntityAlreadyExist) Error() string {
 	return alreadyExistsMessage
@@ -34,6 +39,10 @@ func (ErrorEntityAlreadyExist) Error() string {
 
 func (ErrorEntityAlreadyExist) StatusCode() int {
 	return http.StatusConflict
+}
+
+func (ErrorEntityAlreadyExist) LogLevel() logging.Level {
+	return logging.WARN
 }
 
 // ErrorInvalidParam represents an error for invalid parameter values.
@@ -49,6 +58,10 @@ func (ErrorInvalidParam) StatusCode() int {
 	return http.StatusBadRequest
 }
 
+func (ErrorInvalidParam) LogLevel() logging.Level {
+	return logging.INFO
+}
+
 // ErrorMissingParam represents an error for missing parameters in a request.
 type ErrorMissingParam struct {
 	Params []string `json:"param,omitempty"`
@@ -56,6 +69,10 @@ type ErrorMissingParam struct {
 
 func (e ErrorMissingParam) Error() string {
 	return fmt.Sprintf("'%d' missing parameter(s): %s", len(e.Params), strings.Join(e.Params, ", "))
+}
+
+func (ErrorMissingParam) LogLevel() logging.Level {
+	return logging.INFO
 }
 
 func (ErrorMissingParam) StatusCode() int {
@@ -67,6 +84,10 @@ type ErrorInvalidRoute struct{}
 
 func (ErrorInvalidRoute) Error() string {
 	return "route not registered"
+}
+
+func (ErrorInvalidRoute) LogLevel() logging.Level {
+	return logging.INFO
 }
 
 func (ErrorInvalidRoute) StatusCode() int {
@@ -84,6 +105,10 @@ func (ErrorRequestTimeout) StatusCode() int {
 	return http.StatusRequestTimeout
 }
 
+func (ErrorRequestTimeout) LogLevel() logging.Level {
+	return logging.INFO
+}
+
 // ErrorPanicRecovery represents an error for request which panicked.
 type ErrorPanicRecovery struct{}
 
@@ -94,3 +119,26 @@ func (ErrorPanicRecovery) Error() string {
 func (ErrorPanicRecovery) StatusCode() int {
 	return http.StatusInternalServerError
 }
+
+func (ErrorPanicRecovery) LogLevel() logging.Level {
+	return logging.ERROR
+}
+
+// validate the errors satisfy the underlying interfaces they depend on.
+var (
+	_ statusCodeResponder = ErrorEntityNotFound{}
+	_ statusCodeResponder = ErrorEntityAlreadyExist{}
+	_ statusCodeResponder = ErrorInvalidParam{}
+	_ statusCodeResponder = ErrorMissingParam{}
+	_ statusCodeResponder = ErrorInvalidRoute{}
+	_ statusCodeResponder = ErrorRequestTimeout{}
+	_ statusCodeResponder = ErrorPanicRecovery{}
+
+	_ logging.LogLevelResponder = ErrorEntityNotFound{}
+	_ logging.LogLevelResponder = ErrorEntityAlreadyExist{}
+	_ logging.LogLevelResponder = ErrorInvalidParam{}
+	_ logging.LogLevelResponder = ErrorMissingParam{}
+	_ logging.LogLevelResponder = ErrorInvalidRoute{}
+	_ logging.LogLevelResponder = ErrorRequestTimeout{}
+	_ logging.LogLevelResponder = ErrorPanicRecovery{}
+)

--- a/pkg/gofr/logging/logger.go
+++ b/pkg/gofr/logging/logger.go
@@ -219,3 +219,21 @@ func checkIfTerminal(w io.Writer) bool {
 func (l *logger) ChangeLevel(level Level) {
 	l.level = level
 }
+
+// LogLevelResponder is an interface that provides a method to get the log level.
+type LogLevelResponder interface {
+	LogLevel() Level
+}
+
+// GetLogLevelForError returns the log level for the given error.
+// If the error implements [logLevelResponder], its log level is returned.
+// Otherwise, the default log level "error" is returned.
+func GetLogLevelForError(err error) Level {
+	level := ERROR
+
+	if e, ok := err.(LogLevelResponder); ok {
+		level = e.LogLevel()
+	}
+
+	return level
+}


### PR DESCRIPTION
## Pull Request Template

**Description:**

This PR is an alternative implementation of what was initiated with

- #1295
- #1298 

It goes further than #1298 as it allows defining the log level for any error, not only the HTTP errors

It also provides a way for user to provide a log level for their custom errors (See [docs/advanced-guide/gofr-errors/page.md](https://github.com/gofr-dev/gofr/blob/development/docs/advanced-guide/gofr-errors/page.md))

Fixes #1279
Replaces #1295
Replaces #1298

**Checklist:**

-   [X] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [X] All new code is covered by unit tests.
-   [X] This PR does not decrease the overall code coverage.
-   [X] I have reviewed the code comments and documentation for clarity.
