### PR TITLE
docs: fix quick-start/observability/page.md template syntax for proper GitHub rendering

### DIFF
--- a/docs/quick-start/observability/page.md
+++ b/docs/quick-start/observability/page.md
@@ -15,10 +15,9 @@ Log Level can be changed by setting the environment variable `LOG_LEVEL` value t
 When the GoFr server runs, it prints a log for reading configs, database connection, requests, database queries, missing configs, etc.
 They contain information such as request's correlation ID, status codes, request time, etc.
 
-{% figure src="/quick-start-logs.png" alt="Pretty Printed Logs" /%}
+![Pretty Printed Logs](/docs/public/quick-start-logs.png)
 
-Logs are well-structured, they are of type JSON when exported to a file, such that they can be pushed to logging systems such as {% new-tab-link title="Loki" href="https://grafana.com/oss/loki/" /%}, Elasticsearch, etc.
-
+Logs are well-structured, they are of type JSON when exported to a file, such that they can be pushed to logging systems such as [Loki](https://grafana.com/oss/loki/), Elasticsearch, etc.
 ## Metrics
 
 Metrics enable performance monitoring by providing insights into response times, latency, throughput, resource utilization, tracking CPU, memory, and disk I/O consumption across services, facilitating capacity planning and scalability efforts.
@@ -29,128 +28,43 @@ They are instrumental in measuring and meeting service-level agreements (SLAs) t
 
 GoFr publishes metrics to port: _2121_ on _/metrics_ endpoint in Prometheus format.
 
-{% table %}
+| Name | Type | Description |
+|------|------|-------------|
+| app_go_numGC | gauge | Number of completed Garbage Collector cycles |
+| app_go_routines | gauge | Number of Go routines running |
+| app_go_sys | gauge | Number of total bytes of memory |
+| app_sys_memory_alloc | gauge | Number of bytes allocated for heap objects |
+| app_sys_total_alloc | gauge | Number of cumulative bytes allocated for heap objects |
+| app_info | gauge | Number of instances running with info of app and framework |
+| app_http_response | histogram | Response time of HTTP requests in seconds |
+| app_http_service_response | histogram | Response time of HTTP service requests in seconds |
+| app_sql_open_connections | gauge | Number of open SQL connections |
+| app_sql_inUse_connections | gauge | Number of inUse SQL connections |
+| app_sql_stats | histogram | Response time of SQL queries in milliseconds |
+| app_redis_stats | histogram | Response time of Redis commands in milliseconds |
+| app_pubsub_publish_total_count | counter | Number of total publish operations |
+| app_pubsub_publish_success_count | counter | Number of successful publish operations |
+| app_pubsub_subscribe_total_count | counter | Number of total subscribe operations |
+| app_pubsub_subscribe_success_count | counter | Number of successful subscribe operations |
 
-- Name
-- Type
-- Description
+For example: When running the application locally, we can access the /metrics endpoint on port 2121 from: [http://localhost:2121/metrics](http://localhost:2121/metrics)
 
----
-
-- app_go_numGC
-- gauge
-- Number of completed Garbage Collector cycles
-
----
-
-- app_go_routines
-- gauge
-- Number of Go routines running
-
----
-
-- app_go_sys
-- gauge
-- Number of total bytes of memory
-
----
-
-- app_sys_memory_alloc
-- gauge
-- Number of bytes allocated for heap objects
-
----
-
-- app_sys_total_alloc
-- gauge
-- Number of cumulative bytes allocated for heap objects
-
----
-
-- app_info
-- gauge
-- Number of instances running with info of app and framework
-
----
-
-- app_http_response
-- histogram
-- Response time of HTTP requests in seconds
-
----
-
-- app_http_service_response
-- histogram
-- Response time of HTTP service requests in seconds
-
----
-
-- app_sql_open_connections
-- gauge
-- Number of open SQL connections
-
----
-
-- app_sql_inUse_connections
-- gauge
-- Number of inUse SQL connections
-
----
-
-- app_sql_stats
-- histogram
-- Response time of SQL queries in milliseconds
-
----
-
-- app_redis_stats
-- histogram
-- Response time of Redis commands in milliseconds
-
----
-
-- app_pubsub_publish_total_count
-- counter
-- Number of total publish operations
-
----
-
-- app_pubsub_publish_success_count
-- counter
-- Number of successful publish operations
-
----
-
-- app_pubsub_subscribe_total_count
-- counter
-- Number of total subscribe operations
-
----
-
-- app_pubsub_subscribe_success_count
-- counter
-- Number of successful subscribe operations
-
-{% /table %}
-
-For example: When running the application locally, we can access the /metrics endpoint on port 2121 from: {% new-tab-link title="http://localhost:2121/metrics" href="http://localhost:2121/metrics" /%}
-
-GoFr also supports creating {% new-tab-link newtab=false title="custom metrics" href="/docs/advanced-guide/publishing-custom-metrics" /%}.
+GoFr also supports creating [custom metrics](/docs/advanced-guide/publishing-custom-metrics).
 
 ### Example Dashboard
 
-These metrics can be easily consumed by monitoring systems like {% new-tab-link title="Prometheus" href="https://prometheus.io/" /%}
-and visualized in dashboards using tools like {% new-tab-link title="Grafana" href="https://grafana.com/" /%}.
+These metrics can be easily consumed by monitoring systems like [Prometheus](https://prometheus.io/) and visualized in dashboards using tools like [Grafana](https://grafana.com/).
 
 Here's a sample Grafana dashboard utilizing GoFr's metrics:
 
-{% figure src="/metrics-dashboard.png" alt="Grafana Dashboard showing GoFr metrics including HTTP request rates, 
-response times, etc." caption="Example monitoring dashboard using GoFr's built-in metrics" /%}
+![Grafana Dashboard showing GoFr metrics including HTTP request rates, response times, etc.](/docs/public/metrics-dashboard.png)
+
+*Example monitoring dashboard using GoFr's built-in metrics*
 
 
 ## Tracing
 
-{% new-tab-link title="Tracing" href="https://opentelemetry.io/docs/concepts/signals/#traces" /%} is a powerful tool for gaining insights into your application's behavior, identifying bottlenecks, and improving
+[Tracing](https://opentelemetry.io/docs/concepts/signals/#traces) is a powerful tool for gaining insights into your application's behavior, identifying bottlenecks, and improving
 system performance. A trace is a tree of spans. It is a collective of observable signals showing the path of work
 through a system. A trace on its own is distinguishable by a `TraceID`.
 
@@ -163,7 +77,7 @@ the intricate interactions between components.
 ### Automated Tracing in GoFr
 
 GoFr automatically exports traces for all requests and responses. GoFr uses
-{% new-tab-link title="OpenTelemetry" href="https://opentelemetry.io/docs/concepts/what-is-opentelemetry/" /%} , a popular tracing framework, to
+[OpenTelemetry](https://opentelemetry.io/docs/concepts/what-is-opentelemetry/), a popular tracing framework, to
 automatically add traces to all requests and responses.
 
 **Automatic Correlation ID Propagation:**
@@ -209,8 +123,9 @@ LOG_LEVEL=DEBUG
 > [!NOTE]
 > If the value of `TRACER_PORT` is not provided, GoFr uses port `9411` by default.
 
-Open {% new-tab-link title="zipkin" href="http://localhost:2005/zipkin/" /%} and search by TraceID (correlationID) to see the trace.
-{% figure src="/quick-start-trace.png" alt="Zipkin traces" /%}
+Open `http://localhost:2005/zipkin/` and search by TraceID (correlationID) to see the trace. 
+
+![Zipkin traces](/docs/public/quick-start-trace.png)
 
 #### 2. [Jaeger](https://www.jaegertracing.io/):
 
@@ -235,8 +150,9 @@ TRACER_URL=localhost:14317
 TRACER_RATIO=0.1
 ```
 
-Open {% new-tab-link title="jaeger" href="http://localhost:16686/trace/" /%} and search by TraceID (correlationID) to see the trace.
-{% figure src="/jaeger-traces.png" alt="Jaeger traces" /%}
+Open `http://localhost:16686/trace/` and search by TraceID (correlationID) to see the trace. 
+
+![Jaeger traces](/docs/public/jaeger-traces.png)
 
 #### 3. [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otlp/):
 
@@ -271,4 +187,4 @@ TRACER_RATIO=0.1
 > [!NOTE]
 > `TRACER_RATIO` refers to the proportion of traces that are exported through sampling. It ranges between 0 and 1. By default, this ratio is set to 1, meaning all traces are exported.
 >
-> Open {% new-tab-link title="gofr-tracer" href="https://tracer.gofr.dev/" /%} and search by TraceID (correlationID) to see the trace.
+> Open [gofr-tracer](https://tracer.gofr.dev/) and search by TraceID (correlationID) to see the trace.


### PR DESCRIPTION
Fixes #1927

**Description:**

-   The [quick-start/observability/page.md](https://github.com/gofr-dev/gofr/blob/bf94f1728eed2f1cec47fa94de13574548bd1296/docs/quick-start/observability/page.md) file contains broken template syntax that doesn't render properly on GitHub, making the documentation appear broken and unprofessional to visitors. This PR addresses this issue by fixing the markup so it renders properly.

**Additional Information:**

- Before:
![Screenshot 2025-06-27 224536](https://github.com/user-attachments/assets/70e8e0a5-eada-4c99-afbc-22e541d0c482)

- After:
![Screenshot 2025-06-27 224624](https://github.com/user-attachments/assets/089f7e47-0dc5-4d4d-a636-a24335330d40)



**Checklist:**

-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.
