### PR TITLE
subscribe kafka shouldn't commit before handler execute

### DIFF
--- a/pkg/gofr/datasource/pubsub/kafka/interfaces.go
+++ b/pkg/gofr/datasource/pubsub/kafka/interfaces.go
@@ -10,6 +10,7 @@ import (
 
 type Reader interface {
 	ReadMessage(ctx context.Context) (kafka.Message, error)
+	FetchMessage(ctx context.Context) (kafka.Message, error)
 	CommitMessages(ctx context.Context, msgs ...kafka.Message) error
 	Stats() kafka.ReaderStats
 	Close() error

--- a/pkg/gofr/datasource/pubsub/kafka/kafka.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka.go
@@ -191,7 +191,7 @@ func (k *kafkaClient) Subscribe(ctx context.Context, topic string) (*pubsub.Mess
 
 	// Read a single message from the topic
 	reader = k.reader[topic]
-	msg, err := reader.ReadMessage(ctx)
+	msg, err := reader.FetchMessage(ctx)
 
 	if err != nil {
 		k.logger.Errorf("failed to read message from kafka topic %s: %v", topic, err)

--- a/pkg/gofr/datasource/pubsub/kafka/kafka_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka_test.go
@@ -182,7 +182,7 @@ func TestKafkaClient_SubscribeSuccess(t *testing.T) {
 		Topic: "test",
 	}
 
-	mockReader.EXPECT().ReadMessage(gomock.Any()).
+	mockReader.EXPECT().FetchMessage(gomock.Any()).
 		Return(kafka.Message{Value: []byte(`hello`), Topic: "test"}, nil)
 	mockMetrics.EXPECT().IncrementCounter(gomock.Any(), "app_pubsub_subscribe_total_count", "topic", "test",
 		"consumer_group", gomock.Any())
@@ -250,7 +250,7 @@ func TestKafkaClient_SubscribeError(t *testing.T) {
 		metrics: mockMetrics,
 	}
 
-	mockReader.EXPECT().ReadMessage(gomock.Any()).
+	mockReader.EXPECT().FetchMessage(gomock.Any()).
 		Return(kafka.Message{}, errSub)
 	mockMetrics.EXPECT().IncrementCounter(gomock.Any(), "app_pubsub_subscribe_total_count",
 		"topic", "test", "consumer_group", k.config.ConsumerGroupID)

--- a/pkg/gofr/datasource/pubsub/kafka/mock_interfaces.go
+++ b/pkg/gofr/datasource/pubsub/kafka/mock_interfaces.go
@@ -73,6 +73,21 @@ func (mr *MockReaderMockRecorder) CommitMessages(ctx any, msgs ...any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitMessages", reflect.TypeOf((*MockReader)(nil).CommitMessages), varargs...)
 }
 
+// FetchMessage mocks base method.
+func (m *MockReader) FetchMessage(ctx context.Context) (kafka.Message, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchMessage", ctx)
+	ret0, _ := ret[0].(kafka.Message)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchMessage indicates an expected call of FetchMessage.
+func (mr *MockReaderMockRecorder) FetchMessage(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchMessage", reflect.TypeOf((*MockReader)(nil).FetchMessage), ctx)
+}
+
 // ReadMessage mocks base method.
 func (m *MockReader) ReadMessage(ctx context.Context) (kafka.Message, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Pull Request Template


**Description:**

When calling kafka-go ReadMessage, it include commit message behavior for line
`pkg/gofr/datasource/pubsub/kafka/kafka.go:168`. After method done, Committer.Commit is not useful.
It should fetch first then commit later.


**Additional Information:**

Below is kafka-go source code
```go
func (r *Reader) ReadMessage(ctx context.Context) (Message, error) {
	m, err := r.FetchMessage(ctx)
	if err != nil {
		return Message{}, fmt.Errorf("fetching message: %w", err)
	}

	if r.useConsumerGroup() {
		if err := r.CommitMessages(ctx, m); err != nil {
			return Message{}, fmt.Errorf("committing message: %w", err)
		}
	}

	return m, nil
}
```

**Checklist:**

-   [v] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [v] All new code is covered by unit tests.
-   [v] This PR does not decrease the overall code coverage.
-   [v] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

