### PR TITLE
Fix: Propagation of metrics to create gRPC Client

### DIFF
--- a/docs/advanced-guide/grpc/page.md
+++ b/docs/advanced-guide/grpc/page.md
@@ -159,7 +159,7 @@ This command leverages the `gofr-cli` to generate a `{serviceName}_client.go` fi
 // gRPC Handler with context support
 func {serviceMethod}(ctx *gofr.Context) (*{serviceResponse}, error) {
 // Create the gRPC client
-srv, err := New{serviceName}GoFrClient("your-grpc-server-host", app)
+srv, err := New{serviceName}GoFrClient("your-grpc-server-host", ctx.Metrics())
 if err != nil {
 return nil, err
 }

--- a/examples/grpc/grpc-client/client/hello_client.go
+++ b/examples/grpc/grpc-client/client/hello_client.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"gofr.dev/pkg/gofr"
-
+	"gofr.dev/pkg/gofr/metrics"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -45,14 +45,14 @@ func createGRPCConn(host string) (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
-func NewHelloGoFrClient(host string, app *gofr.App) (*HelloClientWrapper, error) {
+func NewHelloGoFrClient(host string, metrics metrics.Manager) (*HelloClientWrapper, error) {
 	conn, err := createGRPCConn(host)
 	if err != nil {
 		return &HelloClientWrapper{client: nil}, err
 	}
 
 	gRPCBuckets := []float64{0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10}
-	app.Metrics().NewHistogram("app_gRPC-Client_stats",
+	metrics.NewHistogram("app_gRPC-Client_stats",
 		"Response time of gRPC client in milliseconds.",
 		gRPCBuckets...)
 

--- a/examples/grpc/grpc-client/main.go
+++ b/examples/grpc/grpc-client/main.go
@@ -9,7 +9,7 @@ func main() {
 	app := gofr.New()
 
 	// Create a gRPC client for the Hello service
-	helloGRPCClient, err := client.NewHelloGoFrClient(app.Config.Get("GRPC_SERVER_HOST"), app)
+	helloGRPCClient, err := client.NewHelloGoFrClient(app.Config.Get("GRPC_SERVER_HOST"), app.Metrics())
 	if err != nil {
 		app.Logger().Errorf("Failed to create Hello gRPC client: %v", err)
 		return


### PR DESCRIPTION
**Description:**

-   We now pass app.Metrics() instead of app, while registering the metrics for our gRPC clients.

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

