### PR TITLE
 aded an option to get all query parameter as a key value map

### DIFF
--- a/pkg/gofr/http/request.go
+++ b/pkg/gofr/http/request.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -42,6 +43,11 @@ func NewRequest(r *http.Request) *Request {
 // Param returns the query parameter with the given key.
 func (r *Request) Param(key string) string {
 	return r.req.URL.Query().Get(key)
+}
+
+// AllParams returns the all query parameter as a key value map.
+func (r *Request) AllParams() url.Values {
+	return r.req.URL.Query()
 }
 
 // Context returns the context of the request.

--- a/pkg/gofr/http/request_test.go
+++ b/pkg/gofr/http/request_test.go
@@ -26,6 +26,15 @@ func TestParam(t *testing.T) {
 	}
 }
 
+func TestAllParam(t *testing.T) {
+	req := NewRequest(httptest.NewRequest(http.MethodGet, "/abc?a=b&c=d&e=f", http.NoBody))
+	params := req.AllParams()
+	if params.Get("a") != "b" || params.Get("c") != "d" || params.Get("e") != "f" {
+		t.Error("Can not parse the request params")
+	}
+	assert.Nilf(t, params["g"], "expected nil value for non-existent query param")
+}
+
 func TestBind(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/abc", strings.NewReader(`{"a": "b", "b": 5}`))
 	r.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
## Pull Request Template


**Description:**
be able to access  all query parameter as a key value map


**Checklist:**

-   [v] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [v] All new code is covered by unit tests.
-   [v] This PR does not decrease the overall code coverage.


