### PR TITLE
Migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -331,7 +331,7 @@ jobs:
       # Install the linting tool
       - name: Install golangci-lint
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1
 
       - name: Get dependencies
         run: |
@@ -340,7 +340,7 @@ jobs:
       # Run linter on the root module
       - name: Lint Root Module
         run: |
-          golangci-lint run --out-format=colored-line-number --timeout=5m
+          golangci-lint run --output.text.print-issued-lines --output.text.colors=true --show-stats=false --timeout=5m
 
       # Run linter on each submodule
       - name: Lint Submodules
@@ -352,7 +352,7 @@ jobs:
             # Change directory to the submodule and run golangci-lint
             cd $module
             go mod tidy
-            golangci-lint run --timeout 9m0s || total_errors=$((total_errors + 1))
+            golangci-lint run --output.text.print-issued-lines --output.text.colors=true --show-stats=false --timeout 9m0s || total_errors=$((total_errors + 1))
             cd -  # Return to the root directory
           done
           echo "Total submodule lint errors: $total_errors"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,105 +1,6 @@
----
-linters-settings:
-  dupl:
-    threshold: 100
-  exhaustive:
-    default-signifies-exhaustive: false
-  funlen:
-    lines: 100
-    statements: 50
-  gci:
-    sections:
-      - standard
-      - default
-      - localmodule
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - wrapperFunc
-  gocyclo:
-    min-complexity: 10
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
-  mnd:
-    checks:
-      - argument
-      - case
-      - condition
-      - return
-  govet:
-    enable:
-      - shadow
-    settings:
-      printf:
-        funcs:
-          - (gofr.dev/pkg/gofr/Logger).Logf
-          - (gofr.dev/pkg/gofr/Logger).Errorf
-  lll:
-    line-length: 140
-  misspell:
-    locale: US
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: true # require an explanation for nolint directives
-    require-specific: true # require nolint directives to be specific about which linter is being skipped
-  usestdlibvars:
-    time-layout: true # Suggest the use of constants available in time package
-  revive:
-    rules:
-    # default revive rules, they have to be present otherwise they are disabled
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: empty-block
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: exported
-        arguments:
-          # enables checking public methods of private types
-          - "checkPrivateReceivers"
-          # make error messages clearer
-          - "sayRepetitiveInsteadOfStutters"
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: range
-      - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: superfluous-else
-      - name: time-naming
-      - name: unexported-return
-      - name: unreachable-code
-      - name: unused-parameter
-      - name: var-declaration
-      - name: var-naming
-    # additional revive rules
-      - name: bare-return
-      - name: bool-literal-in-expr
-      - name: comment-spacings
-      - name: early-return
-      - name: defer
-      - name: deep-exit
-      - name: unused-receiver
-      - name: use-any
-
+version: "2"
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bodyclose
@@ -112,7 +13,6 @@ linters:
     - errorlint
     - exhaustive
     - funlen
-    - gci
     - gochecknoglobals
     - gochecknoinits
     - gocognit
@@ -120,10 +20,8 @@ linters:
     - gocritic
     - gocyclo
     - godot
-    - gofmt
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -138,33 +36,132 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - stylecheck
     - testifylint
     - thelper
     - unconvert
     - unparam
     - unused
     - usestdlibvars
+    - usetesting
     - whitespace
     - wsl
-    - usetesting
-  
-  
-
-  # don't enable:
-  # - godox  # Disabling because we need TODO lines at this stage of project.
-  # - testpackage # We also need to do unit test for unexported functions. And adding _internal in all files is cumbersome.
-
-issues:
-  include:
-    - EXC0014
-
-  # exclude-use-default: false
-  # exclude-use-default: false # By default, golangci-lint does not enforce comments on exported types. We want it.
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gomnd
-        - dupl
-        - goconst
+  settings:
+    dupl:
+      threshold: 100
+    exhaustive:
+      default-signifies-exhaustive: false
+    funlen:
+      lines: 100
+      statements: 50
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+        - wrapperFunc
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 10
+    govet:
+      enable:
+        - shadow
+      settings:
+        printf:
+          funcs:
+            - (gofr.dev/pkg/gofr/Logger).Logf
+            - (gofr.dev/pkg/gofr/Logger).Errorf
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-unused: false
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: exported
+          arguments:
+            - checkPrivateReceivers
+            - sayRepetitiveInsteadOfStutters
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: var-declaration
+        - name: var-naming
+        - name: bare-return
+        - name: bool-literal-in-expr
+        - name: comment-spacings
+        - name: early-return
+        - name: defer
+        - name: deep-exit
+        - name: unused-receiver
+        - name: use-any
+    usestdlibvars:
+      time-layout: true
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - goconst
+          - mnd
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+    goimports:
+      local-prefixes:
+        - github.com/golangci/golangci-lint
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,6 +135,12 @@ linters:
         - name: deep-exit
         - name: unused-receiver
         - name: use-any
+    staticcheck:
+      checks:
+        - all
+        - -QF1001 # TODO remove this line and fix reported errors
+        - -QF1003 # TODO remove this line and fix reported errors
+        - -QF1008 # TODO remove this line and fix reported errors
     usestdlibvars:
       time-layout: true
   exclusions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -150,9 +150,7 @@ linters:
           - mnd
         path: _test\.go
     paths:
-      - third_party$
-      - builtin$
-      - examples$
+      - examples  # TODO remove this line and fix reported errors
 formatters:
   enable:
     - gci
@@ -168,7 +166,3 @@ formatters:
         - github.com/golangci/golangci-lint
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,6 +141,7 @@ linters:
         - -QF1001 # TODO remove this line and fix reported errors
         - -QF1003 # TODO remove this line and fix reported errors
         - -QF1008 # TODO remove this line and fix reported errors
+        - -ST1000 # TODO remove this line and fix reported errors
     usestdlibvars:
       time-layout: true
   exclusions:
@@ -154,6 +155,9 @@ linters:
           - goconst
           - mnd
         path: _test\.go
+      - linters:
+          - revive
+        text: "exported (.+) should have comment" # TODO fix errors reported by this and remove this line
     paths:
       - examples  # TODO remove this line and fix reported errors
 formatters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,11 @@ linters:
     - usetesting
     - whitespace
     - wsl
+
+    # don't enable:
+    # - godox  # Disabling because we need TODO lines at this stage of project.
+    # - testpackage # We also need to do unit test for unexported functions. And adding _internal in all files is cumbersome.
+
   settings:
     dupl:
       threshold: 100
@@ -58,7 +63,7 @@ linters:
       min-occurrences: 2
     gocritic:
       disabled-checks:
-        - dupImport
+        - dupImport # https://github.com/go-critic/go-critic/issues/845
         - ifElseChain
         - octalLiteral
         - whyNoLint
@@ -90,9 +95,9 @@ linters:
         - condition
         - return
     nolintlint:
-      require-explanation: true
-      require-specific: true
-      allow-unused: false
+      require-explanation: true # require an explanation for nolint directives
+      require-specific: true # require nolint directives to be specific about which linter is being skipped
+      allow-unused: false # report any unused nolint directives
     revive:
       rules:
         - name: blank-imports
@@ -106,7 +111,9 @@ linters:
         - name: errorf
         - name: exported
           arguments:
+             # enables checking public methods of private types
             - checkPrivateReceivers
+            # make error messages clearer
             - sayRepetitiveInsteadOfStutters
         - name: increment-decrement
         - name: indent-error-flow

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -139,9 +139,9 @@ linters:
       time-layout: true
   exclusions:
     presets:
-      - common-false-positives
-      - legacy
-      - std-error-handling
+      - common-false-positives # TODO fix errors reported by this and remove this line
+      - legacy                 # TODO fix errors reported by this and remove this line
+      - std-error-handling     # TODO remove this line, configure errcheck, and fix reported errors
     rules:
       - linters:
           - dupl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -138,7 +138,6 @@ linters:
     usestdlibvars:
       time-layout: true
   exclusions:
-    generated: lax
     presets:
       - common-false-positives
       - legacy
@@ -164,5 +163,3 @@ formatters:
     goimports:
       local-prefixes:
         - github.com/golangci/golangci-lint
-  exclusions:
-    generated: lax

--- a/examples/grpc/grpc-streaming-server/main_test.go
+++ b/examples/grpc/grpc-streaming-server/main_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"gofr.dev/examples/grpc/grpc-streaming-server/server"
 	"google.golang.org/grpc"
+
+	"gofr.dev/examples/grpc/grpc-streaming-server/server"
 )
 
 func TestMain(m *testing.M) {

--- a/examples/grpc/grpc-streaming-server/server/chatservice_server.go
+++ b/examples/grpc/grpc-streaming-server/server/chatservice_server.go
@@ -7,12 +7,14 @@ package server
 
 import (
 	"fmt"
-	"gofr.dev/pkg/gofr"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"io"
 	"strings"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"gofr.dev/pkg/gofr"
 )
 
 // Register the gRPC service in your app using the following code in your main.go:

--- a/examples/grpc/grpc-unary-server/server/hello_server.go
+++ b/examples/grpc/grpc-unary-server/server/hello_server.go
@@ -7,6 +7,7 @@ package server
 
 import (
 	"fmt"
+
 	"gofr.dev/pkg/gofr"
 )
 

--- a/examples/using-add-filestore/main_test.go
+++ b/examples/using-add-filestore/main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
 	"gofr.dev/pkg/gofr"
 	"gofr.dev/pkg/gofr/cmd"
 	"gofr.dev/pkg/gofr/container"

--- a/examples/using-cron-jobs/main_test.go
+++ b/examples/using-cron-jobs/main_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"gofr.dev/pkg/gofr/testutil"
 )
 

--- a/pkg/gofr/cmd/terminal/spinner_test.go
+++ b/pkg/gofr/cmd/terminal/spinner_test.go
@@ -32,7 +32,7 @@ func TestSpinner(t *testing.T) {
 
 	// Check if output contains spinner frames
 	outputStr := b.String()
-	assert.NotZero(t, outputStr)
+	assert.NotEmpty(t, outputStr)
 
 	// Testing Globe Spinner
 	b = &bytes.Buffer{}
@@ -50,7 +50,7 @@ func TestSpinner(t *testing.T) {
 
 	// Check if output contains spinner frames
 	outputStr = b.String()
-	assert.NotZero(t, outputStr)
+	assert.NotEmpty(t, outputStr)
 
 	// Testing Pulse Spinner
 	b = &bytes.Buffer{}
@@ -69,7 +69,7 @@ func TestSpinner(t *testing.T) {
 	// Check if output contains spinner frames
 	outputStr = b.String()
 	fmt.Println(outputStr)
-	assert.NotZero(t, outputStr)
+	assert.NotEmpty(t, outputStr)
 }
 
 func TestSpinner_contextDone(t *testing.T) {

--- a/pkg/gofr/cmd_test.go
+++ b/pkg/gofr/cmd_test.go
@@ -148,7 +148,7 @@ func Test_Run_ErrorParamNotReadWithoutHyphen(t *testing.T) {
 
 	c.addRoute("log",
 		func(c *Context) (any, error) {
-			assert.Equal(t, "", c.Request.Param("hello"))
+			assert.Empty(t, c.Request.Param("hello"))
 			c.Logger.Info("handler called")
 
 			return nil, nil

--- a/pkg/gofr/cron_test.go
+++ b/pkg/gofr/cron_test.go
@@ -326,7 +326,7 @@ func Test_noopRequest(t *testing.T) {
 	noop := noopRequest{}
 
 	assert.Equal(t, t.Context(), noop.Context())
-	assert.Equal(t, "", noop.Param(""))
+	assert.Empty(t, noop.Param(""))
 	assert.Empty(t, noop.PathParam(""))
 	assert.Equal(t, "gofr", noop.HostName())
 	require.NoError(t, noop.Bind(nil))

--- a/pkg/gofr/datasource/arangodb/arango_document_test.go
+++ b/pkg/gofr/datasource/arangodb/arango_document_test.go
@@ -48,7 +48,7 @@ func Test_Client_CreateDocument_Error(t *testing.T) {
 	docName, err := client.CreateDocument(context.Background(), "testDB",
 		"testCollection", "testDocument")
 	require.Empty(t, docName)
-	require.ErrorIs(t, err, errDocumentNotFound, err, "Expected error when document not found")
+	require.ErrorIs(t, err, errDocumentNotFound, "Expected error when document not found")
 }
 
 func Test_Client_GetDocument(t *testing.T) {
@@ -84,7 +84,7 @@ func Test_Client_GetDocument_Error(t *testing.T) {
 
 	err := client.GetDocument(context.Background(), "testDB",
 		"testCollection", "testDocument", "")
-	require.ErrorIs(t, err, errDocumentNotFound, err, "Expected error when document not found")
+	require.ErrorIs(t, err, errDocumentNotFound, "Expected error when document not found")
 }
 
 func Test_Client_UpdateDocument(t *testing.T) {

--- a/pkg/gofr/datasource/arangodb/arango_document_test.go
+++ b/pkg/gofr/datasource/arangodb/arango_document_test.go
@@ -47,7 +47,7 @@ func Test_Client_CreateDocument_Error(t *testing.T) {
 
 	docName, err := client.CreateDocument(context.Background(), "testDB",
 		"testCollection", "testDocument")
-	require.Equal(t, "", docName)
+	require.Empty(t, docName)
 	require.ErrorIs(t, err, errDocumentNotFound, err, "Expected error when document not found")
 }
 

--- a/pkg/gofr/datasource/file/fs_test.go
+++ b/pkg/gofr/datasource/file/fs_test.go
@@ -221,7 +221,7 @@ func Test_ReadFromCSVScanError(t *testing.T) {
 		err := reader.Scan(content)
 
 		require.Error(t, err)
-		assert.Equal(t, "", content)
+		assert.Empty(t, content)
 	}
 }
 

--- a/pkg/gofr/datasource/sql/db_test.go
+++ b/pkg/gofr/datasource/sql/db_test.go
@@ -1140,5 +1140,5 @@ func TestClean(t *testing.T) {
 
 	out := clean(query)
 
-	assert.Equal(t, "", out)
+	assert.Empty(t, out)
 }

--- a/pkg/gofr/http/request_test.go
+++ b/pkg/gofr/http/request_test.go
@@ -114,7 +114,7 @@ func TestBind_FileSuccess(t *testing.T) {
 	assert.Nil(t, x.Skip)
 
 	// Assert incompatible
-	assert.Equal(t, "", x.Incompatible)
+	assert.Empty(t, x.Incompatible)
 
 	// Assert file not present
 	assert.Nil(t, x.FileNotPresent)

--- a/pkg/gofr/logging/logger_test.go
+++ b/pkg/gofr/logging/logger_test.go
@@ -48,7 +48,7 @@ func TestLogger_LevelError(t *testing.T) {
 	infoLog := testutil.StdoutOutputForFunc(printLog)
 	errLog := testutil.StderrOutputForFunc(printLog)
 
-	assert.Equal(t, "", infoLog) // Since log level is ERROR we will not get any INFO logs.
+	assert.Empty(t, infoLog) // Since log level is ERROR we will not get any INFO logs.
 	assertMessageInJSONLog(t, errLog, "Test Error Log")
 }
 
@@ -205,7 +205,7 @@ func Test_NewSilentLoggerSTDOutput(t *testing.T) {
 		l.Warnf("%v Logs", "warnf")
 	})
 
-	assert.Equal(t, "", logs)
+	assert.Empty(t, logs)
 }
 
 type mockLog struct {

--- a/pkg/gofr/service/response_test.go
+++ b/pkg/gofr/service/response_test.go
@@ -19,7 +19,7 @@ func TestResponse_GetHeader(t *testing.T) {
 	headerNotFound := response.GetHeader("key")
 
 	assert.Equal(t, "application/json", result)
-	assert.Equal(t, "", headerNotFound)
+	assert.Empty(t, headerNotFound)
 }
 
 func TestResponse_GetHeaderNil(t *testing.T) {
@@ -28,5 +28,5 @@ func TestResponse_GetHeaderNil(t *testing.T) {
 
 	result := response.GetHeader("Content-Type")
 
-	assert.Equal(t, "", result)
+	assert.Empty(t, result)
 }


### PR DESCRIPTION
**Description:**

- **Use golangci-lint migration tool**
- **Restore the comments stripped by golangci-lint migration tool**
- **Remove useless exclusions from golangci-lint**
- **Remove legacy "lax" option from golangci-lint config**
- **Add TODO comments for golangci-lint presets**
- **Remove some staticcheck rules from golangci-lint config**
- **Fix behavior of golangci-lint against Go comments**
- **Apply suggested fixes provided by latest golangci-lint version**
- **Fix errors reported by testifylint**
- **Apply suggested fixes provided by latest golangci-lint version**
- **Migrate GitHub Actions to use golangci-lint v2**

Fixes #1645

**Breaking Changes (if applicable):**

- None

**Additional Information:**

- developers are now supposed to use golangci-lint v2
- 
**Checklist:**

-   [X] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [X] All new code is covered by unit tests.
-   [X] This PR does not decrease the overall code coverage.
-   [X] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

