### PR TITLE
docs: fix multiple Cassandra documentation issues

### DIFF
--- a/docs/datasources/cassandra/page.md
+++ b/docs/datasources/cassandra/page.md
@@ -43,6 +43,7 @@ go get gofr.dev/pkg/gofr/datasource/cassandra@latest
 package main
 
 import (
+	"context"
 	"gofr.dev/pkg/gofr"
 	cassandraPkg "gofr.dev/pkg/gofr/datasource/cassandra"
 )
@@ -61,7 +62,7 @@ func main() {
 	config := cassandraPkg.Config{
 		Hosts:    "localhost",
 		Keyspace: "test",
-		Port:     2003,
+		Port:     9042, // default CQL native-protocol port
 		Username: "cassandra",
 		Password: "cassandra",
 	}


### PR DESCRIPTION
## Description

This PR addresses two documentation issues in the Cassandra example:

### Issues Fixed

1. **Missing context import (#1910)**: Added missing `"context"` import that was required for `context.Context` usage in the interface methods.

2. **Incorrect Cassandra port (#1911)**: Changed port from `2003` to `9042` (Cassandra's default CQL native protocol port).

### Changes Made

- Added `"context"` import in the example code
- Updated port configuration from `2003` to `9042` with explanatory comment
- Both changes ensure the example code compiles and connects properly

### Testing

- [x] Documentation builds successfully
- [x] Example code now imports all required packages
- [x] Port configuration uses correct default value

Closes #1910, #1911