### PR TITLE
docs: fix references/config.md template syntax for proper GitHub rend…

### DIFF
--- a/docs/references/configs/page.md
+++ b/docs/references/configs/page.md
@@ -4,480 +4,116 @@ This document lists all the configuration options supported by the GoFr framewor
 
 ## App
 
-{% table %}
-
-- Name
-- Description
-- Default Value
-
----
-
--  APP_NAME
--  Name of the application
--  gofr-app
-
----
-
--  APP_ENV
--  Name of the environment file to use (e.g., stage.env, prod.env, or local.env).
-
----
-
--  APP_VERSION
--  Application version
--  dev
-
----
-
--  LOG_LEVEL
--  Level of verbosity for application logs. Supported values are **DEBUG, INFO, NOTICE, WARN, ERROR, FATAL**
--  INFO
-
----
-
--  REMOTE_LOG_URL
--  URL to remotely change the log level
-
----
-
--  REMOTE_LOG_FETCH_INTERVAL
--  Time interval (in seconds) to check for remote log level updates
--  15
-
----
-
--  METRICS_PORT
--  Port on which the application exposes metrics
--  2121
-
----
-
--  HTTP_PORT
--  Port on which the HTTP server listens
--  8000
-
----
-
--  GRPC_PORT
--  Port on which the gRPC server listens
--  9000
-
----
-
--  TRACE_EXPORTER
--  Tracing exporter to use. Supported values: gofr, zipkin, jaeger, otlp.
-
----
-
--  TRACER_HOST
--  Hostname of the tracing collector. Required if TRACE_EXPORTER is set to zipkin or jaeger.
--  **DEPRECATED**
-
----
-
--  TRACER_PORT
--  Port of the tracing collector. Required if TRACE_EXPORTER is set to zipkin or jaeger.
--  9411
--  **DEPRECATED**
-
----
-
--  TRACER_URL
--  URL of the trace collector. Required if TRACE_EXPORTER is set to zipkin or jaeger.
-
----
-
--  TRACER_RATIO
--  Refers to the proportion of traces that are exported through sampling. It is optional configuration. By default, this ratio is set to 1.
-
----
-
--  TRACER_AUTH_KEY
--  Authorization header for trace exporter requests.
--  Supported for zipkin, jaeger.
-
----
-
--  CMD_LOGS_FILE
--  File to save the logs in case of a CMD application
-
----
-
--  SHUTDOWN_GRACE_PERIOD
--  Timeout duration for server shutdown process
--  30s
-
-
-{% /table %}
+| Name | Description | Default Value |
+|------|-------------|---------------|
+| APP_NAME | Name of the application | gofr-app |
+| APP_ENV | Name of the environment file to use (e.g., stage.env, prod.env, or local.env). | |
+| APP_VERSION | Application version | dev |
+| LOG_LEVEL | Level of verbosity for application logs. Supported values are **DEBUG, INFO, NOTICE, WARN, ERROR, FATAL** | INFO |
+| REMOTE_LOG_URL | URL to remotely change the log level | |
+| REMOTE_LOG_FETCH_INTERVAL | Time interval (in seconds) to check for remote log level updates | 15 |
+| METRICS_PORT | Port on which the application exposes metrics | 2121 |
+| HTTP_PORT | Port on which the HTTP server listens | 8000 |
+| GRPC_PORT | Port on which the gRPC server listens | 9000 |
+| TRACE_EXPORTER | Tracing exporter to use. Supported values: gofr, zipkin, jaeger, otlp. | |
+| TRACER_HOST | Hostname of the tracing collector. Required if TRACE_EXPORTER is set to zipkin or jaeger. **DEPRECATED** | |
+| TRACER_PORT | Port of the tracing collector. Required if TRACE_EXPORTER is set to zipkin or jaeger. **DEPRECATED** | 9411 |
+| TRACER_URL | URL of the trace collector. Required if TRACE_EXPORTER is set to zipkin or jaeger. | |
+| TRACER_RATIO | Refers to the proportion of traces that are exported through sampling. It is optional configuration. By default, this ratio is set to 1. | |
+| TRACER_AUTH_KEY | Authorization header for trace exporter requests. Supported for zipkin, jaeger. | |
+| CMD_LOGS_FILE | File to save the logs in case of a CMD application | |
+| SHUTDOWN_GRACE_PERIOD | Timeout duration for server shutdown process | 30s |
 
 ## HTTP
 
-{% table %}
-
-- Name
-- Description
-
----
-
--  REQUEST_TIMEOUT
--  Set the request timeouts (in seconds) for HTTP server.
-
----
-
-- CERT_FILE
-- Set the path to your PEM certificate file for the HTTPS server to establish a secure connection.
-
---- 
-
-- KEY_FILE
-- Set the path to your PEM key file for the HTTPS server to establish a secure connection.
-
-{% /table %}
-
+| Name | Description |
+|------|-------------|
+| REQUEST_TIMEOUT | Set the request timeouts (in seconds) for HTTP server. |
+| CERT_FILE | Set the path to your PEM certificate file for the HTTPS server to establish a secure connection. |
+| KEY_FILE | Set the path to your PEM key file for the HTTPS server to establish a secure connection. |
 
 ## Datasource
 
 ### SQL
 
-{% table %}
-
-- Name
-- Description
-- Default Value
-
----
-
--  DB_DIALECT
--  Database dialect. Supported values: mysql, postgres, supabase
-
----
-
--  DB_HOST
--  Hostname of the database server.
-
----
-
--  DB_PORT
--  Port of the database server.
--  3306
-
----
-
--  DB_USER
--  Username for the database.
-
----
-
--  DB_PASSWORD
--  Password for the database.
-
----
-
--  DB_NAME
--  Name of the database to use.
-
----
-
--  DB_MAX_IDLE_CONNECTION
--  Number of maximum idle connection.
--  2
-
----
-
--  DB_MAX_OPEN_CONNECTION
--  Number of maximum connections which can be used with database.
--  0 (unlimited)
----
-
--  DB_SSL_MODE
--  Currently supported only for PostgreSQL, with Default certificate file.
--  disable
-
----
-
-- DB_CHARSET
-- The character set for database connection
-- utf8
-
----
-
-- SUPABASE_CONNECTION_TYPE 
-- Connection type to Supabase. Supported values: direct, session, transaction 
-- direct
-
----
-
-- SUPABASE_PROJECT_REF 
-- Supabase project reference ID
-
----
-
-- SUPABASE_REGION 
-- Supabase region for pooled connections
-
----
-
-- DB_URL 
-- Full PostgreSQL connection string for Supabase (alternative to separate config parameters)
-
-{% /table %}
+| Name | Description | Default Value |
+|------|-------------|---------------|
+| DB_DIALECT | Database dialect. Supported values: mysql, postgres, supabase | |
+| DB_HOST | Hostname of the database server. | |
+| DB_PORT | Port of the database server. | 3306 |
+| DB_USER | Username for the database. | |
+| DB_PASSWORD | Password for the database. | |
+| DB_NAME | Name of the database to use. | |
+| DB_MAX_IDLE_CONNECTION | Number of maximum idle connection. | 2 |
+| DB_MAX_OPEN_CONNECTION | Number of maximum connections which can be used with database. | 0 (unlimited) |
+| DB_SSL_MODE | Currently supported only for PostgreSQL, with Default certificate file. | disable |
+| DB_CHARSET | The character set for database connection | utf8 |
+| SUPABASE_CONNECTION_TYPE | Connection type to Supabase. Supported values: direct, session, transaction | direct |
+| SUPABASE_PROJECT_REF | Supabase project reference ID | |
+| SUPABASE_REGION | Supabase region for pooled connections | |
+| DB_URL | Full PostgreSQL connection string for Supabase (alternative to separate config parameters) | |
 
 ### Redis
 
-{% table %}
-
-- Name
-- Description
-
----
-
--  REDIS_HOST
--  Hostname of the Redis server.
-
----
-
--  REDIS_PORT
--  Port of the Redis server.
-
----
-
-- REDIS_USER
-- Username for the Redis server.
-
----
-
-- REDIS_PASSWORD
-- Password for the Redis server.
-
----
-
-- REDIS_DB
-- Database number to use for the Redis server.
-
-{% /table %}
+| Name | Description |
+|------|-------------|
+| REDIS_HOST | Hostname of the Redis server. |
+| REDIS_PORT | Port of the Redis server. |
+| REDIS_USER | Username for the Redis server. |
+| REDIS_PASSWORD | Password for the Redis server. |
+| REDIS_DB | Database number to use for the Redis server. |
 
 ### Pub/Sub
 
-{% table %}
-
-
-- Name
-- Description
-- Default Value
-
----
-
--  PUBSUB_BACKEND
--  Pub/Sub message broker backend
--  kafka, google, mqtt, nats
-
-{% /table %}
+| Name | Description | Default Value |
+|------|-------------|---------------|
+| PUBSUB_BACKEND | Pub/Sub message broker backend | kafka, google, mqtt, nats |
 
 **Kafka**
 
-{% table %}
-
-
-- Name
-- Description
-- Default Value
-
----
-
--  PUBSUB_BROKER
--  Comma-separated list of broker addresses
--  localhost:9092
-
----
-
--  PARTITION_SIZE
--  Size of each message partition (in bytes)
--  0
-
----
-
--  PUBSUB_OFFSET
--  Offset to start consuming messages from. -1 for earliest, 0 for latest.
--  -1
-
----
-
-- KAFKA_BATCH_SIZE
-- Number of messages to batch before sending to Kafka
-- 1
-
----
-
-- KAFKA_BATCH_BYTES
-- Number of bytes to batch before sending to Kafka
-- 1048576
-
----
-
-- KAFKA_BATCH_TIMEOUT
-- Time to wait before sending a batch to Kafka
-- 100ms
-
----
-
--  CONSUMER_ID
--  Unique identifier for this consumer
--  gofr-consumer
-
----
-
----
-
-- KAFKA_SECURITY_PROTOCOL
-- Security protocol used to communicate with Kafka (e.g., PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL)
-- PLAINTEXT
-
----
-
-
-- KAFKA_SASL_MECHANISM
-- SASL mechanism for authentication (e.g. PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)
-- None
-
----
-
-- KAFKA_SASL_USERNAME
-- Username for SASL authentication
-- None
-
----
-
-- KAFKA_SASL_PASSWORD
-- Password for SASL authentication
-- None
-
----
-
-- KAFKA_TLS_CERT_FILE
-- Path to the TLS certificate file
-- None
-
----
-
-- KAFKA_TLS_KEY_FILE
-- Path to the TLS key file
-- None
-
----
-
-- KAFKA_TLS_CA_CERT_FILE
-- Path to the TLS CA certificate file
-- None
-
----
-
-- KAFKA_TLS_INSECURE_SKIP_VERIFY
-- Skip TLS certificate verification
-- false
-
-{% /table %}
+| Name | Description | Default Value |
+|------|-------------|---------------|
+| PUBSUB_BROKER | Comma-separated list of broker addresses | localhost:9092 |
+| PARTITION_SIZE | Size of each message partition (in bytes) | 0 |
+| PUBSUB_OFFSET | Offset to start consuming messages from. -1 for earliest, 0 for latest. | -1 |
+| KAFKA_BATCH_SIZE | Number of messages to batch before sending to Kafka | 1 |
+| KAFKA_BATCH_BYTES | Number of bytes to batch before sending to Kafka | 1048576 |
+| KAFKA_BATCH_TIMEOUT | Time to wait before sending a batch to Kafka | 100ms |
+| CONSUMER_ID | Unique identifier for this consumer | gofr-consumer |
+| KAFKA_SECURITY_PROTOCOL | Security protocol used to communicate with Kafka (e.g., PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL) | PLAINTEXT |
+| KAFKA_SASL_MECHANISM | SASL mechanism for authentication (e.g. PLAIN, SCRAM-SHA-256, SCRAM-SHA-512) | None |
+| KAFKA_SASL_USERNAME | Username for SASL authentication | None |
+| KAFKA_SASL_PASSWORD | Password for SASL authentication | None |
+| KAFKA_TLS_CERT_FILE | Path to the TLS certificate file | None |
+| KAFKA_TLS_KEY_FILE | Path to the TLS key file | None |
+| KAFKA_TLS_CA_CERT_FILE | Path to the TLS CA certificate file | None |
+| KAFKA_TLS_INSECURE_SKIP_VERIFY | Skip TLS certificate verification | false |
 
 **Google**
 
-{% table %}
-
-
-- Name
-- Description
-
----
-
--  GOOGLE_PROJECT_ID
--  ID of the Google Cloud project. Required for Google Pub/Sub.
-
----
-
--  GOOGLE_SUBSCRIPTION_NAME
--  Name of the Google Pub/Sub subscription. Required for Google Pub/Sub.
-
-{% /table %}
+| Name | Description |
+|------|-------------|
+| GOOGLE_PROJECT_ID | ID of the Google Cloud project. Required for Google Pub/Sub. |
+| GOOGLE_SUBSCRIPTION_NAME | Name of the Google Pub/Sub subscription. Required for Google Pub/Sub. |
 
 **MQTT**
 
-{% table %}
-
-
-- Name
-- Description
-- Default Value
-
----
-
--  MQTT_PORT
--  Port of the MQTT broker
--  1883
-
----
-
--  MQTT_MESSAGE_ORDER
--  Enable guaranteed message order
--  false
-
----
-
--  MQTT_PROTOCOL
--  Communication protocol. Supported values: tcp, ssl.
--  tcp
-
----
-
--  MQTT_HOST
--  Hostname of the MQTT broker
--  localhost
-
----
-
--  MQTT_USER
--  Username for the MQTT broker
-
----
-
--  MQTT_PASSWORD
--  Password for the MQTT broker
-
----
-
--  MQTT_CLIENT_ID_SUFFIX
--  Suffix appended to the client ID
-
----
-
--  MQTT_QOS
--  Quality of Service Level
-
----
-
--  MQTT_KEEP_ALIVE
--  Sends regular messages to check the link is active. May not work as expected if handling func is blocking execution
-
-- MQTT_RETRIEVE_RETAINED
-- Retrieve retained messages on subscription
-
-{% /table %}
+| Name | Description | Default Value |
+|------|-------------|---------------|
+| MQTT_PORT | Port of the MQTT broker | 1883 |
+| MQTT_MESSAGE_ORDER | Enable guaranteed message order | false |
+| MQTT_PROTOCOL | Communication protocol. Supported values: tcp, ssl. | tcp |
+| MQTT_HOST | Hostname of the MQTT broker | localhost |
+| MQTT_USER | Username for the MQTT broker | |
+| MQTT_PASSWORD | Password for the MQTT broker | |
+| MQTT_CLIENT_ID_SUFFIX | Suffix appended to the client ID | |
+| MQTT_QOS | Quality of Service Level | |
+| MQTT_KEEP_ALIVE | Sends regular messages to check the link is active. May not work as expected if handling func is blocking execution | |
+| MQTT_RETRIEVE_RETAINED | Retrieve retained messages on subscription | |
 
 **NATS JetStream**
 
-{% table %}
-
-- Name
-- Description
-- Default Value
-
----
-
--  NATS_SERVER
--  URL of the NATS server
--  nats://localhost:4222
-
----
-
--  NATS_CREDS_FILE
--  File containing the NATS credentials
-- creds.json
-
-{% /table %}
+| Name | Description | Default Value |
+|------|-------------|---------------|
+| NATS_SERVER | URL of the NATS server | nats://localhost:4222 |
+| NATS_CREDS_FILE | File containing the NATS credentials | creds.json |


### PR DESCRIPTION
**Description:**

-   The `gofr/docs/references/config.md` file contains template syntax ({% table %}) that doesn't render properly on GitHub, making the documentation appear broken and unprofessional to visitors. This PR addresses this issue by fixing the markup so it renders properly.

**Additional Information:**

- Before:
![Screenshot 2025-06-27 221630](https://github.com/user-attachments/assets/a081924b-5ce9-436e-8cfe-d6a2b1bb8a2c)
- After:
![Screenshot 2025-06-27 221714](https://github.com/user-attachments/assets/fdfbf704-d645-418b-a2fd-006b514fd061)

**Checklist:**

-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.
