### PR TITLE
docs: fix getting-started/page.md template syntax for proper GitHub r…

### DIFF
--- a/docs/datasources/getting-started/page.md
+++ b/docs/datasources/getting-started/page.md
@@ -13,163 +13,25 @@ as unnecessary database drivers are not being compiled and added to the build.
 
 ## Supported Databases
 
-{% table %}
-
-- Datasource
-- Health-Check
-- Logs
-- Metrics
-- Traces
-- Version-Migrations
-
----
-
--  MySQL
-- ✅
-- ✅
-- ✅
-- ✅
-- ✅
-
----
-
--  REDIS
-- ✅
-- ✅
-- ✅
-- ✅
-- ✅
-
----
-
--  PostgreSQL
-- ✅
-- ✅
-- ✅
-- ✅
-- ✅
-
----
-
--  CockroachDB
-- ✅
-- ✅
-- ✅
-- ✅
-- ✅
-
----
-
--  ArangoDB
-- ✅
-- ✅
-- ✅
-- ✅
-- ✅
-
----
-
-
--  BadgerDB
-- ✅
-- ✅
-- ✅
-- ✅
--
-
----
-
--  Cassandra
-- ✅
-- ✅
-- ✅
-- ✅
-- ✅
-
----
-
--  ClickHouse
--
-- ✅
-- ✅
-- ✅
-- ✅
-
----
-
--  DGraph
-- ✅
-- ✅
-- ✅
-- ✅
-- ✅
-
----
-
--  MongoDB
-- ✅
-- ✅
-- ✅
-- ✅
-- ✅
-
----
--  NATS KV
-- ✅
-- ✅
-- ✅
-- ✅
--
----
-
--  OpenTSDB
-- ✅
-- ✅
--
-- ✅
--
----
-
--  ScyllaDB
-- ✅
-- ✅
-- ✅
-- ✅
--
----
-
--  Solr
--
-- ✅
-- ✅
-- ✅
--
----
-
--  SQLite
-- ✅
-- ✅
-- ✅
-- ✅
-- ✅
----
-
--  SurrealDB
-- ✅
-- ✅
-- ✅
-- ✅
-- ✅
----
-
--  Elasticsearch
-- ✅
-- ✅
-- ✅
-- ✅
-- 
-
----
+| Datasource | Health-Check | Logs | Metrics | Traces | Version-Migrations |
+|------------|--------------|------|---------|--------|-------------------|
+| MySQL | ✅ | ✅ | ✅ | ✅ | ✅ |
+| REDIS | ✅ | ✅ | ✅ | ✅ | ✅ |
+| PostgreSQL | ✅ | ✅ | ✅ | ✅ | ✅ |
+| CockroachDB | ✅ | ✅ | ✅ | ✅ | ✅ |
+| ArangoDB | ✅ | ✅ | ✅ | ✅ | ✅ |
+| BadgerDB | ✅ | ✅ | ✅ | ✅ | |
+| Cassandra | ✅ | ✅ | ✅ | ✅ | ✅ |
+| ClickHouse | | ✅ | ✅ | ✅ | ✅ |
+| DGraph | ✅ | ✅ | ✅ | ✅ | ✅ |
+| MongoDB | ✅ | ✅ | ✅ | ✅ | ✅ |
+| NATS KV | ✅ | ✅ | ✅ | ✅ | |
+| OpenTSDB | ✅ | ✅ | | ✅ | |
+| ScyllaDB | ✅ | ✅ | ✅ | ✅ | |
+| Solr | | ✅ | ✅ | ✅ | |
+| SQLite | ✅ | ✅ | ✅ | ✅ | ✅ |
+| SurrealDB | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Elasticsearch | ✅ | ✅ | ✅ | ✅ | |
 
 
 


### PR DESCRIPTION
**Description:**

-   The `gofr/docs/datasources/getting-started/page.md` file contains template syntax ({% table %}) that doesn't render properly on GitHub, making the documentation appear broken and unprofessional to visitors. This PR addresses this issue by fixing the markup so it renders properly.

**Additional Information:**

- Before:
![Screenshot 2025-06-27 225853](https://github.com/user-attachments/assets/36fc5e37-da1a-4d62-9c56-ed91ea2d86be)

- After:
![Screenshot 2025-06-27 225927](https://github.com/user-attachments/assets/dca84981-6757-4307-b19b-7cd9eac61ee8)


**Checklist:**

-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.
