### PR TITLE
add OnStart hook for synchronous startup jobs and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ Visit [`localhost:8000/greet`](http://localhost:8000/greet) to see the result.
 
 ---
 
+## 🚀 Registering Synchronous Startup Jobs with OnStart
+
+You can register a synchronous job to run when your GoFr application starts by using the `OnStart` method. This is useful for tasks like initializing in-memory caches, performing critical setup, or making API calls before your server begins handling requests.
+
+```go
+app.OnStart(func(ctx *gofr.Context) error {
+    // Your synchronous startup logic here
+    // For example: initialize cache, make API calls, etc.
+    return nil
+})
+```
+
+- The function you provide will be called with a `*gofr.Context` before any servers are started.
+- If your function returns an error, the application will log the error and exit.
+
+---
+
 ## 📂 **More Examples**
 
 Explore a variety of ready-to-run examples in the [GoFr examples directory](https://github.com/gofr-dev/gofr/tree/development/examples).

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -46,6 +46,7 @@ type App struct {
 	httpRegistered bool
 
 	subscriptionManager SubscriptionManager
+	onStartHooks        []func(ctx *Context) error
 }
 
 // Shutdown stops the service(s) and close the application.
@@ -295,4 +296,8 @@ func (a *App) AddStaticFiles(endpoint, filePath string) {
 	}
 
 	a.httpServer.staticFiles[filePath] = endpoint
+}
+
+func (a *App) OnStart(hook func(ctx *Context) error) {
+	a.onStartHooks = append(a.onStartHooks, hook)
 }

--- a/pkg/gofr/run.go
+++ b/pkg/gofr/run.go
@@ -19,6 +19,12 @@ func (a *App) Run() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	for _, hook := range a.onStartHooks {
+		if err := hook(&Context{}); err != nil {
+			a.Logger().Errorf("OnStart hook failed: %v", err)
+			os.Exit(1)
+		}
+	}
 	timeout, err := getShutdownTimeoutFromConfig(a.Config)
 	if err != nil {
 		a.Logger().Errorf("error parsing value of shutdown timeout from config: %v. Setting default timeout of 30 sec.", err)


### PR DESCRIPTION
**Description:**

This PR implements an OnStart hook for the GoFr framework, allowing users to register synchronous startup jobs that execute before the server starts. The hook accepts a function with the signature func(ctx *gofr.Context) error, following the maintainers’ feedback to use the existing *gofr.Context type and not introduce any new types.

Key points:
Adds an OnStart method to the App struct for registering startup hooks.
Calls all registered hooks with a *gofr.Context before starting any servers.
If any hook returns an error, the application logs the error and exits.
Removes all references to StartupContext as requested by maintainers.
Updates the README.md with documentation and usage examples for the new feature.

**Testing Proof:**

See attached screenshots for successful execution of the OnStart hook in a real app.

   **Checklist:**
   - [x] Implement OnStart hook
   - [x] Remove StartupContext references
   - [x] Update documentation
   - [x] Test OnStart hook in example app

**Screenshots:**

![WhatsApp Image 2025-07-12 at 01 50 59_faf8ba81](https://github.com/user-attachments/assets/92ab2a46-ebef-4718-bc2d-b7924f44bfdd)
![WhatsApp Image 2025-07-12 at 02 17 54_6c0bd9b0](https://github.com/user-attachments/assets/e82e7e66-4079-4686-863b-9428c7f9c060)

fixes #1833 