### PR TITLE
Adding HTML template support.

### DIFF
--- a/docs/advanced-guide/overriding-default/page.md
+++ b/docs/advanced-guide/overriding-default/page.md
@@ -71,6 +71,50 @@ Response example:
 ]
 ```
 
+## Rendering Templates
+GoFr allows rendering HTML templates in handlers using the response.Template type.
+
+### Example
+```go
+package main
+
+import (
+ "gofr.dev/pkg/gofr"
+ "gofr.dev/pkg/gofr/http/response"
+)
+
+func main() {
+ app := gofr.New()
+ app.GET("/list", listHandler)
+ app.AddStaticFiles("/", "./static")
+ app.Run()
+}
+
+type Todo struct {
+ Title string
+ Done  bool
+}
+
+type TodoPageData struct {
+ PageTitle string
+ Todos     []Todo
+}
+
+func listHandler(ctx *gofr.Context) (any, error) {
+ // Get data from somewhere
+ data := TodoPageData{
+  PageTitle: "My TODO list",
+  Todos: []Todo{
+   {Title: "Expand on Gofr documentation ", Done: false},
+   {Title: "Add more examples", Done: true},
+   {Title: "Write some articles", Done: false},
+  },
+ }
+
+ return response.Template{Data: data, Name: "todo.html"}, nil
+}
+```
+
 ## Favicon.ico
 
 By default, GoFr load its own `favicon.ico` present in root directory for an application. To override `favicon.ico` user

--- a/examples/using-html-template/main.go
+++ b/examples/using-html-template/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"gofr.dev/pkg/gofr"
+	"gofr.dev/pkg/gofr/http/response"
+)
+
+func main() {
+	app := gofr.New()
+	app.GET("/list", listHandler)
+	app.AddStaticFiles("/", "./static")
+	app.Run()
+}
+
+type Todo struct {
+	Title string
+	Done  bool
+}
+
+type TodoPageData struct {
+	PageTitle string
+	Todos     []Todo
+}
+
+func listHandler(c *gofr.Context) (any, error) {
+	// Get data from somewhere
+	data := TodoPageData{
+		PageTitle: "My TODO list",
+		Todos: []Todo{
+			{Title: "Expand on Gofr documentation ", Done: false},
+			{Title: "Add more examples", Done: true},
+			{Title: "Write some articles", Done: false},
+		},
+	}
+
+	return response.Template{data, "todo.html"}, nil
+}

--- a/examples/using-html-template/static/index.html
+++ b/examples/using-html-template/static/index.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div id="content">
+    <img src="/favicon.ico"/>
+    <h1>Hello HTML!</h1>
+    <p>This is a simple HTML file served by the server.</p>
+    <a href="/list" /> Click to see template being rendered </a>
+</div>
+</body>
+
+</html>

--- a/examples/using-html-template/static/style.css
+++ b/examples/using-html-template/static/style.css
@@ -1,0 +1,39 @@
+body,html {
+    margin: 0;
+    padding: 0;
+    background: oklch(0.208 0.042 265.755);
+    color: oklch(0.869 0.022 252.894);
+    font-family: ui-sans-serif, system-ui, sans-serif;
+}
+* {
+    box-sizing: border-box;
+}
+h1 {
+    font-size: 2rem;
+    margin: 0;
+    padding: 1rem;
+    background: oklch(0.208 0.042 265.755);
+    color: oklch(0.869 0.022 252.894);
+}
+
+div#content {padding:80px 20px; text-align: center }
+
+a {color: oklch(0.917 0.08 205.041); text-decoration: none;}
+a:hover {font-weight: bold}
+
+
+h2 {
+    text-align: left;
+}
+ul {
+    text-align: left ;
+}
+
+li {
+    list-style-type: circle;
+}
+
+li.done {
+    list-style-type: disc;
+    text-decoration: line-through;
+}

--- a/examples/using-html-template/templates/todo.html
+++ b/examples/using-html-template/templates/todo.html
@@ -1,0 +1,22 @@
+<html>
+<head>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div id="content">
+
+<h2>{{.PageTitle}}</h2>
+<ul>
+    {{range .Todos}}
+    {{if .Done}}
+    <li class="done">{{.Title}}</li>
+    {{else}}
+    <li>{{.Title}}</li>
+    {{end}}
+    {{end}}
+</ul>
+
+</div>
+</body>
+
+</html>

--- a/pkg/gofr/http/responder.go
+++ b/pkg/gofr/http/responder.go
@@ -35,10 +35,12 @@ func (r Responder) Respond(data any, err error) {
 		r.w.WriteHeader(statusCode)
 
 		_, _ = r.w.Write(v.Content)
+
 		return
 	case resTypes.Template:
 		r.w.Header().Set("Content-Type", "text/html")
 		v.Render(r.w)
+
 		return
 	default:
 		// handling where an interface contains a nullable type with a nil value.

--- a/pkg/gofr/http/responder.go
+++ b/pkg/gofr/http/responder.go
@@ -35,7 +35,10 @@ func (r Responder) Respond(data any, err error) {
 		r.w.WriteHeader(statusCode)
 
 		_, _ = r.w.Write(v.Content)
-
+		return
+	case resTypes.Template:
+		r.w.Header().Set("Content-Type", "text/html")
+		v.Render(r.w)
 		return
 	default:
 		// handling where an interface contains a nullable type with a nil value.

--- a/pkg/gofr/http/responder_test.go
+++ b/pkg/gofr/http/responder_test.go
@@ -188,6 +188,7 @@ func TestIsNil(t *testing.T) {
 func TestResponder_TemplateResponse(t *testing.T) {
 	templatePath := "./templates/example.html"
 	templateContent := `<html><head><title>{{.Title}}</title></head><body>{{.Body}}</body></html>`
+
 	createTemplateFile(t, templatePath, templateContent)
 	defer removeTemplateDir(t)
 
@@ -204,18 +205,22 @@ func TestResponder_TemplateResponse(t *testing.T) {
 
 	assert.Equal(t, "text/html", contentType)
 	assert.Equal(t, expectedBody, responseBody)
-
 }
 
 func createTemplateFile(t *testing.T, path, content string) {
+	t.Helper()
+
 	err := os.MkdirAll("./templates", os.ModePerm)
 	require.NoError(t, err)
 
-	err = os.WriteFile(path, []byte(content), 0644)
+	err = os.WriteFile(path, []byte(content), 0600)
 	require.NoError(t, err)
 }
 
 func removeTemplateDir(t *testing.T) {
+	t.Helper()
+
 	err := os.RemoveAll("./templates")
+
 	require.NoError(t, err)
 }

--- a/pkg/gofr/http/response/template.go
+++ b/pkg/gofr/http/response/template.go
@@ -1,0 +1,16 @@
+package response
+
+import (
+	"html/template"
+	"io"
+)
+
+type Template struct { // Named as such to avoid conflict with imported template
+	Data any
+	Name string
+}
+
+func (t *Template) Render(w io.Writer) {
+	tmpl := template.Must(template.ParseFiles("./templates/" + t.Name))
+	tmpl.Execute(w, t.Data)
+}

--- a/pkg/gofr/http/response/template.go
+++ b/pkg/gofr/http/response/template.go
@@ -12,5 +12,5 @@ type Template struct { // Named as such to avoid conflict with imported template
 
 func (t *Template) Render(w io.Writer) {
 	tmpl := template.Must(template.ParseFiles("./templates/" + t.Name))
-	tmpl.Execute(w, t.Data)
+	_ = tmpl.Execute(w, t.Data)
 }


### PR DESCRIPTION
A new type response.Template is introduced. It takes a name of the template and the data. Based on the name template is being read from "templates" folder by default and we are using the data to render the said template. 

fixes #1515 for now. Eventually we may want to make the folder name customisable or add more header support. For now, current issue gets fixed while ensuring that other people who are not concerned about template do not get affected. 


