### PR TITLE
Added function SetPathParam for setting path parameters in HTTP requests

### DIFF
--- a/pkg/gofr/http/request.go
+++ b/pkg/gofr/http/request.go
@@ -179,3 +179,8 @@ func (r *Request) bindBinary(raw interface{}) error {
 
 	return nil
 }
+
+// SetPathParam sets URL path parameters for the given HTTP request.
+func SetPathParam(r *http.Request, prm map[string]string) *http.Request {
+	return mux.SetURLVars(r, prm)
+}


### PR DESCRIPTION
## Pull Request Template


**Description:**

-  Added a function SetPathParam to streamline the process of setting path parameters in HTTP requests. This function uses mux.SetURLVars to associate a map of key-value pairs as path parameters with an HTTP request.

-   Fixes Bug: can't test path params (#1350), which prevented efficient testing of path parameters in HTTP handlers.

-   The inability to set path parameters in test scenarios created significant challenges for unit testing API routes, especially when path parameters were critical for routing logic. By introducing the SetPathParam function, you can now inject path parameters into mock HTTP requests, facilitating more robust and reliable testing workflows.

**Checklist:**

-   [ ] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [ ] All new code is covered by unit tests.
-   [ ] This PR does not decrease the overall code coverage.
-   [ ] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

