### PR TITLE
Add startup job support

### DIFF
--- a/docs/advanced-guide/startup-jobs/page.md
+++ b/docs/advanced-guide/startup-jobs/page.md
@@ -1,0 +1,22 @@
+# Running startup jobs
+
+GoFr applications can execute initialization logic before serving traffic. Use `AddStartJob` to
+register a synchronous function that runs during `app.Run()`. If any job returns an error, the
+application exits without starting the servers.
+
+```go
+package main
+
+import "gofr.dev/pkg/gofr"
+
+func main() {
+    app := gofr.New()
+
+    app.AddStartJob("warm-cache", func(ctx *gofr.Context) error {
+        // load data into an in-memory cache
+        return nil
+    })
+
+    app.Run()
+}
+```

--- a/docs/navigation.js
+++ b/docs/navigation.js
@@ -43,6 +43,11 @@ export const navigation = [
                 desc: "Learn how to schedule and manage cron jobs in your application for automated tasks and background processes with GoFr's CRON job management."
             },
             {
+                title: "Running Startup Jobs",
+                href: "/docs/advanced-guide/startup-jobs",
+                desc: "Execute initialization logic before serving traffic by registering synchronous startup jobs."
+            },
+            {
                 title: 'Overriding Default',
                 href: '/docs/advanced-guide/overriding-default',
                 desc: "Understand how to override default configurations and behaviors in GoFr to tailor framework to your specific needs."

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -39,6 +39,8 @@ type App struct {
 	cmd  *cmd
 	cron *Crontab
 
+	startJobs []startJob
+
 	// container is unexported because this is an internal implementation and applications are provided access to it via Context
 	container *container.Container
 

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -1162,3 +1162,30 @@ func TestApp_Subscribe(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
+
+func Test_runStartJobs(t *testing.T) {
+	c := container.NewContainer(config.NewMockConfig(nil))
+	app := &App{container: c}
+
+	count := 0
+	app.AddStartJob("init", func(ctx *Context) error {
+		count = 42
+		return nil
+	})
+
+	err := app.runStartJobs()
+	require.NoError(t, err)
+	assert.Equal(t, 42, count)
+}
+
+func Test_runStartJobs_Error(t *testing.T) {
+	c := container.NewContainer(config.NewMockConfig(nil))
+	app := &App{container: c}
+
+	app.AddStartJob("fail", func(ctx *Context) error {
+		return fmt.Errorf("boom")
+	})
+
+	err := app.runStartJobs()
+	assert.Error(t, err)
+}

--- a/pkg/gofr/run.go
+++ b/pkg/gofr/run.go
@@ -48,6 +48,10 @@ func (a *App) Run() {
 		go a.sendTelemetry(http.DefaultClient, true)
 	}
 
+	if err := a.runStartJobs(); err != nil {
+		a.Logger().Fatal(err)
+	}
+
 	wg := sync.WaitGroup{}
 
 	// Start Metrics Server

--- a/pkg/gofr/startup.go
+++ b/pkg/gofr/startup.go
@@ -1,0 +1,66 @@
+package gofr
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+
+	"gofr.dev/pkg/gofr/logging"
+	"gofr.dev/pkg/gofr/version"
+)
+
+// StartFunc defines a function that is executed when the application starts.
+// Returning an error will stop the application from starting the servers.
+type StartFunc func(ctx *Context) error
+
+// startJob represents a startup task registered with the App.
+type startJob struct {
+	name string
+	fn   StartFunc
+}
+
+func (a *App) runStartJobs() error {
+	for _, j := range a.startJobs {
+		ctx, span := otel.GetTracerProvider().Tracer("gofr-"+version.Framework).Start(context.Background(), j.name)
+		logger := logging.NewContextLogger(ctx, a.container.Logger)
+		c := &Context{
+			Context:       ctx,
+			Container:     a.container,
+			Request:       noopRequest{},
+			ContextLogger: *logger,
+		}
+
+		c.Infof("Starting startup job: %s", j.name)
+		start := time.Now()
+		err := func() (err error) {
+			defer span.End()
+			defer func() {
+				if r := recover(); r != nil {
+					c.Errorf("Panic in startup job %s: %v", j.name, r)
+					if err == nil {
+						err = fmt.Errorf("%v", r)
+					}
+				}
+				c.Infof("Finished startup job: %s in %s", j.name, time.Since(start))
+			}()
+			err = j.fn(c)
+			return
+		}()
+		if err != nil {
+			return fmt.Errorf("startup job %s failed: %w", j.name, err)
+		}
+	}
+
+	return nil
+}
+
+// AddStartJob registers a synchronous job to be executed before the servers start.
+func (a *App) AddStartJob(name string, fn StartFunc) {
+	if fn == nil {
+		a.Logger().Errorf("nil function provided for startup job: %s", name)
+		return
+	}
+	a.startJobs = append(a.startJobs, startJob{name: name, fn: fn})
+}


### PR DESCRIPTION
## Summary
- implement AddStartJob for synchronous startup tasks
- execute start jobs in `Run()` before servers start
- document startup jobs and add nav entry
- test new functionality