### PR TITLE
Fix/context logger

### DIFF
--- a/pkg/gofr/cmd.go
+++ b/pkg/gofr/cmd.go
@@ -13,7 +13,6 @@ import (
 type cmd struct {
 	routes []route
 	out    terminal.Output
-	ctx    Context
 }
 
 type route struct {

--- a/pkg/gofr/cmd.go
+++ b/pkg/gofr/cmd.go
@@ -13,6 +13,7 @@ import (
 type cmd struct {
 	routes []route
 	out    terminal.Output
+	ctx    Context
 }
 
 type route struct {

--- a/pkg/gofr/cmd/request_test.go
+++ b/pkg/gofr/cmd/request_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -43,7 +44,8 @@ func TestRequest_Bind(t *testing.T) {
 
 	osHostName, _ := os.Hostname()
 
-	assert.Equal(t, t.Context(), ctx, "TEST Failed.\n context is not context.Background.")
+	//nolint:usetesting // Comparing context.Background() directly is intentional and safe in this case.
+	assert.Equal(t, context.Background(), ctx, "TEST Failed.\n context is not context.Background.")
 
 	assert.Equal(t, osHostName, hostName, "TEST Failed.\n Hostname did not match.")
 }

--- a/pkg/gofr/container/health_test.go
+++ b/pkg/gofr/container/health_test.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 
 	"gofr.dev/pkg/gofr/datasource"
 	"gofr.dev/pkg/gofr/datasource/sql"
@@ -86,6 +86,18 @@ func TestContainer_Health(t *testing.T) {
 					"error": "opentsdb not connected",
 				},
 			},
+			"elasticsearch": datasource.Health{
+				Status: tc.datasourceHealth, Details: map[string]any{
+					"host":  "localhost:9200",
+					"error": "elasticsearch not connected",
+				},
+			},
+			"pubsub": datasource.Health{
+				Status: tc.datasourceHealth, Details: map[string]any{
+					"host":  "localhost:pubsub",
+					"error": nil,
+				},
+			},
 			"test-service": &service.Health{
 				Status: "UP", Details: map[string]any{
 					"host": strings.TrimPrefix(srv.URL, "http://"),
@@ -136,7 +148,7 @@ func registerMocks(mocks *Mocks, health string) {
 		},
 	})
 
-	mocks.Mongo.EXPECT().HealthCheck(context.Background()).Return(datasource.Health{
+	mocks.Mongo.EXPECT().HealthCheck(gomock.Any()).Return(datasource.Health{
 		Status: health,
 		Details: map[string]any{
 			"host":  "localhost:6379",
@@ -144,7 +156,7 @@ func registerMocks(mocks *Mocks, health string) {
 		},
 	}, nil)
 
-	mocks.Cassandra.EXPECT().HealthCheck(context.Background()).Return(datasource.Health{
+	mocks.Cassandra.EXPECT().HealthCheck(gomock.Any()).Return(datasource.Health{
 		Status: health,
 		Details: map[string]any{
 			"host":  "localhost:6379",
@@ -152,7 +164,7 @@ func registerMocks(mocks *Mocks, health string) {
 		},
 	}, nil)
 
-	mocks.Clickhouse.EXPECT().HealthCheck(context.Background()).Return(datasource.Health{
+	mocks.Clickhouse.EXPECT().HealthCheck(gomock.Any()).Return(datasource.Health{
 		Status: health,
 		Details: map[string]any{
 			"host":  "localhost:6379",
@@ -160,7 +172,7 @@ func registerMocks(mocks *Mocks, health string) {
 		},
 	}, nil)
 
-	mocks.KVStore.EXPECT().HealthCheck(context.Background()).Return(datasource.Health{
+	mocks.KVStore.EXPECT().HealthCheck(gomock.Any()).Return(datasource.Health{
 		Status: health,
 		Details: map[string]any{
 			"host":  "localhost:1234",
@@ -168,7 +180,7 @@ func registerMocks(mocks *Mocks, health string) {
 		},
 	}, nil)
 
-	mocks.DGraph.EXPECT().HealthCheck(context.Background()).Return(datasource.Health{
+	mocks.DGraph.EXPECT().HealthCheck(gomock.Any()).Return(datasource.Health{
 		Status: health,
 		Details: map[string]any{
 			"host":  "localhost:8000",
@@ -176,11 +188,27 @@ func registerMocks(mocks *Mocks, health string) {
 		},
 	}, nil)
 
-	mocks.OpenTSDB.EXPECT().HealthCheck(context.Background()).Return(datasource.Health{
+	mocks.OpenTSDB.EXPECT().HealthCheck(gomock.Any()).Return(datasource.Health{
 		Status: health,
 		Details: map[string]any{
 			"host":  "localhost:8000",
 			"error": "opentsdb not connected",
+		},
+	}, nil)
+
+	mocks.PubSub.EXPECT().Health().Return(datasource.Health{
+		Status: health,
+		Details: map[string]any{
+			"host":  "localhost:pubsub",
+			"error": nil,
+		},
+	}).Times(1)
+
+	mocks.Elasticsearch.EXPECT().HealthCheck(gomock.Any()).Return(datasource.Health{
+		Status: health,
+		Details: map[string]any{
+			"host":  "localhost:9200",
+			"error": "elasticsearch not connected",
 		},
 	}, nil)
 }

--- a/pkg/gofr/container/health_test.go
+++ b/pkg/gofr/container/health_test.go
@@ -33,80 +33,7 @@ func TestContainer_Health(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		expected := map[string]any{
-			"kv-store": datasource.Health{
-				Status: tc.datasourceHealth, Details: map[string]any{
-					"host":  "localhost:1234",
-					"error": "kv-store not connected",
-				},
-			},
-			"redis": datasource.Health{
-				Status: tc.datasourceHealth, Details: map[string]any{
-					"host":  "localhost:6379",
-					"error": "redis not connected",
-				},
-			},
-			"mongo": datasource.Health{
-				Status: tc.datasourceHealth, Details: map[string]any{
-					"host":  "localhost:6379",
-					"error": "mongo not connected",
-				},
-			},
-			"clickHouse": datasource.Health{
-				Status: tc.datasourceHealth, Details: map[string]any{
-					"host":  "localhost:6379",
-					"error": "clickhouse not connected",
-				},
-			},
-			"cassandra": datasource.Health{
-				Status: tc.datasourceHealth, Details: map[string]any{
-					"host":  "localhost:6379",
-					"error": "cassandra not connected",
-				},
-			},
-
-			"sql": &datasource.Health{
-				Status: tc.datasourceHealth, Details: map[string]any{
-					"host": "localhost:3306/test",
-					"stats": sql.DBStats{
-						MaxOpenConnections: 0, OpenConnections: 1, InUse: 0, Idle: 1, WaitCount: 0,
-						WaitDuration: 0, MaxIdleClosed: 0, MaxIdleTimeClosed: 0, MaxLifetimeClosed: 0,
-					},
-				},
-			},
-			"dgraph": datasource.Health{
-				Status: tc.datasourceHealth, Details: map[string]any{
-					"host":  "localhost:8000",
-					"error": "dgraph not connected",
-				},
-			},
-			"opentsdb": datasource.Health{
-				Status: tc.datasourceHealth, Details: map[string]any{
-					"host":  "localhost:8000",
-					"error": "opentsdb not connected",
-				},
-			},
-			"elasticsearch": datasource.Health{
-				Status: tc.datasourceHealth, Details: map[string]any{
-					"host":  "localhost:9200",
-					"error": "elasticsearch not connected",
-				},
-			},
-			"pubsub": datasource.Health{
-				Status: tc.datasourceHealth, Details: map[string]any{
-					"host":  "localhost:pubsub",
-					"error": nil,
-				},
-			},
-			"test-service": &service.Health{
-				Status: "UP", Details: map[string]any{
-					"host": strings.TrimPrefix(srv.URL, "http://"),
-				},
-			},
-			"name":    "test-app",
-			"status":  tc.appHealth,
-			"version": "test",
-		}
+		expected := getExpectedData(tc.datasourceHealth, tc.appHealth, srv.URL)
 
 		expectedJSONdata, _ := json.Marshal(expected)
 
@@ -211,4 +138,81 @@ func registerMocks(mocks *Mocks, health string) {
 			"error": "elasticsearch not connected",
 		},
 	}, nil)
+}
+
+func getExpectedData(datasourceHealth, appHealth, srvURL string) map[string]any {
+	return map[string]any{
+		"kv-store": datasource.Health{
+			Status: datasourceHealth, Details: map[string]any{
+				"host":  "localhost:1234",
+				"error": "kv-store not connected",
+			},
+		},
+		"redis": datasource.Health{
+			Status: datasourceHealth, Details: map[string]any{
+				"host":  "localhost:6379",
+				"error": "redis not connected",
+			},
+		},
+		"mongo": datasource.Health{
+			Status: datasourceHealth, Details: map[string]any{
+				"host":  "localhost:6379",
+				"error": "mongo not connected",
+			},
+		},
+		"clickHouse": datasource.Health{
+			Status: datasourceHealth, Details: map[string]any{
+				"host":  "localhost:6379",
+				"error": "clickhouse not connected",
+			},
+		},
+		"cassandra": datasource.Health{
+			Status: datasourceHealth, Details: map[string]any{
+				"host":  "localhost:6379",
+				"error": "cassandra not connected",
+			},
+		},
+
+		"sql": &datasource.Health{
+			Status: datasourceHealth, Details: map[string]any{
+				"host": "localhost:3306/test",
+				"stats": sql.DBStats{
+					MaxOpenConnections: 0, OpenConnections: 1, InUse: 0, Idle: 1, WaitCount: 0,
+					WaitDuration: 0, MaxIdleClosed: 0, MaxIdleTimeClosed: 0, MaxLifetimeClosed: 0,
+				},
+			},
+		},
+		"dgraph": datasource.Health{
+			Status: datasourceHealth, Details: map[string]any{
+				"host":  "localhost:8000",
+				"error": "dgraph not connected",
+			},
+		},
+		"opentsdb": datasource.Health{
+			Status: datasourceHealth, Details: map[string]any{
+				"host":  "localhost:8000",
+				"error": "opentsdb not connected",
+			},
+		},
+		"elasticsearch": datasource.Health{
+			Status: datasourceHealth, Details: map[string]any{
+				"host":  "localhost:9200",
+				"error": "elasticsearch not connected",
+			},
+		},
+		"pubsub": datasource.Health{
+			Status: datasourceHealth, Details: map[string]any{
+				"host":  "localhost:pubsub",
+				"error": nil,
+			},
+		},
+		"test-service": &service.Health{
+			Status: "UP", Details: map[string]any{
+				"host": strings.TrimPrefix(srvURL, "http://"),
+			},
+		},
+		"name":    "test-app",
+		"status":  appHealth,
+		"version": "test",
+	}
 }

--- a/pkg/gofr/context.go
+++ b/pkg/gofr/context.go
@@ -158,29 +158,22 @@ func (a *authInfo) GetAPIKey() string {
 // }
 
 func newContext(w Responder, r Request, c *container.Container) *Context {
-	var ctx context.Context
-
-	if r.Context() != nil {
-		ctx = r.Context()
-	} else {
-		ctx = context.Background()
-	}
-
 	return &Context{
-		Context:       ctx,
+		Context:       r.Context(),
 		Request:       r,
 		responder:     w,
 		Container:     c,
-		ContextLogger: *logging.NewContextLogger(ctx, c.Logger),
+		ContextLogger: *logging.NewContextLogger(r.Context(), c.Logger),
 	}
 }
 
 func newCMDContext(w Responder, r Request, c *container.Container, out terminal.Output) *Context {
 	return &Context{
-		Context:   r.Context(),
-		responder: w,
-		Request:   r,
-		Container: c,
-		Out:       out,
+		Context:       r.Context(),
+		responder:     w,
+		Request:       r,
+		Container:     c,
+		Out:           out,
+		ContextLogger: *logging.NewContextLogger(r.Context(), c.Logger),
 	}
 }

--- a/pkg/gofr/context.go
+++ b/pkg/gofr/context.go
@@ -158,11 +158,20 @@ func (a *authInfo) GetAPIKey() string {
 // }
 
 func newContext(w Responder, r Request, c *container.Container) *Context {
+	var ctx context.Context
+
+	if r.Context() != nil {
+		ctx = r.Context()
+	} else {
+		ctx = context.Background()
+	}
+
 	return &Context{
-		Context:   r.Context(),
-		Request:   r,
-		responder: w,
-		Container: c,
+		Context:       ctx,
+		Request:       r,
+		responder:     w,
+		Container:     c,
+		ContextLogger: *logging.NewContextLogger(ctx, c.Logger),
 	}
 }
 

--- a/pkg/gofr/cron.go
+++ b/pkg/gofr/cron.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"gofr.dev/pkg/gofr/container"
-	"gofr.dev/pkg/gofr/logging"
 	"gofr.dev/pkg/gofr/version"
 )
 
@@ -97,14 +96,8 @@ func (j *job) run(cntnr *container.Container) {
 		Start(context.Background(), j.name)
 	defer span.End()
 
-	logger := logging.NewContextLogger(ctx, cntnr.Logger)
-
-	c := &Context{
-		Context:       ctx,
-		Container:     cntnr,
-		Request:       noopRequest{},
-		ContextLogger: *logger,
-	}
+	c := newContext(nil, &noopRequest{}, cntnr)
+	c.Context = ctx
 
 	c.Infof("Starting cron job: %s", j.name)
 

--- a/pkg/gofr/factory.go
+++ b/pkg/gofr/factory.go
@@ -78,9 +78,14 @@ func NewCMD() *App {
 	app.readConfig(true)
 	app.container = container.NewContainer(nil)
 	app.container.Logger = logging.NewFileLogger(app.Config.Get("CMD_LOGS_FILE"))
+
+	cmdCtx := newContext(nil, &noopRequest{}, app.container)
+
 	app.cmd = &cmd{
 		out: terminal.New(),
+		ctx: *cmdCtx,
 	}
+
 	app.container.Create(app.Config)
 	app.initTracer()
 

--- a/pkg/gofr/factory.go
+++ b/pkg/gofr/factory.go
@@ -79,11 +79,8 @@ func NewCMD() *App {
 	app.container = container.NewContainer(nil)
 	app.container.Logger = logging.NewFileLogger(app.Config.Get("CMD_LOGS_FILE"))
 
-	cmdCtx := newContext(nil, &noopRequest{}, app.container)
-
 	app.cmd = &cmd{
 		out: terminal.New(),
-		ctx: *cmdCtx,
 	}
 
 	app.container.Create(app.Config)

--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -67,9 +67,6 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		c.Context = ctx
 	}
 
-	reqLogger := logging.NewContextLogger(c, h.container.Logger)
-	c.ContextLogger = *reqLogger
-
 	done := make(chan struct{})
 	panicked := make(chan struct{})
 


### PR DESCRIPTION
## Pull Request Template


**Description:**

-   Closes #2083. 

### Cause of Panic:
```go
	app.SubCommand("hello", func(c *gofr.Context) (any, error) {
		c.Warn("this is a warn log!")
		return "Hello World!", nil
	},
```

This will panic as `c.Warn` uses the **ContextLogger** present inside context to log.
Since in CMD applications, ContextLogger was not initialzied we got into a panic.

### Solution:

-   Move initilization of `NewContextLogger` inside function `newContext` so we don't need to do it manaually.



**Checklist:**

-   [ ] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [ ] All new code is covered by unit tests.
-   [ ] This PR does not decrease the overall code coverage.
-   [ ] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

