### PR TITLE
Feat: add GetGRPCServer public method

### DIFF
--- a/pkg/gofr/grpc.go
+++ b/pkg/gofr/grpc.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	"google.golang.org/grpc"
 
 	"gofr.dev/pkg/gofr/container"
@@ -56,6 +56,22 @@ func (a *App) AddGRPCUnaryInterceptors(interceptors ...grpc.UnaryServerIntercept
 
 func (a *App) AddGRPCServerStreamInterceptors(interceptors ...grpc.StreamServerInterceptor) {
 	a.grpcServer.streamInterceptors = append(a.grpcServer.streamInterceptors, interceptors...)
+}
+
+// GetGRPCServer returns the gRPC server instance.
+// This is useful for accessing the server directly, for example, to register services or perform custom operations.
+// Note: This should be used with caution as it exposes the internal gRPC server instance.
+// It is recommended to use RegisterService method for registering gRPC services instead of directly manipulating the server.
+// Example usage:
+// grpcServer := app.GetGRPCServer()
+// grpcServer.RegisterService(&myServiceDesc, myServiceImpl)
+// For adding reflection
+// support, you can use the reflection package:
+// import "google.golang.org/grpc/reflection"
+// reflection.Register(grpcServer)
+
+func (a *App) GetGRPCServer() *grpc.Server {
+	return a.grpcServer.server
 }
 
 func newGRPCServer(c *container.Container, port int) *grpcServer {

--- a/pkg/gofr/grpc_test.go
+++ b/pkg/gofr/grpc_test.go
@@ -255,3 +255,17 @@ func TestGRPC_ServerRun_WithInterceptorAndOptions(t *testing.T) {
 	// Verify interceptors were called in order
 	assert.Equal(t, []string{"interceptor1", "interceptor2"}, interceptorExecutions)
 }
+
+func TestApp_GetGRPCServer(t *testing.T) {
+
+	c := &container.Container{
+		Logger: logging.NewLogger(logging.DEBUG),
+	}
+	app := New()
+	app.container = c
+	app.grpcServer = newGRPCServer(c, 9999)
+	app.grpcServer.createServer()
+
+	server := app.GetGRPCServer()
+	require.NotNil(t, server, "GetGRPCServer should return a non-nil *grpc.Server instance")
+}


### PR DESCRIPTION
## Pull Request Template

**Description:**

-   Added a unit test for the `GetGRPCServer` method in the `App` struct.
-   The new test ensures that the method returns a non-nil `*grpc.Server` instance after initialization.
-   This improves test coverage and validates the public API for accessing the underlying gRPC server.

**Breaking Changes (if applicable):**

-   No breaking changes are introduced by this PR.
-   All existing functionality remains backward compatible.

**Additional Information:**

-   No new dependencies or external libraries were added.
-   The test follows the existing test structure and uses `testify/require` for assertions.

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.
