### PR TITLE
doc: gofr/datasource package documentation overview

### DIFF
--- a/pkg/gofr/datasource/datasource.go
+++ b/pkg/gofr/datasource/datasource.go
@@ -1,3 +1,8 @@
+/*
+Package datasource provides an interface for registering datasources with the gofr framework.
+A datasource is a componentc that provides access to data, such as a database or a message queue.
+The Datasource interface defines a method for registering a datasource with the gofr framework.
+*/
 package datasource
 
 import "gofr.dev/pkg/gofr/config"


### PR DESCRIPTION
Fixes #1948 

**Description:**
This PR is adding a `gofr/datasource` package overview so it appears on `pkg.go.dev`.

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.