### PR TITLE
golangci: remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,8 +32,6 @@ linters-settings:
     min-complexity: 10
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
-  golint:
-    min-confidence: 0
   mnd:
     checks:
       - argument
@@ -50,8 +48,6 @@ linters-settings:
           - (gofr.dev/pkg/gofr/Logger).Errorf
   lll:
     line-length: 140
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
   nolintlint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,13 +94,13 @@ linters:
   enable:
     - asciicheck
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - err113
     - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
     - funlen
     - gci
     - gochecknoglobals


### PR DESCRIPTION
- **ci: remove deprecated linters from golangci**
- **ci: exportloopref was renamed to copyloopvar**
