### PR TITLE
enable canonicalheader linter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,7 @@ linters:
   enable:
     - asciicheck
     - bodyclose
+    - canonicalheader
     - copyloopvar
     - dogsled
     - dupl

--- a/pkg/gofr/context_test.go
+++ b/pkg/gofr/context_test.go
@@ -27,7 +27,7 @@ import (
 func Test_newContextSuccess(t *testing.T) {
 	httpRequest, err := http.NewRequestWithContext(context.Background(),
 		http.MethodPost, "/test", bytes.NewBufferString(`{"key":"value"}`))
-	httpRequest.Header.Set("content-type", "application/json")
+	httpRequest.Header.Set("Content-Type", "application/json")
 
 	if err != nil {
 		t.Fatalf("unable to create request with context %v", err)

--- a/pkg/gofr/datasource/solr/solr.go
+++ b/pkg/gofr/datasource/solr/solr.go
@@ -265,7 +265,7 @@ func (*Client) createRequest(ctx context.Context, method, url string, params map
 	}
 
 	if method != http.MethodGet {
-		req.Header.Add("content-type", "application/json")
+		req.Header.Add("Content-Type", "application/json")
 	}
 
 	q := req.URL.Query()

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -139,7 +139,7 @@ func TestGofr_ServerRoutes(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(tc.method, tc.target, http.NoBody)
 
-		r.Header.Set("content-type", "application/json")
+		r.Header.Set("Content-Type", "application/json")
 
 		g.httpServer.router.ServeHTTP(w, r)
 
@@ -785,7 +785,7 @@ func Test_APIKeyAuthMiddleware(t *testing.T) {
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		fmt.Sprintf("http://localhost:%d", port)+"/test", http.NoBody)
-	req.Header.Set("X-API-Key", "test-key")
+	req.Header.Set("X-Api-Key", "test-key")
 
 	// Send the request and check for successful response
 	resp, err := netClient.Do(req)

--- a/pkg/gofr/http/middleware/apikey_auth.go
+++ b/pkg/gofr/http/middleware/apikey_auth.go
@@ -28,7 +28,7 @@ func APIKeyAuthMiddleware(a APIKeyAuthProvider, apiKeys ...string) func(handler 
 				return
 			}
 
-			authKey := r.Header.Get("X-API-KEY")
+			authKey := r.Header.Get("X-Api-Key")
 			if authKey == "" {
 				http.Error(w, "Unauthorized: Authorization header missing", http.StatusUnauthorized)
 				return

--- a/pkg/gofr/http/middleware/apikey_auth_test.go
+++ b/pkg/gofr/http/middleware/apikey_auth_test.go
@@ -53,7 +53,7 @@ func Test_ApiKeyAuthMiddleware(t *testing.T) {
 	for i, tc := range testCases {
 		rr := httptest.NewRecorder()
 
-		req.Header.Set("X-API-KEY", tc.apiKey)
+		req.Header.Set("X-Api-Key", tc.apiKey)
 
 		provider := APIKeyAuthProvider{
 			ValidateFunc:                tc.validatorFunc,

--- a/pkg/gofr/http/request.go
+++ b/pkg/gofr/http/request.go
@@ -56,7 +56,7 @@ func (r *Request) PathParam(key string) string {
 
 // Bind parses the request body and binds it to the provided interface.
 func (r *Request) Bind(i any) error {
-	v := r.req.Header.Get("content-type")
+	v := r.req.Header.Get("Content-Type")
 	contentType := strings.Split(v, ";")[0]
 
 	switch contentType {
@@ -80,7 +80,7 @@ func (r *Request) Bind(i any) error {
 
 // HostName retrieves the hostname from the request.
 func (r *Request) HostName() string {
-	proto := r.req.Header.Get("X-forwarded-proto")
+	proto := r.req.Header.Get("X-Forwarded-Proto")
 	if proto == "" {
 		proto = "http"
 	}

--- a/pkg/gofr/http/request_test.go
+++ b/pkg/gofr/http/request_test.go
@@ -28,7 +28,7 @@ func TestParam(t *testing.T) {
 
 func TestBind(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/abc", strings.NewReader(`{"a": "b", "b": 5}`))
-	r.Header.Set("content-type", "application/json")
+	r.Header.Set("Content-Type", "application/json")
 	req := NewRequest(r)
 
 	x := struct {
@@ -202,7 +202,7 @@ func generateMultipartRequestZip(t *testing.T) *http.Request {
 
 	// Create a new HTTP request with the multipart data
 	req := httptest.NewRequest(http.MethodPost, "/upload", &buf)
-	req.Header.Set("content-type", writer.FormDataContentType())
+	req.Header.Set("Content-Type", writer.FormDataContentType())
 
 	return req
 }

--- a/pkg/gofr/service/new_test.go
+++ b/pkg/gofr/service/new_test.go
@@ -74,8 +74,8 @@ func TestHTTPService_createAndSendRequest(t *testing.T) {
 			assert.Equal(t, http.MethodPost, r.Method)
 			assert.Equal(t, "/test-path", r.URL.Path)
 			assert.Equal(t, tc.expQueryParam, r.URL.RawQuery)
-			assert.Contains(t, "value1", r.Header.Get("header1"))
-			assert.Contains(t, tc.expContentType, r.Header.Get("content-type"))
+			assert.Contains(t, "value1", r.Header.Get("Header1"))
+			assert.Contains(t, tc.expContentType, r.Header.Get("Content-Type"))
 			assert.Equal(t, string(tc.body), string(body))
 
 			w.WriteHeader(http.StatusOK)
@@ -145,7 +145,7 @@ func TestHTTPService_GetWithHeaders(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/test-path", r.URL.Path)
 		assert.Equal(t, "key=value&name=test", r.URL.RawQuery)
-		assert.Contains(t, "value1", r.Header.Get("header1"))
+		assert.Contains(t, "value1", r.Header.Get("Header1"))
 
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -226,7 +226,7 @@ func TestHTTPService_PutWithHeaders(t *testing.T) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Equal(t, "/test-path", r.URL.Path)
 		assert.Equal(t, "key=value&name=test", r.URL.RawQuery)
-		assert.Contains(t, "value1", r.Header.Get("header1"))
+		assert.Contains(t, "value1", r.Header.Get("Header1"))
 		assert.Contains(t, "Test Body", string(body))
 
 		w.WriteHeader(http.StatusOK)
@@ -308,7 +308,7 @@ func TestHTTPService_PatchWithHeaders(t *testing.T) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Equal(t, "/test-path", r.URL.Path)
 		assert.Equal(t, "key=value&name=test", r.URL.RawQuery)
-		assert.Contains(t, "value1", r.Header.Get("header1"))
+		assert.Contains(t, "value1", r.Header.Get("Header1"))
 		assert.Contains(t, "Test Body", string(body))
 
 		w.WriteHeader(http.StatusOK)
@@ -390,7 +390,7 @@ func TestHTTPService_PostWithHeaders(t *testing.T) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/test-path", r.URL.Path)
 		assert.Equal(t, "key=value&name=test", r.URL.RawQuery)
-		assert.Contains(t, "value1", r.Header.Get("header1"))
+		assert.Contains(t, "value1", r.Header.Get("Header1"))
 		assert.Contains(t, "Test Body", string(body))
 
 		w.WriteHeader(http.StatusOK)
@@ -469,7 +469,7 @@ func TestHTTPService_DeleteWithHeaders(t *testing.T) {
 
 		assert.Equal(t, http.MethodDelete, r.Method)
 		assert.Equal(t, "/test-path", r.URL.Path)
-		assert.Contains(t, "value1", r.Header.Get("header1"))
+		assert.Contains(t, "value1", r.Header.Get("Header1"))
 		assert.Contains(t, "Test Body", string(body))
 
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
- **ci: enable canonicalheader in golangci-lint**
- **chore: use canonical form for all HTTP headers**
