### PR TITLE
En/add exists method arango

### DIFF
--- a/docs/advanced-guide/injecting-databases-drivers/page.md
+++ b/docs/advanced-guide/injecting-databases-drivers/page.md
@@ -1019,10 +1019,13 @@ type ArangoDB interface {
 	// Parameters:
 	//   - ctx: Request context for tracing and cancellation.
 	//   - name: Name of the database, collection, or graph.
-	//   - resourceType: Type of the resource ("database", "collection", "graph").
+	//   - resourceType: Type of the resource (any). Allowed values are:
+	//     - arangodb.ResourceTypeDatabase
+	//     - arangodb.ResourceTypeCollection
+	//     - arangodb.ResourceTypeGraph
 	//
 	// Returns true if the resource exists, otherwise false.
-	Exists(ctx context.Context, name, resourceType string) (bool, error)
+	Exists(ctx context.Context, name string, resourceType any) (bool, error)
 
 
    HealthCheck(context.Context) (any, error)

--- a/docs/advanced-guide/injecting-databases-drivers/page.md
+++ b/docs/advanced-guide/injecting-databases-drivers/page.md
@@ -969,6 +969,13 @@ type ArangoDB interface {
 	DropCollection(ctx context.Context, database, collection string) error
 
 	// CreateGraph creates a new graph in a database.
+	// Parameters:
+	//   - ctx: Request context for tracing and cancellation.
+	//   - database: Name of the database where the graph will be created.
+	//   - graph: Name of the graph to be created.
+	//   - edgeDefinitions: Pointer to EdgeDefinition struct containing edge definitions.
+	//
+	// Returns an error if the edgeDefinitions parameter is not of type *EdgeDefinition or is nil.
 	CreateGraph(ctx context.Context, database, graph string, edgeDefinitions any) error
 	// DropGraph deletes an existing graph from a database.
 	DropGraph(ctx context.Context, database, graph string) error
@@ -982,11 +989,41 @@ type ArangoDB interface {
 	// DeleteDocument deletes a document by its ID from the specified collection.
 	DeleteDocument(ctx context.Context, dbName, collectionName, documentID string) error
 
-	// GetEdges retrieves all the edge documents connected to a specific vertex in an ArangoDB graph.
+	// GetEdges fetches all edges connected to a given vertex in the specified edge collection.
+	//
+	// Parameters:
+	//   - ctx: Request context for tracing and cancellation.
+	//   - dbName: Database name.
+	//   - graphName: Graph name.
+	//   - edgeCollection: Edge collection name.
+	//   - vertexID: Full vertex ID (e.g., "persons/16563").
+	//   - resp: Pointer to `*EdgeDetails` to store results.
+	//
+	// Returns an error if input is invalid, `resp` is of the wrong type, or the query fails.
 	GetEdges(ctx context.Context, dbName, graphName, edgeCollection, vertexID string, resp any) error
 
-	// Query executes an AQL query and binds the results
+	// Query executes an AQL query and binds the results.
+	//
+	// Parameters:
+	//   - ctx: Request context for tracing and cancellation.
+	//   - dbName: Name of the database where the query will be executed.
+	//   - query: AQL query string to be executed.
+	//   - bindVars: Map of bind variables to be used in the query.
+	//   - result: Pointer to a slice of maps where the query results will be stored.
+	//
+	// Returns an error if the database connection fails, the query execution fails, or
+	// the result parameter is not a pointer to a slice of maps.
 	Query(ctx context.Context, dbName string, query string, bindVars map[string]any, result any) error
+
+	// Exists checks if a database, collection, or graph exists.
+	// Parameters:
+	//   - ctx: Request context for tracing and cancellation.
+	//   - name: Name of the database, collection, or graph.
+	//   - resourceType: Type of the resource ("database", "collection", "graph").
+	//
+	// Returns true if the resource exists, otherwise false.
+	Exists(ctx context.Context, name, resourceType string) (bool, error)
+
 
    HealthCheck(context.Context) (any, error)
 }

--- a/pkg/gofr/container/datasources.go
+++ b/pkg/gofr/container/datasources.go
@@ -637,7 +637,10 @@ type ArangoDB interface {
 	// Parameters:
 	//   - ctx: Request context for tracing and cancellation.
 	//   - name: Name of the database, collection, or graph.
-	//   - resourceType: Type of the resource ("database", "collection", "graph").
+	//   - resourceType: Type of the resource (any). Allowed values are:
+	//     - arangodb.ResourceTypeDatabase
+	//     - arangodb.ResourceTypeCollection
+	//     - arangodb.ResourceTypeGraph
 	//
 	// Returns true if the resource exists, otherwise false.
 	Exists(ctx context.Context, name string, resourceType any) (bool, error)

--- a/pkg/gofr/container/datasources.go
+++ b/pkg/gofr/container/datasources.go
@@ -633,6 +633,15 @@ type ArangoDB interface {
 	// the result parameter is not a pointer to a slice of maps.
 	Query(ctx context.Context, dbName string, query string, bindVars map[string]any, result any) error
 
+	// Exists checks if a database, collection, or graph exists.
+	// Parameters:
+	//   - ctx: Request context for tracing and cancellation.
+	//   - name: Name of the database, collection, or graph.
+	//   - resourceType: Type of the resource ("database", "collection", "graph").
+	//
+	// Returns true if the resource exists, otherwise false.
+	Exists(ctx context.Context, name, resourceType string) (bool, error)
+
 	HealthChecker
 }
 

--- a/pkg/gofr/container/datasources.go
+++ b/pkg/gofr/container/datasources.go
@@ -640,7 +640,7 @@ type ArangoDB interface {
 	//   - resourceType: Type of the resource ("database", "collection", "graph").
 	//
 	// Returns true if the resource exists, otherwise false.
-	Exists(ctx context.Context, name, resourceType string) (bool, error)
+	Exists(ctx context.Context, name string, resourceType any) (bool, error)
 
 	HealthChecker
 }

--- a/pkg/gofr/container/mock_datasources.go
+++ b/pkg/gofr/container/mock_datasources.go
@@ -12461,7 +12461,7 @@ func (mr *MockArangoDBProviderMockRecorder) UpdateDocument(ctx, dbName, collecti
 }
 
 // Exists mocks base method.
-func (m *MockArangoDBProvider) Exists(ctx context.Context, name string, resourceType string) (bool, error) {
+func (m *MockArangoDBProvider) Exists(ctx context.Context, name string, resourceType any) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Exists", ctx, name, resourceType)
 	ret0, _ := ret[0].(bool)
@@ -12470,7 +12470,7 @@ func (m *MockArangoDBProvider) Exists(ctx context.Context, name string, resource
 }
 
 // Exists indicates an expected call of Exists.
-func (mr *MockArangoDBProviderMockRecorder) Exists(ctx, name, resourceType any) *gomock.Call {
+func (mr *MockArangoDBProviderMockRecorder) Exists(ctx context.Context, name string, resourceType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockArangoDBProvider)(nil).Exists), ctx, name, resourceType)
 }

--- a/pkg/gofr/container/mock_datasources.go
+++ b/pkg/gofr/container/mock_datasources.go
@@ -12460,6 +12460,21 @@ func (mr *MockArangoDBProviderMockRecorder) UpdateDocument(ctx, dbName, collecti
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDocument", reflect.TypeOf((*MockArangoDBProvider)(nil).UpdateDocument), ctx, dbName, collectionName, documentID, document)
 }
 
+// Exists mocks base method.
+func (m *MockArangoDBProvider) Exists(ctx context.Context, name string, resourceType string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", ctx, name, resourceType)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Exists indicates an expected call of Exists.
+func (mr *MockArangoDBProviderMockRecorder) Exists(ctx, name, resourceType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockArangoDBProvider)(nil).Exists), ctx, name, resourceType)
+}
+
 // UseLogger mocks base method.
 func (m *MockArangoDBProvider) UseLogger(logger any) {
 	m.ctrl.T.Helper()

--- a/pkg/gofr/datasource/arangodb/arango.go
+++ b/pkg/gofr/datasource/arangodb/arango.go
@@ -225,37 +225,8 @@ func (c *Client) Exists(ctx context.Context, name, resourceType string) (bool, e
 	case "graph":
 		return c.graphExists(tracerCtx, name)
 	default:
-		return false, fmt.Errorf("%w", errInvalidResourceType)
+		return false, errInvalidResourceType
 	}
-}
-
-func (c *Client) graphExists(ctx context.Context, name string) (bool, error) {
-	db, err := c.client.Database(ctx, "_system")
-	if err != nil {
-		return false, err
-	}
-
-	graphs, err := db.Graphs(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	for {
-		graph, err := graphs.Read()
-		if arangoShared.IsNoMoreDocuments(err) {
-			break
-		}
-
-		if err != nil {
-			return false, err
-		}
-
-		if graph.Name() == name {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }
 
 // addTrace adds tracing to context if tracer is configured.

--- a/pkg/gofr/datasource/arangodb/arango.go
+++ b/pkg/gofr/datasource/arangodb/arango.go
@@ -214,9 +214,9 @@ func (c *Client) Query(ctx context.Context, dbName, query string, bindVars map[s
 //   - ctx: Request context for tracing and cancellation.
 //   - name: Name of the database, collection, or graph.
 //   - resourceType: Type of the resource (any). Allowed values are:
-//     - arangodb.ResourceTypeDatabase
-//     - arangodb.ResourceTypeCollection
-//     - arangodb.ResourceTypeGraph
+//   - arangodb.ResourceTypeDatabase
+//   - arangodb.ResourceTypeCollection
+//   - arangodb.ResourceTypeGraph
 //
 // Returns true if the resource exists, otherwise false.
 func (c *Client) Exists(ctx context.Context, name string, resourceType any) (bool, error) {

--- a/pkg/gofr/datasource/arangodb/arango.go
+++ b/pkg/gofr/datasource/arangodb/arango.go
@@ -229,41 +229,6 @@ func (c *Client) Exists(ctx context.Context, name, resourceType string) (bool, e
 	}
 }
 
-func (c *Client) databaseExists(ctx context.Context, name string) (bool, error) {
-	dbs, err := c.client.Databases(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	for _, db := range dbs {
-		if db.Name() == name {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func (c *Client) collectionExists(ctx context.Context, name string) (bool, error) {
-	db, err := c.client.Database(ctx, "_system")
-	if err != nil {
-		return false, err
-	}
-
-	collections, err := db.Collections(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	for _, col := range collections {
-		if col.Name() == name {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
 func (c *Client) graphExists(ctx context.Context, name string) (bool, error) {
 	db, err := c.client.Database(ctx, "_system")
 	if err != nil {

--- a/pkg/gofr/datasource/arangodb/arango_db.go
+++ b/pkg/gofr/datasource/arangodb/arango_db.go
@@ -87,6 +87,41 @@ func (d *DB) getCollection(ctx context.Context, dbName, collectionName string) (
 	return collection, nil
 }
 
+func (c *Client) databaseExists(ctx context.Context, name string) (bool, error) {
+	dbs, err := c.client.Databases(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	for _, db := range dbs {
+		if db.Name() == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (c *Client) collectionExists(ctx context.Context, name string) (bool, error) {
+	db, err := c.client.Database(ctx, "_system")
+	if err != nil {
+		return false, err
+	}
+
+	collections, err := db.Collections(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	for _, col := range collections {
+		if col.Name() == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // handleCollectionOperation handles common logic for collection operations.
 func (d *DB) handleCollectionOperation(ctx context.Context, operation, database, collectionName string,
 	action func(arangodb.Collection) error) error {

--- a/pkg/gofr/datasource/arangodb/arango_db_test.go
+++ b/pkg/gofr/datasource/arangodb/arango_db_test.go
@@ -166,7 +166,7 @@ func Test_Client_DatabaseExists_Success(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.databaseExists(ctx, database)
+	exists, err := client.Exists(ctx, database, "database")
 	require.NoError(t, err, "Expected no error while checking if the database exists")
 	require.True(t, exists, "Expected the database to exist")
 }
@@ -182,7 +182,7 @@ func Test_Client_DatabaseExists_Error(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.databaseExists(ctx, database)
+	exists, err := client.Exists(ctx, database, "database")
 	require.Error(t, err, "Expected an error while checking if the database exists")
 	require.False(t, exists, "Expected the database to not exist")
 }
@@ -200,7 +200,7 @@ func Test_Client_DatabaseExists_NotExist(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.databaseExists(ctx, database)
+	exists, err := client.Exists(ctx, database, "database")
 	require.NoError(t, err, "Expected no error while checking if the database exists")
 	require.False(t, exists, "Expected the database to not exist")
 }
@@ -220,7 +220,7 @@ func Test_Client_CollectionExists_Success(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.collectionExists(ctx, collection)
+	exists, err := client.Exists(ctx, collection, "collection")
 	require.NoError(t, err, "Expected no error while checking if the collection exists")
 	require.True(t, exists, "Expected the collection to exist")
 }
@@ -236,7 +236,7 @@ func Test_Client_CollectionExists_DatabaseError(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.collectionExists(ctx, collection)
+	exists, err := client.Exists(ctx, collection, "collection")
 	require.Error(t, err, "Expected an error while checking if the collection exists")
 	require.False(t, exists, "Expected the collection to not exist")
 }
@@ -254,7 +254,7 @@ func Test_Client_CollectionExists_Error(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.collectionExists(ctx, collection)
+	exists, err := client.Exists(ctx, collection, "collection")
 	require.Error(t, err, "Expected an error while checking if the collection exists")
 	require.False(t, exists, "Expected the collection to not exist")
 }
@@ -274,7 +274,7 @@ func Test_Client_CollectionExists_NotExist(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.collectionExists(ctx, collection)
+	exists, err := client.Exists(ctx, collection, "collection")
 	require.NoError(t, err, "Expected no error while checking if the collection exists")
 	require.False(t, exists, "Expected the collection to not exist")
 }

--- a/pkg/gofr/datasource/arangodb/arango_db_test.go
+++ b/pkg/gofr/datasource/arangodb/arango_db_test.go
@@ -166,7 +166,7 @@ func Test_Client_DatabaseExists_Success(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.Exists(ctx, database, "database")
+	exists, err := client.Exists(ctx, database, ResourceTypeDatabase)
 	require.NoError(t, err, "Expected no error while checking if the database exists")
 	require.True(t, exists, "Expected the database to exist")
 }
@@ -182,7 +182,7 @@ func Test_Client_DatabaseExists_Error(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.Exists(ctx, database, "database")
+	exists, err := client.Exists(ctx, database, ResourceTypeDatabase)
 	require.Error(t, err, "Expected an error while checking if the database exists")
 	require.False(t, exists, "Expected the database to not exist")
 }
@@ -200,7 +200,7 @@ func Test_Client_DatabaseExists_NotExist(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.Exists(ctx, database, "database")
+	exists, err := client.Exists(ctx, database, ResourceTypeDatabase)
 	require.NoError(t, err, "Expected no error while checking if the database exists")
 	require.False(t, exists, "Expected the database to not exist")
 }
@@ -220,7 +220,7 @@ func Test_Client_CollectionExists_Success(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.Exists(ctx, collection, "collection")
+	exists, err := client.Exists(ctx, collection, ResourceTypeCollection)
 	require.NoError(t, err, "Expected no error while checking if the collection exists")
 	require.True(t, exists, "Expected the collection to exist")
 }
@@ -236,7 +236,7 @@ func Test_Client_CollectionExists_DatabaseError(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.Exists(ctx, collection, "collection")
+	exists, err := client.Exists(ctx, collection, ResourceTypeCollection)
 	require.Error(t, err, "Expected an error while checking if the collection exists")
 	require.False(t, exists, "Expected the collection to not exist")
 }
@@ -254,7 +254,7 @@ func Test_Client_CollectionExists_Error(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.Exists(ctx, collection, "collection")
+	exists, err := client.Exists(ctx, collection, ResourceTypeCollection)
 	require.Error(t, err, "Expected an error while checking if the collection exists")
 	require.False(t, exists, "Expected the collection to not exist")
 }
@@ -274,7 +274,7 @@ func Test_Client_CollectionExists_NotExist(t *testing.T) {
 	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	exists, err := client.Exists(ctx, collection, "collection")
+	exists, err := client.Exists(ctx, collection, ResourceTypeCollection)
 	require.NoError(t, err, "Expected no error while checking if the collection exists")
 	require.False(t, exists, "Expected the collection to not exist")
 }

--- a/pkg/gofr/datasource/arangodb/arango_graph.go
+++ b/pkg/gofr/datasource/arangodb/arango_graph.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/arangodb/go-driver/v2/arangodb"
+	"github.com/arangodb/go-driver/v2/arangodb/shared"
 )
 
 var (
@@ -149,4 +150,33 @@ func (c *Client) GetEdges(ctx context.Context, dbName, graphName, edgeCollection
 	*edgeResp = edges
 
 	return nil
+}
+
+func (c *Client) graphExists(ctx context.Context, name string) (bool, error) {
+	db, err := c.client.Database(ctx, "_system")
+	if err != nil {
+		return false, err
+	}
+
+	graphs, err := db.Graphs(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	for {
+		graph, err := graphs.Read()
+		if shared.IsNoMoreDocuments(err) {
+			break
+		}
+
+		if err != nil {
+			return false, err
+		}
+
+		if graph.Name() == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/gofr/datasource/arangodb/arango_test.go
+++ b/pkg/gofr/datasource/arangodb/arango_test.go
@@ -1,6 +1,7 @@
 package arangodb
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -129,4 +130,17 @@ func TestValidateConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_Client_Exists_InvalidResourceType(t *testing.T) {
+	client, _, _, mockLogger, mockMetrics := setupDB(t)
+
+	mockLogger.EXPECT().Debug(gomock.Any()).AnyTimes()
+	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats",
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	exists, err := client.Exists(context.Background(), "testResource", "invalid")
+	require.Error(t, err, "Expected an error for invalid resource type")
+	require.False(t, exists, "Expected the resource to not exist")
+	require.Equal(t, errInvalidResourceType, err)
 }

--- a/pkg/gofr/datasource/arangodb/interface.go
+++ b/pkg/gofr/datasource/arangodb/interface.go
@@ -75,10 +75,13 @@ type ArangoDB interface {
 	// Parameters:
 	//   - ctx: Request context for tracing and cancellation.
 	//   - name: Name of the database, collection, or graph.
-	//   - resourceType: Type of the resource ("database", "collection", "graph").
+	//   - resourceType: Type of the resource (any). Allowed values are:
+	//     - arangodb.ResourceTypeDatabase
+	//     - arangodb.ResourceTypeCollection
+	//     - arangodb.ResourceTypeGraph
 	//
 	// Returns true if the resource exists, otherwise false.
-	Exists(ctx context.Context, name, resourceType string) (bool, error)
+	Exists(ctx context.Context, name string, resourceType any) (bool, error)
 
 	HealthCheck(ctx context.Context) (any, error)
 }

--- a/pkg/gofr/datasource/arangodb/interface.go
+++ b/pkg/gofr/datasource/arangodb/interface.go
@@ -25,20 +25,60 @@ type ArangoDB interface {
 	DropCollection(ctx context.Context, database, collection string) error
 
 	// CreateGraph creates a new graph in a database.
+	// Parameters:
+	//   - ctx: Request context for tracing and cancellation.
+	//   - database: Name of the database where the graph will be created.
+	//   - graph: Name of the graph to be created.
+	//   - edgeDefinitions: Pointer to EdgeDefinition struct containing edge definitions.
+	//
+	// Returns an error if the edgeDefinitions parameter is not of type *EdgeDefinition or is nil.
 	CreateGraph(ctx context.Context, database, graph string, edgeDefinitions any) error
 	// DropGraph deletes an existing graph from a database.
 	DropGraph(ctx context.Context, database, graph string) error
 
+	// CreateDocument creates a new document in the specified collection.
 	CreateDocument(ctx context.Context, dbName, collectionName string, document any) (string, error)
+	// GetDocument retrieves a document by its ID from the specified collection.
 	GetDocument(ctx context.Context, dbName, collectionName, documentID string, result any) error
+	// UpdateDocument updates an existing document in the specified collection.
 	UpdateDocument(ctx context.Context, dbName, collectionName, documentID string, document any) error
+	// DeleteDocument deletes a document by its ID from the specified collection.
 	DeleteDocument(ctx context.Context, dbName, collectionName, documentID string) error
 
-	// GetEdges retrieves all the edge documents connected to a specific vertex in an ArangoDB graph.
+	// GetEdges fetches all edges connected to a given vertex in the specified edge collection.
+	//
+	// Parameters:
+	//   - ctx: Request context for tracing and cancellation.
+	//   - dbName: Database name.
+	//   - graphName: Graph name.
+	//   - edgeCollection: Edge collection name.
+	//   - vertexID: Full vertex ID (e.g., "persons/16563").
+	//   - resp: Pointer to `*EdgeDetails` to store results.
+	//
+	// Returns an error if input is invalid, `resp` is of the wrong type, or the query fails.
 	GetEdges(ctx context.Context, dbName, graphName, edgeCollection, vertexID string, resp any) error
 
-	// Query operations
+	// Query executes an AQL query and binds the results.
+	//
+	// Parameters:
+	//   - ctx: Request context for tracing and cancellation.
+	//   - dbName: Name of the database where the query will be executed.
+	//   - query: AQL query string to be executed.
+	//   - bindVars: Map of bind variables to be used in the query.
+	//   - result: Pointer to a slice of maps where the query results will be stored.
+	//
+	// Returns an error if the database connection fails, the query execution fails, or
+	// the result parameter is not a pointer to a slice of maps.
 	Query(ctx context.Context, dbName string, query string, bindVars map[string]any, result any) error
+
+	// Exists checks if a database, collection, or graph exists.
+	// Parameters:
+	//   - ctx: Request context for tracing and cancellation.
+	//   - name: Name of the database, collection, or graph.
+	//   - resourceType: Type of the resource ("database", "collection", "graph").
+	//
+	// Returns true if the resource exists, otherwise false.
+	Exists(ctx context.Context, name, resourceType string) (bool, error)
 
 	HealthCheck(ctx context.Context) (any, error)
 }

--- a/pkg/gofr/migration/arango.go
+++ b/pkg/gofr/migration/arango.go
@@ -62,6 +62,10 @@ func (ds arangoDS) DropGraph(ctx context.Context, database, graph string) error 
 	return ds.client.DropGraph(ctx, database, graph)
 }
 
+func (ds arangoDS) Exists(ctx context.Context, name, resourceType string) (bool, error) {
+	return ds.client.Exists(ctx, name, resourceType)
+}
+
 func (ds arangoDS) apply(m migrator) migrator {
 	return arangoMigrator{
 		ArangoDB: ds,

--- a/pkg/gofr/migration/arango.go
+++ b/pkg/gofr/migration/arango.go
@@ -62,7 +62,17 @@ func (ds arangoDS) DropGraph(ctx context.Context, database, graph string) error 
 	return ds.client.DropGraph(ctx, database, graph)
 }
 
-func (ds arangoDS) Exists(ctx context.Context, name, resourceType string) (bool, error) {
+// Exists checks if a database, collection, or graph exists.
+// Parameters:
+//   - ctx: Request context for tracing and cancellation.
+//   - name: Name of the database, collection, or graph.
+//   - resourceType: Type of the resource (any). Allowed values are:
+//   - arangodb.ResourceTypeDatabase
+//   - arangodb.ResourceTypeCollection
+//   - arangodb.ResourceTypeGraph
+//
+// Returns true if the resource exists, otherwise false.
+func (ds arangoDS) Exists(ctx context.Context, name string, resourceType any) (bool, error) {
 	return ds.client.Exists(ctx, name, resourceType)
 }
 

--- a/pkg/gofr/migration/arango_test.go
+++ b/pkg/gofr/migration/arango_test.go
@@ -188,6 +188,6 @@ func Test_ArangoMigration_Exists(t *testing.T) {
 
 	res, err := arangoDB.Exists(context.Background(), "test", "database")
 
-	assert.Equal(t, true, res)
+	assert.True(t, res, "Test_ArangoMigration_Exists failed!")
 	assert.NoError(t, err, "Test_ArangoMigration_Exists failed!")
 }

--- a/pkg/gofr/migration/arango_test.go
+++ b/pkg/gofr/migration/arango_test.go
@@ -114,3 +114,80 @@ func Test_ArangoBeginTransaction(t *testing.T) {
 
 	assert.Contains(t, logs, "ArangoDB migrator begin successfully")
 }
+
+func Test_ArangoMigration_CreateDB(t *testing.T) {
+	_, mockArango, _ := arangoSetup(t)
+
+	arangoDB := arangoDS{client: mockArango}
+
+	mockArango.EXPECT().CreateDB(context.Background(), "test").Return(nil)
+
+	err := arangoDB.CreateDB(context.Background(), "test")
+
+	assert.NoError(t, err, "Test_ArangoMigration_CreateDB failed!")
+}
+
+func Test_ArangoMigration_DropDB(t *testing.T) {
+	_, mockArango, _ := arangoSetup(t)
+
+	arangoDB := arangoDS{client: mockArango}
+
+	mockArango.EXPECT().DropDB(context.Background(), "test").Return(nil)
+
+	err := arangoDB.DropDB(context.Background(), "test")
+
+	assert.NoError(t, err, "Test_ArangoMigration_DropDB failed!")
+}
+
+func Test_ArangoMigration_DropCollection(t *testing.T) {
+	_, mockArango, _ := arangoSetup(t)
+
+	arangoDB := arangoDS{client: mockArango}
+
+	mockArango.EXPECT().DropCollection(context.Background(), "test",
+		"database").Return(nil)
+
+	err := arangoDB.DropCollection(context.Background(), "test", "database")
+
+	assert.NoError(t, err, "Test_ArangoMigration_DropCollection failed!")
+}
+
+func Test_ArangoMigration_CreateGraph(t *testing.T) {
+	_, mockArango, _ := arangoSetup(t)
+
+	arangoDB := arangoDS{client: mockArango}
+
+	mockArango.EXPECT().CreateGraph(context.Background(), "test",
+		"database", nil).Return(nil)
+
+	err := arangoDB.CreateGraph(context.Background(), "test", "database", nil)
+
+	assert.NoError(t, err, "Test_ArangoMigration_CreateGraph failed!")
+}
+
+func Test_ArangoMigration_DropGraph(t *testing.T) {
+	_, mockArango, _ := arangoSetup(t)
+
+	arangoDB := arangoDS{client: mockArango}
+
+	mockArango.EXPECT().DropGraph(context.Background(), "test",
+		"database").Return(nil)
+
+	err := arangoDB.DropGraph(context.Background(), "test", "database")
+
+	assert.NoError(t, err, "Test_ArangoMigration_DropGraph failed!")
+}
+
+func Test_ArangoMigration_Exists(t *testing.T) {
+	_, mockArango, _ := arangoSetup(t)
+
+	arangoDB := arangoDS{client: mockArango}
+
+	mockArango.EXPECT().Exists(context.Background(), "test",
+		"database").Return(true, nil)
+
+	res, err := arangoDB.Exists(context.Background(), "test", "database")
+
+	assert.Equal(t, true, res)
+	assert.NoError(t, err, "Test_ArangoMigration_Exists failed!")
+}

--- a/pkg/gofr/migration/arango_test.go
+++ b/pkg/gofr/migration/arango_test.go
@@ -177,17 +177,3 @@ func Test_ArangoMigration_DropGraph(t *testing.T) {
 
 	assert.NoError(t, err, "Test_ArangoMigration_DropGraph failed!")
 }
-
-func Test_ArangoMigration_Exists(t *testing.T) {
-	_, mockArango, _ := arangoSetup(t)
-
-	arangoDB := arangoDS{client: mockArango}
-
-	mockArango.EXPECT().Exists(context.Background(), "test",
-		"database").Return(true, nil)
-
-	res, err := arangoDB.Exists(context.Background(), "test", "database")
-
-	assert.True(t, res, "Test_ArangoMigration_Exists failed!")
-	assert.NoError(t, err, "Test_ArangoMigration_Exists failed!")
-}

--- a/pkg/gofr/migration/interface.go
+++ b/pkg/gofr/migration/interface.go
@@ -79,6 +79,15 @@ type ArangoDB interface {
 	CreateGraph(ctx context.Context, database, graph string, edgeDefinitions any) error
 	// DropGraph deletes an existing graph from a database.
 	DropGraph(ctx context.Context, database, graph string) error
+
+	// Exists checks if a database, collection, or graph exists.
+	// Parameters:
+	//   - ctx: Request context for tracing and cancellation.
+	//   - name: Name of the database, collection, or graph.
+	//   - resourceType: Type of the resource ("database", "collection", "graph").
+	//
+	// Returns true if the resource exists, otherwise false.
+	Exists(ctx context.Context, name, resourceType string) (bool, error)
 }
 
 // keeping the migrator interface unexported as, right now it is not being implemented directly, by the externalDB drivers.

--- a/pkg/gofr/migration/interface.go
+++ b/pkg/gofr/migration/interface.go
@@ -84,10 +84,13 @@ type ArangoDB interface {
 	// Parameters:
 	//   - ctx: Request context for tracing and cancellation.
 	//   - name: Name of the database, collection, or graph.
-	//   - resourceType: Type of the resource ("database", "collection", "graph").
+	//   - resourceType: Type of the resource (any). Allowed values are:
+	//     - arangodb.ResourceTypeDatabase
+	//     - arangodb.ResourceTypeCollection
+	//     - arangodb.ResourceTypeGraph
 	//
 	// Returns true if the resource exists, otherwise false.
-	Exists(ctx context.Context, name, resourceType string) (bool, error)
+	Exists(ctx context.Context, name string, resourceType any) (bool, error)
 }
 
 // keeping the migrator interface unexported as, right now it is not being implemented directly, by the externalDB drivers.

--- a/pkg/gofr/migration/mock_interface.go
+++ b/pkg/gofr/migration/mock_interface.go
@@ -780,6 +780,21 @@ func (mr *MockArangoDBMockRecorder) DropGraph(ctx, database, graph any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropGraph", reflect.TypeOf((*MockArangoDB)(nil).DropGraph), ctx, database, graph)
 }
 
+// Exists mocks base method.
+func (m *MockArangoDB) Exists(ctx context.Context, name, resourceType string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", ctx, name, resourceType)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Exists indicates an expected call of Exists.
+func (mr *MockArangoDBMockRecorder) Exists(ctx, name, resourceType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockArangoDB)(nil).Exists), ctx, name, resourceType)
+}
+
 // Mockmigrator is a mock of migrator interface.
 type Mockmigrator struct {
 	ctrl     *gomock.Controller

--- a/pkg/gofr/migration/mock_interface.go
+++ b/pkg/gofr/migration/mock_interface.go
@@ -781,7 +781,7 @@ func (mr *MockArangoDBMockRecorder) DropGraph(ctx, database, graph any) *gomock.
 }
 
 // Exists mocks base method.
-func (m *MockArangoDB) Exists(ctx context.Context, name, resourceType string) (bool, error) {
+func (m *MockArangoDB) Exists(ctx context.Context, name string, resourceType string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Exists", ctx, name, resourceType)
 	ret0, _ := ret[0].(bool)
@@ -790,7 +790,7 @@ func (m *MockArangoDB) Exists(ctx context.Context, name, resourceType string) (b
 }
 
 // Exists indicates an expected call of Exists.
-func (mr *MockArangoDBMockRecorder) Exists(ctx, name, resourceType any) *gomock.Call {
+func (mr *MockArangoDBMockRecorder) Exists(ctx context.Context, name string, resourceType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockArangoDB)(nil).Exists), ctx, name, resourceType)
 }


### PR DESCRIPTION
## Pull Request Template


**Description:**

-   Resolves #1507 
-   Introduce a new method `Exists(ctx context.Context, name string, resourceType any) (bool, error)` to check if a database, collection or a graph exists.


```go
package migrations

import (
	"context"
	"gofr.dev/pkg/gofr/datasource/arangodb"

	"gofr.dev/pkg/gofr/migration"
)

func createCollection() migration.Migrate {
	return migration.Migrate{
		UP: func(d migration.Datasource) error {
			// .....
			
			ans, err := d.ArangoDB.Exists(context.Background(), "employee_db", arangodb.ResourceTypeCollection)
			if err != nil || ans == false {
				return err
			}

			return nil
		},
	}
}

```


**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

