### PR TITLE
En/refactor arango methods

### DIFF
--- a/pkg/gofr/datasource/arangodb/arango.go
+++ b/pkg/gofr/datasource/arangodb/arango.go
@@ -52,6 +52,9 @@ var (
 	errMissingField           = errors.New("missing required field in config")
 	errInvalidResultType      = errors.New("result must be a pointer to a slice of maps")
 	errInvalidUserOptionsType = errors.New("userOptions must be a *UserOptions type")
+	ErrDatabaseExists         = errors.New("database already exists")
+	ErrCollectionExists       = errors.New("collection already exists")
+	ErrGraphExists            = errors.New("graph already exists")
 )
 
 // New creates a new ArangoDB client with the provided configuration.

--- a/pkg/gofr/datasource/arangodb/arango_db.go
+++ b/pkg/gofr/datasource/arangodb/arango_db.go
@@ -12,6 +12,8 @@ type DB struct {
 }
 
 // CreateDB creates a new database in ArangoDB.
+// It first checks if the database already exists before attempting to create it.
+// Returns ErrDatabaseExists if the database already exists.
 func (d *DB) CreateDB(ctx context.Context, database string) error {
 	tracerCtx, span := d.client.addTrace(ctx, "createDB", map[string]string{"DB": database})
 	startTime := time.Now()
@@ -55,6 +57,8 @@ func (d *DB) DropDB(ctx context.Context, database string) error {
 }
 
 // CreateCollection creates a new collection in a database with specified type.
+// It first checks if the collection already exists before attempting to create it.
+// Returns ErrCollectionExists if the collection already exists.
 func (d *DB) CreateCollection(ctx context.Context, database, collection string, isEdge bool) error {
 	tracerCtx, span := d.client.addTrace(ctx, "createCollection", map[string]string{"collection": collection})
 	startTime := time.Now()

--- a/pkg/gofr/datasource/arangodb/arango_graph.go
+++ b/pkg/gofr/datasource/arangodb/arango_graph.go
@@ -42,6 +42,17 @@ func (g *Graph) CreateGraph(ctx context.Context, database, graph string, edgeDef
 		return err
 	}
 
+	// Check if the graph already exists
+	exists, err := db.GraphExists(tracerCtx, graph)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		g.client.logger.Debugf("graph %s already exists in database %s", graph, database)
+		return ErrGraphExists
+	}
+
 	edgeDefs, ok := edgeDefinitions.(*EdgeDefinition)
 	if !ok {
 		return fmt.Errorf("%w", errInvalidEdgeDefinitionsType)

--- a/pkg/gofr/datasource/arangodb/arango_graph.go
+++ b/pkg/gofr/datasource/arangodb/arango_graph.go
@@ -23,12 +23,14 @@ type Graph struct {
 }
 
 // CreateGraph creates a new graph in a database.
+// It first checks if the graph already exists before attempting to create it.
 // Parameters:
 //   - ctx: Request context for tracing and cancellation.
 //   - database: Name of the database where the graph will be created.
 //   - graph: Name of the graph to be created.
 //   - edgeDefinitions: Pointer to EdgeDefinition struct containing edge definitions.
 //
+// Returns ErrGraphExists if the graph already exists.
 // Returns an error if the edgeDefinitions parameter is not of type *EdgeDefinition or is nil.
 func (g *Graph) CreateGraph(ctx context.Context, database, graph string, edgeDefinitions any) error {
 	tracerCtx, span := g.client.addTrace(ctx, "createGraph", map[string]string{"graph": graph})

--- a/pkg/gofr/datasource/arangodb/arango_graph_test.go
+++ b/pkg/gofr/datasource/arangodb/arango_graph_test.go
@@ -1,0 +1,80 @@
+package arangodb
+
+import (
+	"context"
+	"github.com/arangodb/go-driver/v2/arangodb"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGraph_CreateGraph_AlreadyExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockArango := NewMockArango(ctrl)
+	mockDB := NewMockDatabase(ctrl)
+	mockLogger := NewMockLogger(ctrl)
+	mockMetrics := NewMockMetrics(ctrl)
+
+	client := &Client{
+		logger:  mockLogger,
+		metrics: mockMetrics,
+		client:  mockArango,
+	}
+
+	graph := &Graph{client: client}
+	ctx := context.Background()
+	databaseName := "testDB"
+	graphName := "testGraph"
+	edgeDefinitions := &EdgeDefinition{{Collection: "edgeColl", From: []string{"fromColl"}, To: []string{"toColl"}}}
+
+	mockArango.EXPECT().Database(ctx, databaseName).Return(mockDB, nil)
+	mockDB.EXPECT().GraphExists(ctx, graphName).Return(true, nil)
+	mockLogger.EXPECT().Debugf("graph %s already exists in database %s", graphName, databaseName)
+	mockLogger.EXPECT().Debug(gomock.Any()).AnyTimes()
+	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats", gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	err := graph.CreateGraph(ctx, databaseName, graphName, edgeDefinitions)
+	require.Equal(t, ErrGraphExists, err, "Expected graph already exits error but got %v", err)
+}
+
+func TestGraph_CreateGraph_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockArango := NewMockArango(ctrl)
+	mockDB := NewMockDatabase(ctrl)
+	mockLogger := NewMockLogger(ctrl)
+	mockMetrics := NewMockMetrics(ctrl)
+
+	client := &Client{
+		logger:  mockLogger,
+		metrics: mockMetrics,
+		client:  mockArango,
+	}
+
+	graph := &Graph{client: client}
+	ctx := context.Background()
+	databaseName := "testDB"
+	graphName := "testGraph"
+	edgeDefinitions := &EdgeDefinition{{Collection: "edgeColl", From: []string{"fromColl"}, To: []string{"toColl"}}}
+	options := &arangodb.GraphDefinition{EdgeDefinitions: []arangodb.EdgeDefinition{{
+		Collection: "edgeColl",
+		To:         []string{"toColl"},
+		From:       []string{"fromColl"},
+	}}}
+
+	mockArango.EXPECT().Database(ctx, databaseName).Return(mockDB, nil)
+	mockDB.EXPECT().GraphExists(ctx, graphName).Return(false, nil)
+	mockDB.EXPECT().CreateGraph(ctx, graphName, options, nil).Return(nil, errInvalidEdgeDocumentType)
+	mockLogger.EXPECT().Debug(gomock.Any()).AnyTimes()
+	mockMetrics.EXPECT().RecordHistogram(gomock.Any(), "app_arango_stats", gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	err := graph.CreateGraph(ctx, databaseName, graphName, edgeDefinitions)
+	require.Equal(t, errInvalidEdgeDocumentType, err, "Expected err  %v but got %v",
+		errInvalidEdgeDocumentType, err)
+}

--- a/pkg/gofr/datasource/arangodb/go.mod
+++ b/pkg/gofr/datasource/arangodb/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.23.4
 
 require (
+	github.com/arangodb/go-driver v1.6.6
 	github.com/arangodb/go-driver/v2 v2.1.2
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.34.0

--- a/pkg/gofr/datasource/arangodb/go.sum
+++ b/pkg/gofr/datasource/arangodb/go.sum
@@ -1,3 +1,5 @@
+github.com/arangodb/go-driver v1.6.6 h1:yL1ybRCKqY+eREnVuJ/GYNYowoyy/g0fiUvL3fKNtJM=
+github.com/arangodb/go-driver v1.6.6/go.mod h1:ZWyW3T8YPA1weGxohGtW4lFjJmpr9aHNTTbaiD5bBhI=
 github.com/arangodb/go-driver/v2 v2.1.2 h1:3dxx97pjcJPajw4hnHJMXRz2bY/KizUj/ZrlAVEx10Q=
 github.com/arangodb/go-driver/v2 v2.1.2/go.mod h1:POYSylTzBPej3qEouU3dSyfdVfo3WxawaRwzhA9mbJ4=
 github.com/arangodb/go-velocypack v0.0.0-20200318135517-5af53c29c67e h1:Xg+hGrY2LcQBbxd0ZFdbGSyRKTYMZCfBbw/pMJFOk1g=

--- a/pkg/gofr/datasource/arangodb/mock_graph.go
+++ b/pkg/gofr/datasource/arangodb/mock_graph.go
@@ -2,10 +2,9 @@ package arangodb
 
 import (
 	"context"
-	"github.com/arangodb/go-driver/v2/arangodb"
 	"reflect"
 
-	"github.com/arangodb/go-driver"
+	"github.com/arangodb/go-driver/v2/arangodb"
 	"go.uber.org/mock/gomock"
 )
 
@@ -13,7 +12,6 @@ import (
 type MockDatabaseGraph struct {
 	ctrl     *gomock.Controller
 	recorder *MockDatabaseGraphMockRecorder
-	isgomock struct{}
 }
 
 // MockDatabaseGraphMockRecorder is the mock recorder for MockDatabaseGraph.
@@ -35,21 +33,14 @@ type GetEdgesOptions struct {
 
 type GraphsResponseReader interface {
 	// Read returns next Graph. If no Graph left, shared.NoMoreDocumentsError returned
-	Read() (driver.Graph, error)
-}
-
-func (q *GetEdgesOptions) modifyRequest(r driver.Request) error {
-	if q == nil {
-		return nil
-	}
-
-	return nil
+	Read() (arangodb.Graph, error)
 }
 
 // NewMockDatabaseGraph creates a new mock instance.
 func NewMockDatabaseGraph(ctrl *gomock.Controller) *MockDatabaseGraph {
 	mock := &MockDatabaseGraph{ctrl: ctrl}
 	mock.recorder = &MockDatabaseGraphMockRecorder{mock}
+
 	return mock
 }
 
@@ -59,48 +50,57 @@ func (m *MockDatabaseGraph) EXPECT() *MockDatabaseGraphMockRecorder {
 }
 
 // CreateGraph mocks base method.
-func (m *MockDatabaseGraph) CreateGraph(ctx context.Context, name string, graph *arangodb.GraphDefinition, options *arangodb.CreateGraphOptions) (driver.Graph, error) {
+func (m *MockDatabaseGraph) CreateGraph(ctx context.Context, name string, graph *arangodb.GraphDefinition,
+	options *arangodb.CreateGraphOptions) (arangodb.Graph, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateGraph", ctx, name, graph, options)
-	ret0, _ := ret[0].(driver.Graph)
+	ret0, _ := ret[0].(arangodb.Graph)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // CreateGraph indicates an expected call of CreateGraph.
 func (mr *MockDatabaseGraphMockRecorder) CreateGraph(ctx, name, graph, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGraph", reflect.TypeOf((*MockDatabaseGraph)(nil).CreateGraph), ctx, name, graph, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGraph",
+		reflect.TypeOf((*MockDatabaseGraph)(nil).CreateGraph), ctx, name, graph, options)
 }
 
 // GetEdges mocks base method.
-func (m *MockDatabaseGraph) GetEdges(ctx context.Context, name, vertex string, options *GetEdgesOptions) ([]EdgeDetails, error) {
+func (m *MockDatabaseGraph) GetEdges(ctx context.Context, name, vertex string,
+	options *GetEdgesOptions) ([]EdgeDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEdges", ctx, name, vertex, options)
 	ret0, _ := ret[0].([]EdgeDetails)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // GetEdges indicates an expected call of GetEdges.
 func (mr *MockDatabaseGraphMockRecorder) GetEdges(ctx, name, vertex, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEdges", reflect.TypeOf((*MockDatabaseGraph)(nil).GetEdges), ctx, name, vertex, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEdges",
+		reflect.TypeOf((*MockDatabaseGraph)(nil).GetEdges), ctx, name, vertex, options)
 }
 
 // Graph mocks base method.
-func (m *MockDatabaseGraph) Graph(ctx context.Context, name string, options *arangodb.GetGraphOptions) (driver.Graph, error) {
+func (m *MockDatabaseGraph) Graph(ctx context.Context, name string,
+	options *arangodb.GetGraphOptions) (arangodb.Graph, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Graph", ctx, name, options)
-	ret0, _ := ret[0].(driver.Graph)
+	ret0, _ := ret[0].(arangodb.Graph)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // Graph indicates an expected call of Graph.
 func (mr *MockDatabaseGraphMockRecorder) Graph(ctx, name, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Graph", reflect.TypeOf((*MockDatabaseGraph)(nil).Graph), ctx, name, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Graph",
+		reflect.TypeOf((*MockDatabaseGraph)(nil).Graph), ctx, name, options)
 }
 
 // GraphExists mocks base method.
@@ -109,13 +109,15 @@ func (m *MockDatabaseGraph) GraphExists(ctx context.Context, name string) (bool,
 	ret := m.ctrl.Call(m, "GraphExists", ctx, name)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // GraphExists indicates an expected call of GraphExists.
 func (mr *MockDatabaseGraphMockRecorder) GraphExists(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GraphExists", reflect.TypeOf((*MockDatabaseGraph)(nil).GraphExists), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GraphExists",
+		reflect.TypeOf((*MockDatabaseGraph)(nil).GraphExists), ctx, name)
 }
 
 // Graphs mocks base method.
@@ -124,20 +126,21 @@ func (m *MockDatabaseGraph) Graphs(ctx context.Context) (GraphsResponseReader, e
 	ret := m.ctrl.Call(m, "Graphs", ctx)
 	ret0, _ := ret[0].(GraphsResponseReader)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // Graphs indicates an expected call of Graphs.
 func (mr *MockDatabaseGraphMockRecorder) Graphs(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Graphs", reflect.TypeOf((*MockDatabaseGraph)(nil).Graphs), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Graphs",
+		reflect.TypeOf((*MockDatabaseGraph)(nil).Graphs), ctx)
 }
 
 // MockGraphsResponseReader is a mock of GraphsResponseReader interface.
 type MockGraphsResponseReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockGraphsResponseReaderMockRecorder
-	isgomock struct{}
 }
 
 // MockGraphsResponseReaderMockRecorder is the mock recorder for MockGraphsResponseReader.
@@ -149,6 +152,7 @@ type MockGraphsResponseReaderMockRecorder struct {
 func NewMockGraphsResponseReader(ctrl *gomock.Controller) *MockGraphsResponseReader {
 	mock := &MockGraphsResponseReader{ctrl: ctrl}
 	mock.recorder = &MockGraphsResponseReaderMockRecorder{mock}
+
 	return mock
 }
 
@@ -158,25 +162,26 @@ func (m *MockGraphsResponseReader) EXPECT() *MockGraphsResponseReaderMockRecorde
 }
 
 // Read mocks base method.
-func (m *MockGraphsResponseReader) Read() (driver.Graph, error) {
+func (m *MockGraphsResponseReader) Read() (arangodb.Graph, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read")
-	ret0, _ := ret[0].(driver.Graph)
+	ret0, _ := ret[0].(arangodb.Graph)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
 func (mr *MockGraphsResponseReaderMockRecorder) Read() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockGraphsResponseReader)(nil).Read))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read",
+		reflect.TypeOf((*MockGraphsResponseReader)(nil).Read))
 }
 
 // MockGraph is a mock of Graph interface.
 type MockGraph struct {
 	ctrl     *gomock.Controller
 	recorder *MockGraphMockRecorder
-	isgomock struct{}
 }
 
 // MockGraphMockRecorder is the mock recorder for MockGraph.
@@ -188,6 +193,7 @@ type MockGraphMockRecorder struct {
 func NewMockGraph(ctrl *gomock.Controller) *MockGraph {
 	mock := &MockGraph{ctrl: ctrl}
 	mock.recorder = &MockGraphMockRecorder{mock}
+
 	return mock
 }
 
@@ -197,63 +203,75 @@ func (m *MockGraph) EXPECT() *MockGraphMockRecorder {
 }
 
 // CreateEdgeDefinition mocks base method.
-func (m *MockGraph) CreateEdgeDefinition(ctx context.Context, collection string, from, to []string, opts *arangodb.CreateEdgeDefinitionOptions) (arangodb.CreateEdgeDefinitionResponse, error) {
+func (m *MockGraph) CreateEdgeDefinition(ctx context.Context, collection string, from, to []string,
+	opts *arangodb.CreateEdgeDefinitionOptions) (arangodb.CreateEdgeDefinitionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateEdgeDefinition", ctx, collection, from, to, opts)
 	ret0, _ := ret[0].(arangodb.CreateEdgeDefinitionResponse)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // CreateEdgeDefinition indicates an expected call of CreateEdgeDefinition.
 func (mr *MockGraphMockRecorder) CreateEdgeDefinition(ctx, collection, from, to, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEdgeDefinition", reflect.TypeOf((*MockGraph)(nil).CreateEdgeDefinition), ctx, collection, from, to, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEdgeDefinition",
+		reflect.TypeOf((*MockGraph)(nil).CreateEdgeDefinition), ctx, collection, from, to, opts)
 }
 
 // CreateVertexCollection mocks base method.
-func (m *MockGraph) CreateVertexCollection(ctx context.Context, name string, opts *arangodb.CreateVertexCollectionOptions) (arangodb.CreateVertexCollectionResponse, error) {
+func (m *MockGraph) CreateVertexCollection(ctx context.Context, name string,
+	opts *arangodb.CreateVertexCollectionOptions) (arangodb.CreateVertexCollectionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVertexCollection", ctx, name, opts)
 	ret0, _ := ret[0].(arangodb.CreateVertexCollectionResponse)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // CreateVertexCollection indicates an expected call of CreateVertexCollection.
 func (mr *MockGraphMockRecorder) CreateVertexCollection(ctx, name, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVertexCollection", reflect.TypeOf((*MockGraph)(nil).CreateVertexCollection), ctx, name, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVertexCollection",
+		reflect.TypeOf((*MockGraph)(nil).CreateVertexCollection), ctx, name, opts)
 }
 
 // DeleteEdgeDefinition mocks base method.
-func (m *MockGraph) DeleteEdgeDefinition(ctx context.Context, collection string, opts *arangodb.DeleteEdgeDefinitionOptions) (arangodb.DeleteEdgeDefinitionResponse, error) {
+func (m *MockGraph) DeleteEdgeDefinition(ctx context.Context, collection string,
+	opts *arangodb.DeleteEdgeDefinitionOptions) (arangodb.DeleteEdgeDefinitionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteEdgeDefinition", ctx, collection, opts)
 	ret0, _ := ret[0].(arangodb.DeleteEdgeDefinitionResponse)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // DeleteEdgeDefinition indicates an expected call of DeleteEdgeDefinition.
 func (mr *MockGraphMockRecorder) DeleteEdgeDefinition(ctx, collection, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEdgeDefinition", reflect.TypeOf((*MockGraph)(nil).DeleteEdgeDefinition), ctx, collection, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEdgeDefinition",
+		reflect.TypeOf((*MockGraph)(nil).DeleteEdgeDefinition), ctx, collection, opts)
 }
 
 // DeleteVertexCollection mocks base method.
-func (m *MockGraph) DeleteVertexCollection(ctx context.Context, name string, opts *arangodb.DeleteVertexCollectionOptions) (arangodb.DeleteVertexCollectionResponse, error) {
+func (m *MockGraph) DeleteVertexCollection(ctx context.Context, name string,
+	opts *arangodb.DeleteVertexCollectionOptions) (arangodb.DeleteVertexCollectionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVertexCollection", ctx, name, opts)
 	ret0, _ := ret[0].(arangodb.DeleteVertexCollectionResponse)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // DeleteVertexCollection indicates an expected call of DeleteVertexCollection.
 func (mr *MockGraphMockRecorder) DeleteVertexCollection(ctx, name, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertexCollection", reflect.TypeOf((*MockGraph)(nil).DeleteVertexCollection), ctx, name, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertexCollection",
+		reflect.TypeOf((*MockGraph)(nil).DeleteVertexCollection), ctx, name, opts)
 }
 
 // EdgeDefinition mocks base method.
@@ -262,13 +280,15 @@ func (m *MockGraph) EdgeDefinition(ctx context.Context, collection string) (aran
 	ret := m.ctrl.Call(m, "EdgeDefinition", ctx, collection)
 	ret0, _ := ret[0].(arangodb.Edge)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // EdgeDefinition indicates an expected call of EdgeDefinition.
 func (mr *MockGraphMockRecorder) EdgeDefinition(ctx, collection any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinition", reflect.TypeOf((*MockGraph)(nil).EdgeDefinition), ctx, collection)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinition",
+		reflect.TypeOf((*MockGraph)(nil).EdgeDefinition), ctx, collection)
 }
 
 // EdgeDefinitionExists mocks base method.
@@ -277,13 +297,15 @@ func (m *MockGraph) EdgeDefinitionExists(ctx context.Context, collection string)
 	ret := m.ctrl.Call(m, "EdgeDefinitionExists", ctx, collection)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // EdgeDefinitionExists indicates an expected call of EdgeDefinitionExists.
 func (mr *MockGraphMockRecorder) EdgeDefinitionExists(ctx, collection any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinitionExists", reflect.TypeOf((*MockGraph)(nil).EdgeDefinitionExists), ctx, collection)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinitionExists",
+		reflect.TypeOf((*MockGraph)(nil).EdgeDefinitionExists), ctx, collection)
 }
 
 // EdgeDefinitions mocks base method.
@@ -291,6 +313,7 @@ func (m *MockGraph) EdgeDefinitions() []EdgeDefinition {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EdgeDefinitions")
 	ret0, _ := ret[0].([]EdgeDefinition)
+
 	return ret0
 }
 
@@ -306,6 +329,7 @@ func (m *MockGraph) GetEdgeDefinitions(ctx context.Context) ([]arangodb.Edge, er
 	ret := m.ctrl.Call(m, "GetEdgeDefinitions", ctx)
 	ret0, _ := ret[0].([]arangodb.Edge)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
@@ -320,6 +344,7 @@ func (m *MockGraph) IsDisjoint() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsDisjoint")
 	ret0, _ := ret[0].(bool)
+
 	return ret0
 }
 
@@ -334,6 +359,7 @@ func (m *MockGraph) IsSatellite() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSatellite")
 	ret0, _ := ret[0].(bool)
+
 	return ret0
 }
 
@@ -348,6 +374,7 @@ func (m *MockGraph) IsSmart() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSmart")
 	ret0, _ := ret[0].(bool)
+
 	return ret0
 }
 
@@ -362,6 +389,7 @@ func (m *MockGraph) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
+
 	return ret0
 }
 
@@ -376,13 +404,15 @@ func (m *MockGraph) NumberOfShards() *int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NumberOfShards")
 	ret0, _ := ret[0].(*int)
+
 	return ret0
 }
 
 // NumberOfShards indicates an expected call of NumberOfShards.
 func (mr *MockGraphMockRecorder) NumberOfShards() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumberOfShards", reflect.TypeOf((*MockGraph)(nil).NumberOfShards))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumberOfShards",
+		reflect.TypeOf((*MockGraph)(nil).NumberOfShards))
 }
 
 // OrphanCollections mocks base method.
@@ -390,13 +420,15 @@ func (m *MockGraph) OrphanCollections() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OrphanCollections")
 	ret0, _ := ret[0].([]string)
+
 	return ret0
 }
 
 // OrphanCollections indicates an expected call of OrphanCollections.
 func (mr *MockGraphMockRecorder) OrphanCollections() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OrphanCollections", reflect.TypeOf((*MockGraph)(nil).OrphanCollections))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OrphanCollections",
+		reflect.TypeOf((*MockGraph)(nil).OrphanCollections))
 }
 
 // Remove mocks base method.
@@ -404,6 +436,7 @@ func (m *MockGraph) Remove(ctx context.Context, opts *arangodb.RemoveGraphOption
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove", ctx, opts)
 	ret0, _ := ret[0].(error)
+
 	return ret0
 }
 
@@ -414,18 +447,21 @@ func (mr *MockGraphMockRecorder) Remove(ctx, opts any) *gomock.Call {
 }
 
 // ReplaceEdgeDefinition mocks base method.
-func (m *MockGraph) ReplaceEdgeDefinition(ctx context.Context, collection string, from, to []string, opts *arangodb.ReplaceEdgeOptions) (arangodb.ReplaceEdgeDefinitionResponse, error) {
+func (m *MockGraph) ReplaceEdgeDefinition(ctx context.Context, collection string, from, to []string,
+	opts *arangodb.ReplaceEdgeOptions) (arangodb.ReplaceEdgeDefinitionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceEdgeDefinition", ctx, collection, from, to, opts)
 	ret0, _ := ret[0].(arangodb.ReplaceEdgeDefinitionResponse)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // ReplaceEdgeDefinition indicates an expected call of ReplaceEdgeDefinition.
 func (mr *MockGraphMockRecorder) ReplaceEdgeDefinition(ctx, collection, from, to, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceEdgeDefinition", reflect.TypeOf((*MockGraph)(nil).ReplaceEdgeDefinition), ctx, collection, from, to, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceEdgeDefinition",
+		reflect.TypeOf((*MockGraph)(nil).ReplaceEdgeDefinition), ctx, collection, from, to, opts)
 }
 
 // ReplicationFactor mocks base method.
@@ -433,13 +469,15 @@ func (m *MockGraph) ReplicationFactor() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplicationFactor")
 	ret0, _ := ret[0].(int)
+
 	return ret0
 }
 
 // ReplicationFactor indicates an expected call of ReplicationFactor.
 func (mr *MockGraphMockRecorder) ReplicationFactor() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicationFactor", reflect.TypeOf((*MockGraph)(nil).ReplicationFactor))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicationFactor",
+		reflect.TypeOf((*MockGraph)(nil).ReplicationFactor))
 }
 
 // SmartGraphAttribute mocks base method.
@@ -447,13 +485,15 @@ func (m *MockGraph) SmartGraphAttribute() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SmartGraphAttribute")
 	ret0, _ := ret[0].(string)
+
 	return ret0
 }
 
 // SmartGraphAttribute indicates an expected call of SmartGraphAttribute.
 func (mr *MockGraphMockRecorder) SmartGraphAttribute() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SmartGraphAttribute", reflect.TypeOf((*MockGraph)(nil).SmartGraphAttribute))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SmartGraphAttribute",
+		reflect.TypeOf((*MockGraph)(nil).SmartGraphAttribute))
 }
 
 // VertexCollection mocks base method.
@@ -462,13 +502,15 @@ func (m *MockGraph) VertexCollection(ctx context.Context, name string) (arangodb
 	ret := m.ctrl.Call(m, "VertexCollection", ctx, name)
 	ret0, _ := ret[0].(arangodb.VertexCollection)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // VertexCollection indicates an expected call of VertexCollection.
 func (mr *MockGraphMockRecorder) VertexCollection(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollection", reflect.TypeOf((*MockGraph)(nil).VertexCollection), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollection",
+		reflect.TypeOf((*MockGraph)(nil).VertexCollection), ctx, name)
 }
 
 // VertexCollectionExists mocks base method.
@@ -477,13 +519,15 @@ func (m *MockGraph) VertexCollectionExists(ctx context.Context, name string) (bo
 	ret := m.ctrl.Call(m, "VertexCollectionExists", ctx, name)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // VertexCollectionExists indicates an expected call of VertexCollectionExists.
 func (mr *MockGraphMockRecorder) VertexCollectionExists(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollectionExists", reflect.TypeOf((*MockGraph)(nil).VertexCollectionExists), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollectionExists",
+		reflect.TypeOf((*MockGraph)(nil).VertexCollectionExists), ctx, name)
 }
 
 // VertexCollections mocks base method.
@@ -492,13 +536,15 @@ func (m *MockGraph) VertexCollections(ctx context.Context) ([]arangodb.VertexCol
 	ret := m.ctrl.Call(m, "VertexCollections", ctx)
 	ret0, _ := ret[0].([]arangodb.VertexCollection)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // VertexCollections indicates an expected call of VertexCollections.
 func (mr *MockGraphMockRecorder) VertexCollections(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollections", reflect.TypeOf((*MockGraph)(nil).VertexCollections), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollections",
+		reflect.TypeOf((*MockGraph)(nil).VertexCollections), ctx)
 }
 
 // WriteConcern mocks base method.
@@ -506,6 +552,7 @@ func (m *MockGraph) WriteConcern() *int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteConcern")
 	ret0, _ := ret[0].(*int)
+
 	return ret0
 }
 
@@ -519,7 +566,6 @@ func (mr *MockGraphMockRecorder) WriteConcern() *gomock.Call {
 type MockGraphVertexCollections struct {
 	ctrl     *gomock.Controller
 	recorder *MockGraphVertexCollectionsMockRecorder
-	isgomock struct{}
 }
 
 // MockGraphVertexCollectionsMockRecorder is the mock recorder for MockGraphVertexCollections.
@@ -531,6 +577,7 @@ type MockGraphVertexCollectionsMockRecorder struct {
 func NewMockGraphVertexCollections(ctrl *gomock.Controller) *MockGraphVertexCollections {
 	mock := &MockGraphVertexCollections{ctrl: ctrl}
 	mock.recorder = &MockGraphVertexCollectionsMockRecorder{mock}
+
 	return mock
 }
 
@@ -540,33 +587,39 @@ func (m *MockGraphVertexCollections) EXPECT() *MockGraphVertexCollectionsMockRec
 }
 
 // CreateVertexCollection mocks base method.
-func (m *MockGraphVertexCollections) CreateVertexCollection(ctx context.Context, name string, opts *arangodb.CreateVertexCollectionOptions) (arangodb.CreateVertexCollectionResponse, error) {
+func (m *MockGraphVertexCollections) CreateVertexCollection(ctx context.Context, name string,
+	opts *arangodb.CreateVertexCollectionOptions) (arangodb.CreateVertexCollectionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVertexCollection", ctx, name, opts)
 	ret0, _ := ret[0].(arangodb.CreateVertexCollectionResponse)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // CreateVertexCollection indicates an expected call of CreateVertexCollection.
 func (mr *MockGraphVertexCollectionsMockRecorder) CreateVertexCollection(ctx, name, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVertexCollection", reflect.TypeOf((*MockGraphVertexCollections)(nil).CreateVertexCollection), ctx, name, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVertexCollection",
+		reflect.TypeOf((*MockGraphVertexCollections)(nil).CreateVertexCollection), ctx, name, opts)
 }
 
 // DeleteVertexCollection mocks base method.
-func (m *MockGraphVertexCollections) DeleteVertexCollection(ctx context.Context, name string, opts *arangodb.DeleteVertexCollectionOptions) (arangodb.DeleteVertexCollectionResponse, error) {
+func (m *MockGraphVertexCollections) DeleteVertexCollection(ctx context.Context, name string,
+	opts *arangodb.DeleteVertexCollectionOptions) (arangodb.DeleteVertexCollectionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVertexCollection", ctx, name, opts)
 	ret0, _ := ret[0].(arangodb.DeleteVertexCollectionResponse)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // DeleteVertexCollection indicates an expected call of DeleteVertexCollection.
 func (mr *MockGraphVertexCollectionsMockRecorder) DeleteVertexCollection(ctx, name, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertexCollection", reflect.TypeOf((*MockGraphVertexCollections)(nil).DeleteVertexCollection), ctx, name, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock,
+		"DeleteVertexCollection", reflect.TypeOf((*MockGraphVertexCollections)(nil).DeleteVertexCollection), ctx, name, opts)
 }
 
 // VertexCollection mocks base method.
@@ -575,13 +628,15 @@ func (m *MockGraphVertexCollections) VertexCollection(ctx context.Context, name 
 	ret := m.ctrl.Call(m, "VertexCollection", ctx, name)
 	ret0, _ := ret[0].(arangodb.VertexCollection)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // VertexCollection indicates an expected call of VertexCollection.
 func (mr *MockGraphVertexCollectionsMockRecorder) VertexCollection(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollection", reflect.TypeOf((*MockGraphVertexCollections)(nil).VertexCollection), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock,
+		"VertexCollection", reflect.TypeOf((*MockGraphVertexCollections)(nil).VertexCollection), ctx, name)
 }
 
 // VertexCollectionExists mocks base method.
@@ -590,13 +645,15 @@ func (m *MockGraphVertexCollections) VertexCollectionExists(ctx context.Context,
 	ret := m.ctrl.Call(m, "VertexCollectionExists", ctx, name)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // VertexCollectionExists indicates an expected call of VertexCollectionExists.
 func (mr *MockGraphVertexCollectionsMockRecorder) VertexCollectionExists(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollectionExists", reflect.TypeOf((*MockGraphVertexCollections)(nil).VertexCollectionExists), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock,
+		"VertexCollectionExists", reflect.TypeOf((*MockGraphVertexCollections)(nil).VertexCollectionExists), ctx, name)
 }
 
 // VertexCollections mocks base method.
@@ -605,20 +662,21 @@ func (m *MockGraphVertexCollections) VertexCollections(ctx context.Context) ([]a
 	ret := m.ctrl.Call(m, "VertexCollections", ctx)
 	ret0, _ := ret[0].([]arangodb.VertexCollection)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // VertexCollections indicates an expected call of VertexCollections.
 func (mr *MockGraphVertexCollectionsMockRecorder) VertexCollections(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollections", reflect.TypeOf((*MockGraphVertexCollections)(nil).VertexCollections), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollections",
+		reflect.TypeOf((*MockGraphVertexCollections)(nil).VertexCollections), ctx)
 }
 
 // MockGraphEdgesDefinition is a mock of GraphEdgesDefinition interface.
 type MockGraphEdgesDefinition struct {
 	ctrl     *gomock.Controller
 	recorder *MockGraphEdgesDefinitionMockRecorder
-	isgomock struct{}
 }
 
 // MockGraphEdgesDefinitionMockRecorder is the mock recorder for MockGraphEdgesDefinition.
@@ -630,6 +688,7 @@ type MockGraphEdgesDefinitionMockRecorder struct {
 func NewMockGraphEdgesDefinition(ctrl *gomock.Controller) *MockGraphEdgesDefinition {
 	mock := &MockGraphEdgesDefinition{ctrl: ctrl}
 	mock.recorder = &MockGraphEdgesDefinitionMockRecorder{mock}
+
 	return mock
 }
 
@@ -639,33 +698,39 @@ func (m *MockGraphEdgesDefinition) EXPECT() *MockGraphEdgesDefinitionMockRecorde
 }
 
 // CreateEdgeDefinition mocks base method.
-func (m *MockGraphEdgesDefinition) CreateEdgeDefinition(ctx context.Context, collection string, from, to []string, opts *arangodb.CreateEdgeDefinitionOptions) (arangodb.CreateEdgeDefinitionResponse, error) {
+func (m *MockGraphEdgesDefinition) CreateEdgeDefinition(ctx context.Context, collection string, from, to []string,
+	opts *arangodb.CreateEdgeDefinitionOptions) (arangodb.CreateEdgeDefinitionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateEdgeDefinition", ctx, collection, from, to, opts)
 	ret0, _ := ret[0].(arangodb.CreateEdgeDefinitionResponse)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // CreateEdgeDefinition indicates an expected call of CreateEdgeDefinition.
 func (mr *MockGraphEdgesDefinitionMockRecorder) CreateEdgeDefinition(ctx, collection, from, to, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEdgeDefinition", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).CreateEdgeDefinition), ctx, collection, from, to, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEdgeDefinition",
+		reflect.TypeOf((*MockGraphEdgesDefinition)(nil).CreateEdgeDefinition), ctx, collection, from, to, opts)
 }
 
 // DeleteEdgeDefinition mocks base method.
-func (m *MockGraphEdgesDefinition) DeleteEdgeDefinition(ctx context.Context, collection string, opts *arangodb.DeleteEdgeDefinitionOptions) (arangodb.DeleteEdgeDefinitionResponse, error) {
+func (m *MockGraphEdgesDefinition) DeleteEdgeDefinition(ctx context.Context, collection string,
+	opts *arangodb.DeleteEdgeDefinitionOptions) (arangodb.DeleteEdgeDefinitionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteEdgeDefinition", ctx, collection, opts)
 	ret0, _ := ret[0].(arangodb.DeleteEdgeDefinitionResponse)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // DeleteEdgeDefinition indicates an expected call of DeleteEdgeDefinition.
 func (mr *MockGraphEdgesDefinitionMockRecorder) DeleteEdgeDefinition(ctx, collection, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEdgeDefinition", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).DeleteEdgeDefinition), ctx, collection, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEdgeDefinition",
+		reflect.TypeOf((*MockGraphEdgesDefinition)(nil).DeleteEdgeDefinition), ctx, collection, opts)
 }
 
 // EdgeDefinition mocks base method.
@@ -674,13 +739,15 @@ func (m *MockGraphEdgesDefinition) EdgeDefinition(ctx context.Context, collectio
 	ret := m.ctrl.Call(m, "EdgeDefinition", ctx, collection)
 	ret0, _ := ret[0].(arangodb.Edge)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // EdgeDefinition indicates an expected call of EdgeDefinition.
 func (mr *MockGraphEdgesDefinitionMockRecorder) EdgeDefinition(ctx, collection any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinition", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).EdgeDefinition), ctx, collection)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinition",
+		reflect.TypeOf((*MockGraphEdgesDefinition)(nil).EdgeDefinition), ctx, collection)
 }
 
 // EdgeDefinitionExists mocks base method.
@@ -689,13 +756,15 @@ func (m *MockGraphEdgesDefinition) EdgeDefinitionExists(ctx context.Context, col
 	ret := m.ctrl.Call(m, "EdgeDefinitionExists", ctx, collection)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // EdgeDefinitionExists indicates an expected call of EdgeDefinitionExists.
 func (mr *MockGraphEdgesDefinitionMockRecorder) EdgeDefinitionExists(ctx, collection any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinitionExists", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).EdgeDefinitionExists), ctx, collection)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinitionExists",
+		reflect.TypeOf((*MockGraphEdgesDefinition)(nil).EdgeDefinitionExists), ctx, collection)
 }
 
 // GetEdgeDefinitions mocks base method.
@@ -704,26 +773,32 @@ func (m *MockGraphEdgesDefinition) GetEdgeDefinitions(ctx context.Context) ([]ar
 	ret := m.ctrl.Call(m, "GetEdgeDefinitions", ctx)
 	ret0, _ := ret[0].([]arangodb.Edge)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // GetEdgeDefinitions indicates an expected call of GetEdgeDefinitions.
 func (mr *MockGraphEdgesDefinitionMockRecorder) GetEdgeDefinitions(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEdgeDefinitions", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).GetEdgeDefinitions), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEdgeDefinitions",
+		reflect.TypeOf((*MockGraphEdgesDefinition)(nil).GetEdgeDefinitions), ctx)
 }
 
 // ReplaceEdgeDefinition mocks base method.
-func (m *MockGraphEdgesDefinition) ReplaceEdgeDefinition(ctx context.Context, collection string, from, to []string, opts *arangodb.ReplaceEdgeOptions) (arangodb.ReplaceEdgeDefinitionResponse, error) {
+func (m *MockGraphEdgesDefinition) ReplaceEdgeDefinition(ctx context.Context, collection string,
+	from, to []string, opts *arangodb.ReplaceEdgeOptions) (arangodb.ReplaceEdgeDefinitionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceEdgeDefinition", ctx, collection, from, to, opts)
 	ret0, _ := ret[0].(arangodb.ReplaceEdgeDefinitionResponse)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
 // ReplaceEdgeDefinition indicates an expected call of ReplaceEdgeDefinition.
 func (mr *MockGraphEdgesDefinitionMockRecorder) ReplaceEdgeDefinition(ctx, collection, from, to, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceEdgeDefinition", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).ReplaceEdgeDefinition), ctx, collection, from, to, opts)
+
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceEdgeDefinition",
+		reflect.TypeOf((*MockGraphEdgesDefinition)(nil).ReplaceEdgeDefinition), ctx, collection, from, to, opts)
 }

--- a/pkg/gofr/datasource/arangodb/mock_graph.go
+++ b/pkg/gofr/datasource/arangodb/mock_graph.go
@@ -309,10 +309,10 @@ func (mr *MockGraphMockRecorder) EdgeDefinitionExists(ctx, collection any) *gomo
 }
 
 // EdgeDefinitions mocks base method.
-func (m *MockGraph) EdgeDefinitions() []EdgeDefinition {
+func (m *MockGraph) EdgeDefinitions() []arangodb.EdgeDefinition {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EdgeDefinitions")
-	ret0, _ := ret[0].([]EdgeDefinition)
+	ret0, _ := ret[0].([]arangodb.EdgeDefinition)
 
 	return ret0
 }

--- a/pkg/gofr/datasource/arangodb/mock_graph.go
+++ b/pkg/gofr/datasource/arangodb/mock_graph.go
@@ -1,0 +1,729 @@
+package arangodb
+
+import (
+	"context"
+	"github.com/arangodb/go-driver/v2/arangodb"
+	"reflect"
+
+	"github.com/arangodb/go-driver"
+	"go.uber.org/mock/gomock"
+)
+
+// MockDatabaseGraph is a mock of DatabaseGraph interface.
+type MockDatabaseGraph struct {
+	ctrl     *gomock.Controller
+	recorder *MockDatabaseGraphMockRecorder
+	isgomock struct{}
+}
+
+// MockDatabaseGraphMockRecorder is the mock recorder for MockDatabaseGraph.
+type MockDatabaseGraphMockRecorder struct {
+	mock *MockDatabaseGraph
+}
+
+type EdgeDirection string
+type GetEdgesOptions struct {
+	// The direction of the edges. Allowed values are "in" and "out". If not set, edges in both directions are returned.
+	Direction EdgeDirection `json:"direction,omitempty"`
+
+	// Set this to true to allow the Coordinator to ask any shard replica for the data, not only the shard leader.
+	// This may result array of collection names that is used to create SatelliteCollections for a (Disjoint) SmartGraph
+	// using SatelliteCollections (Enterprise Edition only). Each array element must be a string and a valid
+	// collection name. The collection type cannot be modified later.
+	Satellites []string `json:"satellites,omitempty"`
+}
+
+type GraphsResponseReader interface {
+	// Read returns next Graph. If no Graph left, shared.NoMoreDocumentsError returned
+	Read() (driver.Graph, error)
+}
+
+func (q *GetEdgesOptions) modifyRequest(r driver.Request) error {
+	if q == nil {
+		return nil
+	}
+
+	return nil
+}
+
+// NewMockDatabaseGraph creates a new mock instance.
+func NewMockDatabaseGraph(ctrl *gomock.Controller) *MockDatabaseGraph {
+	mock := &MockDatabaseGraph{ctrl: ctrl}
+	mock.recorder = &MockDatabaseGraphMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDatabaseGraph) EXPECT() *MockDatabaseGraphMockRecorder {
+	return m.recorder
+}
+
+// CreateGraph mocks base method.
+func (m *MockDatabaseGraph) CreateGraph(ctx context.Context, name string, graph *arangodb.GraphDefinition, options *arangodb.CreateGraphOptions) (driver.Graph, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateGraph", ctx, name, graph, options)
+	ret0, _ := ret[0].(driver.Graph)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateGraph indicates an expected call of CreateGraph.
+func (mr *MockDatabaseGraphMockRecorder) CreateGraph(ctx, name, graph, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGraph", reflect.TypeOf((*MockDatabaseGraph)(nil).CreateGraph), ctx, name, graph, options)
+}
+
+// GetEdges mocks base method.
+func (m *MockDatabaseGraph) GetEdges(ctx context.Context, name, vertex string, options *GetEdgesOptions) ([]EdgeDetails, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEdges", ctx, name, vertex, options)
+	ret0, _ := ret[0].([]EdgeDetails)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEdges indicates an expected call of GetEdges.
+func (mr *MockDatabaseGraphMockRecorder) GetEdges(ctx, name, vertex, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEdges", reflect.TypeOf((*MockDatabaseGraph)(nil).GetEdges), ctx, name, vertex, options)
+}
+
+// Graph mocks base method.
+func (m *MockDatabaseGraph) Graph(ctx context.Context, name string, options *arangodb.GetGraphOptions) (driver.Graph, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Graph", ctx, name, options)
+	ret0, _ := ret[0].(driver.Graph)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Graph indicates an expected call of Graph.
+func (mr *MockDatabaseGraphMockRecorder) Graph(ctx, name, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Graph", reflect.TypeOf((*MockDatabaseGraph)(nil).Graph), ctx, name, options)
+}
+
+// GraphExists mocks base method.
+func (m *MockDatabaseGraph) GraphExists(ctx context.Context, name string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GraphExists", ctx, name)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GraphExists indicates an expected call of GraphExists.
+func (mr *MockDatabaseGraphMockRecorder) GraphExists(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GraphExists", reflect.TypeOf((*MockDatabaseGraph)(nil).GraphExists), ctx, name)
+}
+
+// Graphs mocks base method.
+func (m *MockDatabaseGraph) Graphs(ctx context.Context) (GraphsResponseReader, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Graphs", ctx)
+	ret0, _ := ret[0].(GraphsResponseReader)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Graphs indicates an expected call of Graphs.
+func (mr *MockDatabaseGraphMockRecorder) Graphs(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Graphs", reflect.TypeOf((*MockDatabaseGraph)(nil).Graphs), ctx)
+}
+
+// MockGraphsResponseReader is a mock of GraphsResponseReader interface.
+type MockGraphsResponseReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockGraphsResponseReaderMockRecorder
+	isgomock struct{}
+}
+
+// MockGraphsResponseReaderMockRecorder is the mock recorder for MockGraphsResponseReader.
+type MockGraphsResponseReaderMockRecorder struct {
+	mock *MockGraphsResponseReader
+}
+
+// NewMockGraphsResponseReader creates a new mock instance.
+func NewMockGraphsResponseReader(ctrl *gomock.Controller) *MockGraphsResponseReader {
+	mock := &MockGraphsResponseReader{ctrl: ctrl}
+	mock.recorder = &MockGraphsResponseReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockGraphsResponseReader) EXPECT() *MockGraphsResponseReaderMockRecorder {
+	return m.recorder
+}
+
+// Read mocks base method.
+func (m *MockGraphsResponseReader) Read() (driver.Graph, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Read")
+	ret0, _ := ret[0].(driver.Graph)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Read indicates an expected call of Read.
+func (mr *MockGraphsResponseReaderMockRecorder) Read() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockGraphsResponseReader)(nil).Read))
+}
+
+// MockGraph is a mock of Graph interface.
+type MockGraph struct {
+	ctrl     *gomock.Controller
+	recorder *MockGraphMockRecorder
+	isgomock struct{}
+}
+
+// MockGraphMockRecorder is the mock recorder for MockGraph.
+type MockGraphMockRecorder struct {
+	mock *MockGraph
+}
+
+// NewMockGraph creates a new mock instance.
+func NewMockGraph(ctrl *gomock.Controller) *MockGraph {
+	mock := &MockGraph{ctrl: ctrl}
+	mock.recorder = &MockGraphMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockGraph) EXPECT() *MockGraphMockRecorder {
+	return m.recorder
+}
+
+// CreateEdgeDefinition mocks base method.
+func (m *MockGraph) CreateEdgeDefinition(ctx context.Context, collection string, from, to []string, opts *arangodb.CreateEdgeDefinitionOptions) (arangodb.CreateEdgeDefinitionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateEdgeDefinition", ctx, collection, from, to, opts)
+	ret0, _ := ret[0].(arangodb.CreateEdgeDefinitionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateEdgeDefinition indicates an expected call of CreateEdgeDefinition.
+func (mr *MockGraphMockRecorder) CreateEdgeDefinition(ctx, collection, from, to, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEdgeDefinition", reflect.TypeOf((*MockGraph)(nil).CreateEdgeDefinition), ctx, collection, from, to, opts)
+}
+
+// CreateVertexCollection mocks base method.
+func (m *MockGraph) CreateVertexCollection(ctx context.Context, name string, opts *arangodb.CreateVertexCollectionOptions) (arangodb.CreateVertexCollectionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVertexCollection", ctx, name, opts)
+	ret0, _ := ret[0].(arangodb.CreateVertexCollectionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVertexCollection indicates an expected call of CreateVertexCollection.
+func (mr *MockGraphMockRecorder) CreateVertexCollection(ctx, name, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVertexCollection", reflect.TypeOf((*MockGraph)(nil).CreateVertexCollection), ctx, name, opts)
+}
+
+// DeleteEdgeDefinition mocks base method.
+func (m *MockGraph) DeleteEdgeDefinition(ctx context.Context, collection string, opts *arangodb.DeleteEdgeDefinitionOptions) (arangodb.DeleteEdgeDefinitionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEdgeDefinition", ctx, collection, opts)
+	ret0, _ := ret[0].(arangodb.DeleteEdgeDefinitionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteEdgeDefinition indicates an expected call of DeleteEdgeDefinition.
+func (mr *MockGraphMockRecorder) DeleteEdgeDefinition(ctx, collection, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEdgeDefinition", reflect.TypeOf((*MockGraph)(nil).DeleteEdgeDefinition), ctx, collection, opts)
+}
+
+// DeleteVertexCollection mocks base method.
+func (m *MockGraph) DeleteVertexCollection(ctx context.Context, name string, opts *arangodb.DeleteVertexCollectionOptions) (arangodb.DeleteVertexCollectionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVertexCollection", ctx, name, opts)
+	ret0, _ := ret[0].(arangodb.DeleteVertexCollectionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteVertexCollection indicates an expected call of DeleteVertexCollection.
+func (mr *MockGraphMockRecorder) DeleteVertexCollection(ctx, name, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertexCollection", reflect.TypeOf((*MockGraph)(nil).DeleteVertexCollection), ctx, name, opts)
+}
+
+// EdgeDefinition mocks base method.
+func (m *MockGraph) EdgeDefinition(ctx context.Context, collection string) (arangodb.Edge, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EdgeDefinition", ctx, collection)
+	ret0, _ := ret[0].(arangodb.Edge)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EdgeDefinition indicates an expected call of EdgeDefinition.
+func (mr *MockGraphMockRecorder) EdgeDefinition(ctx, collection any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinition", reflect.TypeOf((*MockGraph)(nil).EdgeDefinition), ctx, collection)
+}
+
+// EdgeDefinitionExists mocks base method.
+func (m *MockGraph) EdgeDefinitionExists(ctx context.Context, collection string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EdgeDefinitionExists", ctx, collection)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EdgeDefinitionExists indicates an expected call of EdgeDefinitionExists.
+func (mr *MockGraphMockRecorder) EdgeDefinitionExists(ctx, collection any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinitionExists", reflect.TypeOf((*MockGraph)(nil).EdgeDefinitionExists), ctx, collection)
+}
+
+// EdgeDefinitions mocks base method.
+func (m *MockGraph) EdgeDefinitions() []EdgeDefinition {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EdgeDefinitions")
+	ret0, _ := ret[0].([]EdgeDefinition)
+	return ret0
+}
+
+// EdgeDefinitions indicates an expected call of EdgeDefinitions.
+func (mr *MockGraphMockRecorder) EdgeDefinitions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinitions", reflect.TypeOf((*MockGraph)(nil).EdgeDefinitions))
+}
+
+// GetEdgeDefinitions mocks base method.
+func (m *MockGraph) GetEdgeDefinitions(ctx context.Context) ([]arangodb.Edge, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEdgeDefinitions", ctx)
+	ret0, _ := ret[0].([]arangodb.Edge)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEdgeDefinitions indicates an expected call of GetEdgeDefinitions.
+func (mr *MockGraphMockRecorder) GetEdgeDefinitions(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEdgeDefinitions", reflect.TypeOf((*MockGraph)(nil).GetEdgeDefinitions), ctx)
+}
+
+// IsDisjoint mocks base method.
+func (m *MockGraph) IsDisjoint() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDisjoint")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDisjoint indicates an expected call of IsDisjoint.
+func (mr *MockGraphMockRecorder) IsDisjoint() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDisjoint", reflect.TypeOf((*MockGraph)(nil).IsDisjoint))
+}
+
+// IsSatellite mocks base method.
+func (m *MockGraph) IsSatellite() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSatellite")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSatellite indicates an expected call of IsSatellite.
+func (mr *MockGraphMockRecorder) IsSatellite() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSatellite", reflect.TypeOf((*MockGraph)(nil).IsSatellite))
+}
+
+// IsSmart mocks base method.
+func (m *MockGraph) IsSmart() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSmart")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSmart indicates an expected call of IsSmart.
+func (mr *MockGraphMockRecorder) IsSmart() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSmart", reflect.TypeOf((*MockGraph)(nil).IsSmart))
+}
+
+// Name mocks base method.
+func (m *MockGraph) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockGraphMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockGraph)(nil).Name))
+}
+
+// NumberOfShards mocks base method.
+func (m *MockGraph) NumberOfShards() *int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NumberOfShards")
+	ret0, _ := ret[0].(*int)
+	return ret0
+}
+
+// NumberOfShards indicates an expected call of NumberOfShards.
+func (mr *MockGraphMockRecorder) NumberOfShards() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumberOfShards", reflect.TypeOf((*MockGraph)(nil).NumberOfShards))
+}
+
+// OrphanCollections mocks base method.
+func (m *MockGraph) OrphanCollections() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OrphanCollections")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// OrphanCollections indicates an expected call of OrphanCollections.
+func (mr *MockGraphMockRecorder) OrphanCollections() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OrphanCollections", reflect.TypeOf((*MockGraph)(nil).OrphanCollections))
+}
+
+// Remove mocks base method.
+func (m *MockGraph) Remove(ctx context.Context, opts *arangodb.RemoveGraphOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Remove", ctx, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Remove indicates an expected call of Remove.
+func (mr *MockGraphMockRecorder) Remove(ctx, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockGraph)(nil).Remove), ctx, opts)
+}
+
+// ReplaceEdgeDefinition mocks base method.
+func (m *MockGraph) ReplaceEdgeDefinition(ctx context.Context, collection string, from, to []string, opts *arangodb.ReplaceEdgeOptions) (arangodb.ReplaceEdgeDefinitionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReplaceEdgeDefinition", ctx, collection, from, to, opts)
+	ret0, _ := ret[0].(arangodb.ReplaceEdgeDefinitionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReplaceEdgeDefinition indicates an expected call of ReplaceEdgeDefinition.
+func (mr *MockGraphMockRecorder) ReplaceEdgeDefinition(ctx, collection, from, to, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceEdgeDefinition", reflect.TypeOf((*MockGraph)(nil).ReplaceEdgeDefinition), ctx, collection, from, to, opts)
+}
+
+// ReplicationFactor mocks base method.
+func (m *MockGraph) ReplicationFactor() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReplicationFactor")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ReplicationFactor indicates an expected call of ReplicationFactor.
+func (mr *MockGraphMockRecorder) ReplicationFactor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicationFactor", reflect.TypeOf((*MockGraph)(nil).ReplicationFactor))
+}
+
+// SmartGraphAttribute mocks base method.
+func (m *MockGraph) SmartGraphAttribute() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SmartGraphAttribute")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// SmartGraphAttribute indicates an expected call of SmartGraphAttribute.
+func (mr *MockGraphMockRecorder) SmartGraphAttribute() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SmartGraphAttribute", reflect.TypeOf((*MockGraph)(nil).SmartGraphAttribute))
+}
+
+// VertexCollection mocks base method.
+func (m *MockGraph) VertexCollection(ctx context.Context, name string) (arangodb.VertexCollection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VertexCollection", ctx, name)
+	ret0, _ := ret[0].(arangodb.VertexCollection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VertexCollection indicates an expected call of VertexCollection.
+func (mr *MockGraphMockRecorder) VertexCollection(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollection", reflect.TypeOf((*MockGraph)(nil).VertexCollection), ctx, name)
+}
+
+// VertexCollectionExists mocks base method.
+func (m *MockGraph) VertexCollectionExists(ctx context.Context, name string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VertexCollectionExists", ctx, name)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VertexCollectionExists indicates an expected call of VertexCollectionExists.
+func (mr *MockGraphMockRecorder) VertexCollectionExists(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollectionExists", reflect.TypeOf((*MockGraph)(nil).VertexCollectionExists), ctx, name)
+}
+
+// VertexCollections mocks base method.
+func (m *MockGraph) VertexCollections(ctx context.Context) ([]arangodb.VertexCollection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VertexCollections", ctx)
+	ret0, _ := ret[0].([]arangodb.VertexCollection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VertexCollections indicates an expected call of VertexCollections.
+func (mr *MockGraphMockRecorder) VertexCollections(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollections", reflect.TypeOf((*MockGraph)(nil).VertexCollections), ctx)
+}
+
+// WriteConcern mocks base method.
+func (m *MockGraph) WriteConcern() *int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteConcern")
+	ret0, _ := ret[0].(*int)
+	return ret0
+}
+
+// WriteConcern indicates an expected call of WriteConcern.
+func (mr *MockGraphMockRecorder) WriteConcern() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteConcern", reflect.TypeOf((*MockGraph)(nil).WriteConcern))
+}
+
+// MockGraphVertexCollections is a mock of GraphVertexCollections interface.
+type MockGraphVertexCollections struct {
+	ctrl     *gomock.Controller
+	recorder *MockGraphVertexCollectionsMockRecorder
+	isgomock struct{}
+}
+
+// MockGraphVertexCollectionsMockRecorder is the mock recorder for MockGraphVertexCollections.
+type MockGraphVertexCollectionsMockRecorder struct {
+	mock *MockGraphVertexCollections
+}
+
+// NewMockGraphVertexCollections creates a new mock instance.
+func NewMockGraphVertexCollections(ctrl *gomock.Controller) *MockGraphVertexCollections {
+	mock := &MockGraphVertexCollections{ctrl: ctrl}
+	mock.recorder = &MockGraphVertexCollectionsMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockGraphVertexCollections) EXPECT() *MockGraphVertexCollectionsMockRecorder {
+	return m.recorder
+}
+
+// CreateVertexCollection mocks base method.
+func (m *MockGraphVertexCollections) CreateVertexCollection(ctx context.Context, name string, opts *arangodb.CreateVertexCollectionOptions) (arangodb.CreateVertexCollectionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVertexCollection", ctx, name, opts)
+	ret0, _ := ret[0].(arangodb.CreateVertexCollectionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVertexCollection indicates an expected call of CreateVertexCollection.
+func (mr *MockGraphVertexCollectionsMockRecorder) CreateVertexCollection(ctx, name, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVertexCollection", reflect.TypeOf((*MockGraphVertexCollections)(nil).CreateVertexCollection), ctx, name, opts)
+}
+
+// DeleteVertexCollection mocks base method.
+func (m *MockGraphVertexCollections) DeleteVertexCollection(ctx context.Context, name string, opts *arangodb.DeleteVertexCollectionOptions) (arangodb.DeleteVertexCollectionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVertexCollection", ctx, name, opts)
+	ret0, _ := ret[0].(arangodb.DeleteVertexCollectionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteVertexCollection indicates an expected call of DeleteVertexCollection.
+func (mr *MockGraphVertexCollectionsMockRecorder) DeleteVertexCollection(ctx, name, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVertexCollection", reflect.TypeOf((*MockGraphVertexCollections)(nil).DeleteVertexCollection), ctx, name, opts)
+}
+
+// VertexCollection mocks base method.
+func (m *MockGraphVertexCollections) VertexCollection(ctx context.Context, name string) (arangodb.VertexCollection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VertexCollection", ctx, name)
+	ret0, _ := ret[0].(arangodb.VertexCollection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VertexCollection indicates an expected call of VertexCollection.
+func (mr *MockGraphVertexCollectionsMockRecorder) VertexCollection(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollection", reflect.TypeOf((*MockGraphVertexCollections)(nil).VertexCollection), ctx, name)
+}
+
+// VertexCollectionExists mocks base method.
+func (m *MockGraphVertexCollections) VertexCollectionExists(ctx context.Context, name string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VertexCollectionExists", ctx, name)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VertexCollectionExists indicates an expected call of VertexCollectionExists.
+func (mr *MockGraphVertexCollectionsMockRecorder) VertexCollectionExists(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollectionExists", reflect.TypeOf((*MockGraphVertexCollections)(nil).VertexCollectionExists), ctx, name)
+}
+
+// VertexCollections mocks base method.
+func (m *MockGraphVertexCollections) VertexCollections(ctx context.Context) ([]arangodb.VertexCollection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VertexCollections", ctx)
+	ret0, _ := ret[0].([]arangodb.VertexCollection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VertexCollections indicates an expected call of VertexCollections.
+func (mr *MockGraphVertexCollectionsMockRecorder) VertexCollections(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VertexCollections", reflect.TypeOf((*MockGraphVertexCollections)(nil).VertexCollections), ctx)
+}
+
+// MockGraphEdgesDefinition is a mock of GraphEdgesDefinition interface.
+type MockGraphEdgesDefinition struct {
+	ctrl     *gomock.Controller
+	recorder *MockGraphEdgesDefinitionMockRecorder
+	isgomock struct{}
+}
+
+// MockGraphEdgesDefinitionMockRecorder is the mock recorder for MockGraphEdgesDefinition.
+type MockGraphEdgesDefinitionMockRecorder struct {
+	mock *MockGraphEdgesDefinition
+}
+
+// NewMockGraphEdgesDefinition creates a new mock instance.
+func NewMockGraphEdgesDefinition(ctrl *gomock.Controller) *MockGraphEdgesDefinition {
+	mock := &MockGraphEdgesDefinition{ctrl: ctrl}
+	mock.recorder = &MockGraphEdgesDefinitionMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockGraphEdgesDefinition) EXPECT() *MockGraphEdgesDefinitionMockRecorder {
+	return m.recorder
+}
+
+// CreateEdgeDefinition mocks base method.
+func (m *MockGraphEdgesDefinition) CreateEdgeDefinition(ctx context.Context, collection string, from, to []string, opts *arangodb.CreateEdgeDefinitionOptions) (arangodb.CreateEdgeDefinitionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateEdgeDefinition", ctx, collection, from, to, opts)
+	ret0, _ := ret[0].(arangodb.CreateEdgeDefinitionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateEdgeDefinition indicates an expected call of CreateEdgeDefinition.
+func (mr *MockGraphEdgesDefinitionMockRecorder) CreateEdgeDefinition(ctx, collection, from, to, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEdgeDefinition", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).CreateEdgeDefinition), ctx, collection, from, to, opts)
+}
+
+// DeleteEdgeDefinition mocks base method.
+func (m *MockGraphEdgesDefinition) DeleteEdgeDefinition(ctx context.Context, collection string, opts *arangodb.DeleteEdgeDefinitionOptions) (arangodb.DeleteEdgeDefinitionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEdgeDefinition", ctx, collection, opts)
+	ret0, _ := ret[0].(arangodb.DeleteEdgeDefinitionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteEdgeDefinition indicates an expected call of DeleteEdgeDefinition.
+func (mr *MockGraphEdgesDefinitionMockRecorder) DeleteEdgeDefinition(ctx, collection, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEdgeDefinition", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).DeleteEdgeDefinition), ctx, collection, opts)
+}
+
+// EdgeDefinition mocks base method.
+func (m *MockGraphEdgesDefinition) EdgeDefinition(ctx context.Context, collection string) (arangodb.Edge, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EdgeDefinition", ctx, collection)
+	ret0, _ := ret[0].(arangodb.Edge)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EdgeDefinition indicates an expected call of EdgeDefinition.
+func (mr *MockGraphEdgesDefinitionMockRecorder) EdgeDefinition(ctx, collection any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinition", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).EdgeDefinition), ctx, collection)
+}
+
+// EdgeDefinitionExists mocks base method.
+func (m *MockGraphEdgesDefinition) EdgeDefinitionExists(ctx context.Context, collection string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EdgeDefinitionExists", ctx, collection)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EdgeDefinitionExists indicates an expected call of EdgeDefinitionExists.
+func (mr *MockGraphEdgesDefinitionMockRecorder) EdgeDefinitionExists(ctx, collection any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeDefinitionExists", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).EdgeDefinitionExists), ctx, collection)
+}
+
+// GetEdgeDefinitions mocks base method.
+func (m *MockGraphEdgesDefinition) GetEdgeDefinitions(ctx context.Context) ([]arangodb.Edge, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEdgeDefinitions", ctx)
+	ret0, _ := ret[0].([]arangodb.Edge)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEdgeDefinitions indicates an expected call of GetEdgeDefinitions.
+func (mr *MockGraphEdgesDefinitionMockRecorder) GetEdgeDefinitions(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEdgeDefinitions", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).GetEdgeDefinitions), ctx)
+}
+
+// ReplaceEdgeDefinition mocks base method.
+func (m *MockGraphEdgesDefinition) ReplaceEdgeDefinition(ctx context.Context, collection string, from, to []string, opts *arangodb.ReplaceEdgeOptions) (arangodb.ReplaceEdgeDefinitionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReplaceEdgeDefinition", ctx, collection, from, to, opts)
+	ret0, _ := ret[0].(arangodb.ReplaceEdgeDefinitionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReplaceEdgeDefinition indicates an expected call of ReplaceEdgeDefinition.
+func (mr *MockGraphEdgesDefinitionMockRecorder) ReplaceEdgeDefinition(ctx, collection, from, to, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceEdgeDefinition", reflect.TypeOf((*MockGraphEdgesDefinition)(nil).ReplaceEdgeDefinition), ctx, collection, from, to, opts)
+}

--- a/pkg/gofr/datasource/arangodb/mock_interfaces.go
+++ b/pkg/gofr/datasource/arangodb/mock_interfaces.go
@@ -145,8 +145,11 @@ func (mr *MockArangoMockRecorder) GetDatabase(ctx, name, options interface{}) *g
 }
 
 func (m *MockArango) DatabaseExists(ctx context.Context, name string) (bool, error) {
-	//TODO implement me
-	panic("implement me")
+	if strings.EqualFold(name, "dbExists") {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (m *MockArango) AccessibleDatabases(ctx context.Context) ([]arangodb.Database, error) {


### PR DESCRIPTION
## Pull Request Template


**Description:**

-   Resolves issue #1507.
- Now the `CreateDB`, `CreateGraph` as well as `CreateCollection` method checks if the DB, graph or collection already exists with the same name before creating it.
- Add test for other methods of Arango to improve code coverage.


**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

