### PR TITLE
docs: fix quick-start/configuration/page.md template syntax for proper GitHub rendering

### DIFF
--- a/docs/quick-start/configuration/page.md
+++ b/docs/quick-start/configuration/page.md
@@ -1,7 +1,7 @@
 # Configurations
 
 GoFr simplifies configuration management by reading configuration via environment variables.
-Application code is decoupled from how configuration is managed as per the {%new-tab-link title="12-factor" href="https://12factor.net/config" %}.
+Application code is decoupled from how configuration is managed as per the [12-factor](https://12factor.net/config).
 Configs in GoFr can be used to initialize datasources, tracing, setting log levels, changing default HTTP or metrics port.
 This abstraction provides a user-friendly interface for configuring user's application without modifying the code itself.
 


### PR DESCRIPTION
Fixes #1928

**Description:**

-   The [quick-start/configuration/page.md](https://github.com/gofr-dev/gofr/blob/bf94f1728eed2f1cec47fa94de13574548bd1296/docs/quick-start/configuration/page.md) file contains template syntax `{% new-tab-link %}` that doesn't render properly on GitHub, making the documentation appear broken and unprofessional to visitors. This PR addresses this issue by fixing the markup so it renders properly.

**Additional Information:**

-   Before:
![Screenshot 2025-06-27 225151](https://github.com/user-attachments/assets/5ed1eafb-dcbc-4e82-8749-e89b1af8e22a)

-   After:
![Screenshot 2025-06-27 225428](https://github.com/user-attachments/assets/d63267d9-05f8-4a0a-a94c-7cd870fdab3d)


**Checklist:**

-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.
