### PR TITLE
Add missing table end tag in redis documentation

### DIFF
--- a/docs/quick-start/connecting-redis/page.md
+++ b/docs/quick-start/connecting-redis/page.md
@@ -58,6 +58,7 @@ These variables are stored in a `.env` file located within the `configs` directo
 - Redis database number (default: `0`)
 
 ---
+{% /table %}
 
 ## TLS Support (Optional):
 
@@ -87,6 +88,7 @@ These variables are stored in a `.env` file located within the `configs` directo
 - File path to the client private key (for mTLS)
 
 ---
+{% /table %}
 
 ## ✅ Example `.env` File
 


### PR DESCRIPTION
## Pull Request Template


**Description:**

-   Added missing end table tag in redis documentation that affected rendering.

<img width="2880" height="3200" alt="image" src="https://github.com/user-attachments/assets/7f840b85-a9c9-4f05-bcf3-13ee57085aec" />


**Checklist:**

-   [ ] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [ ] All new code is covered by unit tests.
-   [ ] This PR does not decrease the overall code coverage.
-   [ ] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

