### PR TITLE
API Key Auth Option Initialisation

### DIFF
--- a/docs/advanced-guide/http-communication/page.md
+++ b/docs/advanced-guide/http-communication/page.md
@@ -100,7 +100,7 @@ GoFr provides its user with additional configurational options while registering
 
 ```go
 a.AddHTTPService("cat-facts", "https://catfact.ninja",
-    &service.APIKeyConfig{APIKey: "some-random-key"},
+	service.NewAPIKeyConfig("some-random-key"),
 
     &service.BasicAuthConfig{
        UserName: "gofr",

--- a/pkg/gofr/service/apikey_auth.go
+++ b/pkg/gofr/service/apikey_auth.go
@@ -8,14 +8,16 @@ import (
 	"strings"
 )
 
-const apiKeyHeader = "X-API-KEY"
+// #nosec G101
+const xAPIKeyHeader = "X-Api-Key"
 
 type APIKeyConfig struct {
 	APIKey string
 }
 
 func NewAPIKeyConfig(apiKey string) (Options, error) {
-	if strings.TrimSpace(apiKey) == "" {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
 		return nil, AuthErr{Message: "non empty api key is required"}
 	}
 
@@ -98,7 +100,7 @@ func setXApiKey(headers map[string]string, apiKey string) map[string]string {
 		headers = make(map[string]string)
 	}
 
-	headers[apiKeyHeader] = apiKey
+	headers[xAPIKeyHeader] = apiKey
 
 	return headers
 }

--- a/pkg/gofr/service/apikey_auth.go
+++ b/pkg/gofr/service/apikey_auth.go
@@ -5,10 +5,21 @@ package service
 import (
 	"context"
 	"net/http"
+	"strings"
 )
+
+const apiKeyHeader = "X-API-KEY"
 
 type APIKeyConfig struct {
 	APIKey string
+}
+
+func NewAPIKeyConfig(apiKey string) (Options, error) {
+	if strings.TrimSpace(apiKey) == "" {
+		return nil, AuthErr{Message: "non empty api key is required"}
+	}
+
+	return &APIKeyConfig{APIKey: apiKey}, nil
 }
 
 func (a *APIKeyConfig) AddOption(h HTTP) HTTP {
@@ -87,7 +98,7 @@ func setXApiKey(headers map[string]string, apiKey string) map[string]string {
 		headers = make(map[string]string)
 	}
 
-	headers["X-API-KEY"] = apiKey
+	headers[apiKeyHeader] = apiKey
 
 	return headers
 }

--- a/pkg/gofr/service/apikey_auth_test.go
+++ b/pkg/gofr/service/apikey_auth_test.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"io"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,145 +19,128 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func Test_APIKeyAuthProvider_Get(t *testing.T) {
+func TestSetXApiKey(t *testing.T) {
+	testCases := []struct {
+		name           string
+		headers        map[string]string
+		apiKey         string
+		expectedHeader map[string]string
+	}{
+		{
+			name:           "existing header empty",
+			headers:        nil,
+			apiKey:         "valid-key",
+			expectedHeader: map[string]string{apiKeyHeader: "valid-key"},
+		},
+		{
+			name:           "existing header non empty",
+			headers:        map[string]string{"header": "value"},
+			apiKey:         "valid-key",
+			expectedHeader: map[string]string{"header": "value", apiKeyHeader: "valid-key"},
+		},
+
+		{
+			name:           "existing header containing api key",
+			headers:        map[string]string{apiKeyHeader: "value"},
+			apiKey:         "valid-key",
+			expectedHeader: map[string]string{apiKeyHeader: "valid-key"},
+		},
+	}
+
+	for i, tc := range testCases {
+		result := setXApiKey(tc.headers, tc.apiKey)
+		assert.Equal(t, tc.expectedHeader, result, "failed test case #%d: %v", i, tc.name)
+	}
+}
+
+func TestNewAPIKeyConfig(t *testing.T) {
+	testCases := []struct {
+		apiKey       string
+		apiKeyOption Options
+		err          error
+	}{
+		{apiKey: "valid", apiKeyOption: &APIKeyConfig{APIKey: "valid"}, err: nil},
+		{apiKey: "", apiKeyOption: nil, err: AuthErr{Message: "non empty api key is required"}},
+		{apiKey: "  ", apiKeyOption: nil, err: AuthErr{Message: "non empty api key is required"}},
+	}
+
+	for i, tc := range testCases {
+		options, err := NewAPIKeyConfig(tc.apiKey)
+		assert.Equal(t, tc.apiKeyOption, options, "failed test case #%d", i)
+		assert.Equal(t, tc.err, err, "failed test case #%d", i)
+	}
+}
+
+func TestAPIKeyAuthProvider(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
+	testCases := []struct {
+		httpMethod string
+		statusCode int
+	}{
+
+		{httpMethod: http.MethodPost, statusCode: http.StatusCreated},
+		{httpMethod: http.MethodGet, statusCode: http.StatusOK},
+		{httpMethod: http.MethodDelete, statusCode: http.StatusNoContent},
+		{httpMethod: http.MethodPatch, statusCode: http.StatusOK},
+		{httpMethod: http.MethodPut, statusCode: http.StatusOK},
+	}
 
 	path := "/path"
 	queryParams := map[string]any{"key": "value"}
 	body := []byte("body")
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Test Case #%d", i), func(t *testing.T) {
+			server := httpServerSetup(t, tc.httpMethod, tc.statusCode)
 
-		w.WriteHeader(http.StatusOK)
+			httpService := NewHTTPService(server.URL, logging.NewMockLogger(logging.INFO), nil,
+				&APIKeyConfig{"valid-key"})
 
-		_, err := w.Write(body)
-		if err != nil {
-			return
-		}
-	}))
-	defer server.Close()
+			var (
+				resp *http.Response
+				err  error
+			)
 
-	httpService := NewHTTPService(server.URL, logging.NewMockLogger(logging.INFO), nil,
-		&APIKeyConfig{"valid-key"})
+			switch tc.httpMethod {
+			case http.MethodGet:
+				resp, err = httpService.Get(t.Context(), path, queryParams)
+			case http.MethodPost:
+				resp, err = httpService.Post(t.Context(), path, queryParams, body)
+			case http.MethodPut:
+				resp, err = httpService.Put(t.Context(), path, queryParams, body)
+			case http.MethodPatch:
+				resp, err = httpService.Patch(t.Context(), path, queryParams, body)
+			case http.MethodDelete:
+				resp, err = httpService.Delete(t.Context(), path, body)
+			}
 
-	resp, err := httpService.Get(t.Context(), path, queryParams)
-	require.NoError(t, err)
+			require.NoError(t, err)
 
-	defer resp.Body.Close()
+			assert.Equal(t, tc.statusCode, resp.StatusCode)
+			require.NoError(t, err)
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, err)
-
-	bodyBytes, _ := io.ReadAll(resp.Body)
-
-	assert.Equal(t, string(body), string(bodyBytes))
+			err = resp.Body.Close()
+			if err != nil {
+				t.Errorf("error closing response body %v", err)
+			}
+		})
+	}
 }
 
-func Test_APIKeyAuthProvider_Post(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	path := "/path"
-	queryParams := map[string]any{"key": "value"}
-	body := []byte("body")
+func httpServerSetup(t *testing.T, method string, responseCode int) *httptest.Server {
+	t.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, method, r.Method)
 
-		w.WriteHeader(http.StatusCreated)
+		w.WriteHeader(responseCode)
 	}))
-	defer server.Close()
 
-	httpService := NewHTTPService(server.URL, logging.NewMockLogger(logging.INFO), nil,
-		&APIKeyConfig{"valid-key"})
+	t.Cleanup(func() {
+		server.Close()
+	})
 
-	resp, err := httpService.Post(t.Context(), path, queryParams, body)
-	require.NoError(t, err)
-
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
-	require.NoError(t, err)
-}
-
-func TestApiKeyProvider_Put(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	path := "/path"
-	queryParams := map[string]any{"key": "value"}
-	body := []byte("body")
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPut, r.Method)
-
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	httpService := NewHTTPService(server.URL, logging.NewMockLogger(logging.INFO), nil,
-		&APIKeyConfig{"valid-key"})
-
-	resp, err := httpService.Put(t.Context(), path, queryParams, body)
-	require.NoError(t, err)
-
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, err)
-}
-
-func TestApiKeyAuthProvider_Patch(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	path := "/path"
-	queryParams := map[string]any{"key": "value"}
-	body := []byte("body")
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPatch, r.Method)
-
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	httpService := NewHTTPService(server.URL, logging.NewMockLogger(logging.INFO), nil,
-		&APIKeyConfig{"valid-key"})
-
-	resp, err := httpService.Patch(t.Context(), path, queryParams, body)
-	require.NoError(t, err)
-
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, err)
-}
-
-func TestApiKeyAuthProvider_Delete(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	path := "/path"
-	body := []byte("body")
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodDelete, r.Method)
-
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer server.Close()
-
-	httpService := NewHTTPService(server.URL, logging.NewMockLogger(logging.INFO), nil,
-		&APIKeyConfig{"valid-key"})
-
-	resp, err := httpService.Delete(t.Context(), path, body)
-	require.NoError(t, err)
-
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.NoError(t, err)
+	return server
 }

--- a/pkg/gofr/service/errors.go
+++ b/pkg/gofr/service/errors.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 )
 
-type OAuthErr struct {
+type AuthErr struct {
 	Err     error
 	Message string
 }
 
-func (o OAuthErr) Error() string {
+func (o AuthErr) Error() string {
 	switch {
 	case o.Message == "" && o.Err == nil:
 		return "unknown error"

--- a/pkg/gofr/service/errors_test.go
+++ b/pkg/gofr/service/errors_test.go
@@ -23,7 +23,7 @@ func TestHttpService_OAuthError(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		oAuthError := OAuthErr{tc.err, tc.message}
+		oAuthError := AuthErr{tc.err, tc.message}
 		assert.Equal(t, tc.response, oAuthError.Error(), "failed test case #%d", i)
 	}
 }

--- a/pkg/gofr/service/oauth.go
+++ b/pkg/gofr/service/oauth.go
@@ -39,11 +39,11 @@ type OAuthConfig struct {
 
 func NewOAuthConfig(clientID, secret, tokenURL string, scopes []string, params url.Values, authStyle oauth2.AuthStyle) (Options, error) {
 	if clientID == "" {
-		return nil, OAuthErr{nil, "client id is mandatory"}
+		return nil, AuthErr{nil, "client id is mandatory"}
 	}
 
 	if secret == "" {
-		return nil, OAuthErr{nil, "client secret is mandatory"}
+		return nil, AuthErr{nil, "client secret is mandatory"}
 	}
 
 	if err := validateTokenURL(tokenURL); err != nil {
@@ -64,22 +64,22 @@ func NewOAuthConfig(clientID, secret, tokenURL string, scopes []string, params u
 
 func validateTokenURL(tokenURL string) error {
 	if tokenURL == "" {
-		return OAuthErr{nil, "token url is mandatory"}
+		return AuthErr{nil, "token url is mandatory"}
 	}
 
 	u, err := url.Parse(tokenURL)
 
 	switch {
 	case err != nil:
-		return OAuthErr{err, "error in token URL"}
+		return AuthErr{err, "error in token URL"}
 	case u.Host == "" || u.Scheme == "":
-		return OAuthErr{err, "empty host"}
+		return AuthErr{err, "empty host"}
 	case strings.Contains(u.Host, ".."):
-		return OAuthErr{nil, "invalid host pattern, contains `..`"}
+		return AuthErr{nil, "invalid host pattern, contains `..`"}
 	case strings.HasSuffix(u.Host, "."):
-		return OAuthErr{nil, "invalid host pattern, ends with `.`"}
+		return AuthErr{nil, "invalid host pattern, ends with `.`"}
 	case u.Scheme != "http" && u.Scheme != "https":
-		return OAuthErr{nil, "invalid scheme, allowed http and https only"}
+		return AuthErr{nil, "invalid scheme, allowed http and https only"}
 	default:
 		return nil
 	}
@@ -111,7 +111,7 @@ func (o *oAuth) addAuthorizationHeader(ctx context.Context, headers map[string]s
 	if headers == nil {
 		headers = make(map[string]string)
 	} else if authHeader, ok := headers[AuthHeader]; ok && authHeader != "" {
-		return nil, OAuthErr{Message: "auth header already exists " + authHeader}
+		return nil, AuthErr{Message: "auth header already exists " + authHeader}
 	}
 
 	token, err := o.TokenSource(ctx).Token()

--- a/pkg/gofr/service/oauth_test.go
+++ b/pkg/gofr/service/oauth_test.go
@@ -163,11 +163,11 @@ func TestHttpService_NewOAuthConfig(t *testing.T) {
 		authStyle    oauth2.AuthStyle
 		err          error
 	}{
-		{err: OAuthErr{nil, "client id is mandatory"}},
-		{clientID: clientID, err: OAuthErr{nil, "client secret is mandatory"}},
-		{clientID: clientID, tokenURL: tokenURL, err: OAuthErr{nil, "client secret is mandatory"}},
-		{clientID: clientID, clientSecret: clientSecret, err: OAuthErr{nil, "token url is mandatory"}},
-		{clientID: clientID, clientSecret: clientSecret, tokenURL: "invalid_url_format", err: OAuthErr{nil, "empty host"}},
+		{err: AuthErr{nil, "client id is mandatory"}},
+		{clientID: clientID, err: AuthErr{nil, "client secret is mandatory"}},
+		{clientID: clientID, tokenURL: tokenURL, err: AuthErr{nil, "client secret is mandatory"}},
+		{clientID: clientID, clientSecret: clientSecret, err: AuthErr{nil, "token url is mandatory"}},
+		{clientID: clientID, clientSecret: clientSecret, tokenURL: "invalid_url_format", err: AuthErr{nil, "empty host"}},
 		{clientID: clientID, clientSecret: clientSecret, tokenURL: tokenURL},
 		{clientID: clientID, clientSecret: "some_random_client_secret", tokenURL: tokenURL},
 		{clientID: "some_random_client_id", clientSecret: clientSecret, tokenURL: tokenURL},
@@ -241,7 +241,7 @@ func TestHttpService_addAuthorizationHeader(t *testing.T) {
 	headerWithEmptyAuth := map[string]string{AuthHeader: ""}
 	headerWithoutAuth := map[string]string{"Content Type": "Value"}
 	headerWithEmptyAuthAndOtherValues := map[string]string{"Content Type": "Value", AuthHeader: ""}
-	authHeaderExistsError := OAuthErr{Message: "auth header already exists Value"}
+	authHeaderExistsError := AuthErr{Message: "auth header already exists Value"}
 
 	testCases := []struct {
 		tokenURL string


### PR DESCRIPTION
**Description:**

- Added function `NewAPIKeyConfig(string)` to return valid APIKeyConfig object i.e. validate the API Key value to be non empty and trim spaces. Removed redundant code in unit tests and added tests for setXApiKey function.
- Renamed OAuthErr to AuthErr to allow re-usability

**Breaking Changes (if applicable):**
N/A

**Additional Information:**
`APIKeyConfig` should be converted un-exported in future releases to avoid incorrect usage

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.



