### PR TITLE
[DOCS] Replace interface{} with any across documentation

### DIFF
--- a/docs/advanced-guide/http-authentication/page.md
+++ b/docs/advanced-guide/http-authentication/page.md
@@ -28,7 +28,7 @@ func main() {
 
 	app.EnableBasicAuth("admin", "secret_password") // Replace with your credentials
 
-	app.GET("/protected-resource", func(c *gofr.Context) (interface{}, error) {
+	app.GET("/protected-resource", func(c *gofr.Context) (any, error) {
 		// Handle protected resource access
 		return nil, nil
 	})
@@ -54,7 +54,7 @@ func main() {
 
 	app.EnableBasicAuthWithValidator(validateUser)
 
-	app.GET("/secure-data", func(c *gofr.Context) (interface{}, error) {
+	app.GET("/secure-data", func(c *gofr.Context) (any, error) {
 		// Handle access to secure data
 		return nil, nil
 	})
@@ -205,7 +205,7 @@ func main() {
         jwt.WithIssuer("https://auth.example.com")
 		)
 
-	app.GET("/protected-resource", func(c *gofr.Context) (interface{}, error) {
+	app.GET("/protected-resource", func(c *gofr.Context) (any, error) {
 		// Handle protected resource access
 		return nil, nil
 	})

--- a/docs/advanced-guide/http-communication/page.md
+++ b/docs/advanced-guide/http-communication/page.md
@@ -63,7 +63,7 @@ svc := ctx.GetHTTPService(<service_name>)
 ```
 
 ```go  
-func Customer(ctx *gofr.Context) (interface{}, error) {
+func Customer(ctx *gofr.Context) (any, error) {
 	// Get the payment service client
 	paymentSvc := ctx.GetHTTPService("payment")
 

--- a/docs/datasources/arangodb/page.md
+++ b/docs/datasources/arangodb/page.md
@@ -86,7 +86,7 @@ func main() {
 }
 
 // Setup demonstrates database and collection creation
-func Setup(ctx *gofr.Context) (interface{}, error) {
+func Setup(ctx *gofr.Context) (any, error) {
 	_, err := ctx.ArangoDB.CreateDocument(ctx, "social_network", "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create database: %w", err)
@@ -122,7 +122,7 @@ func createCollection(ctx *gofr.Context, dbName, collectionName string) error {
 }
 
 // CreateUserHandler demonstrates user management and document creation
-func CreateUserHandler(ctx *gofr.Context) (interface{}, error) {
+func CreateUserHandler(ctx *gofr.Context) (any, error) {
 	name := ctx.PathParam("name")
 
 	// Create a person document
@@ -142,7 +142,7 @@ func CreateUserHandler(ctx *gofr.Context) (interface{}, error) {
 }
 
 // CreateFriendship demonstrates edge document creation
-func CreateFriendship(ctx *gofr.Context) (interface{}, error) {
+func CreateFriendship(ctx *gofr.Context) (any, error) {
 	var req struct {
 		From      string `json:"from"`
 		To        string `json:"to"`
@@ -172,7 +172,7 @@ func CreateFriendship(ctx *gofr.Context) (interface{}, error) {
 }
 
 // GetEdgesHandler demonstrates fetching edges connected to a vertex
-func GetEdgesHandler(ctx *gofr.Context) (interface{}, error) {
+func GetEdgesHandler(ctx *gofr.Context) (any, error) {
 	collection := ctx.PathParam("collection")
 	vertexID := ctx.PathParam("vertexID")
 
@@ -188,7 +188,7 @@ func GetEdgesHandler(ctx *gofr.Context) (interface{}, error) {
 		return nil, fmt.Errorf("failed to get edges: %w", err)
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"vertexID": vertexID,
 		"edges":    edges,
 	}, nil

--- a/docs/references/gofrcli/page.md
+++ b/docs/references/gofrcli/page.md
@@ -172,7 +172,7 @@ func NewGreetHandler(helloClient client.HelloGoFrClient) *GreetHandler {
     }
 }
 
-func (g GreetHandler) Hello(ctx *gofr.Context) (interface{}, error) {
+func (g GreetHandler) Hello(ctx *gofr.Context) (any, error) {
     userName := ctx.Param("name")
     helloResponse, err := g.helloGRPCClient.SayHello(ctx, &client.HelloRequest{Name: userName})
     if err != nil {

--- a/examples/grpc/grpc-streaming-client/main.go
+++ b/examples/grpc/grpc-streaming-client/main.go
@@ -43,7 +43,7 @@ type StreamResponse struct {
 }
 
 // ServerStreamHandler handles server-side streaming with detailed response tracking
-func (c *ChatHandler) ServerStreamHandler(ctx *gofr.Context) (interface{}, error) {
+func (c *ChatHandler) ServerStreamHandler(ctx *gofr.Context) (any, error) {
 	startTime := time.Now()
 	var responses []StreamResponse
 
@@ -80,7 +80,7 @@ func (c *ChatHandler) ServerStreamHandler(ctx *gofr.Context) (interface{}, error
 	}
 
 	// Return detailed stream information
-	return map[string]interface{}{
+	return map[string]any{
 		"status":          "server stream completed",
 		"start_time":      startTime,
 		"end_time":        time.Now(),
@@ -90,7 +90,7 @@ func (c *ChatHandler) ServerStreamHandler(ctx *gofr.Context) (interface{}, error
 }
 
 // ClientStreamHandler handles client-side streaming with detailed tracking
-func (c *ChatHandler) ClientStreamHandler(ctx *gofr.Context) (interface{}, error) {
+func (c *ChatHandler) ClientStreamHandler(ctx *gofr.Context) (any, error) {
 	startTime := time.Now()
 	var streamLog []StreamResponse
 
@@ -134,7 +134,7 @@ func (c *ChatHandler) ClientStreamHandler(ctx *gofr.Context) (interface{}, error
 		Direction: "received",
 	})
 
-	return map[string]interface{}{
+	return map[string]any{
 		"final_response": response.Message,
 		"start_time":     startTime,
 		"end_time":       time.Now(),
@@ -144,7 +144,7 @@ func (c *ChatHandler) ClientStreamHandler(ctx *gofr.Context) (interface{}, error
 }
 
 // BiDiStreamHandler handles bidirectional streaming with detailed tracking
-func (c *ChatHandler) BiDiStreamHandler(ctx *gofr.Context) (interface{}, error) {
+func (c *ChatHandler) BiDiStreamHandler(ctx *gofr.Context) (any, error) {
 	startTime := time.Now()
 	streamLog := make([]StreamResponse, 0)
 
@@ -170,7 +170,7 @@ func (c *ChatHandler) BiDiStreamHandler(ctx *gofr.Context) (interface{}, error) 
 		return nil, err
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"status":            "bidirectional stream completed",
 		"start_time":        startTime,
 		"end_time":          time.Now(),


### PR DESCRIPTION
## Description
This PR addresses issue #1984 by replacing all instances of `interface{}` with the modern `any` alias across documentation and examples.

## Changes Made
- ✅ `docs/advanced-guide/http-authentication/page.md` (3 instances)
- ✅ `docs/advanced-guide/http-communication/page.md` (1 instance)  
- ✅ `docs/datasources/arangodb/page.md` (5 instances)
- ✅ `docs/references/gofrcli/page.md` (1 instance)
- ✅ `examples/grpc/grpc-streaming-client/main.go` (3 instances)

## Types of Changes
- [x] Documentation update
- [x] Code modernization (interface{} → any)

## Testing
- All documentation changes maintain the same functionality
- Code examples remain syntactically correct
- No breaking changes to API or behavior

Fixes #1984