### PR TITLE
Fix/pubsub migration get last version

### DIFF
--- a/pkg/gofr/migration/pubsub_test.go
+++ b/pkg/gofr/migration/pubsub_test.go
@@ -172,7 +172,7 @@ type mockNextMigrator struct {
 	version int64
 }
 
-func (m mockNextMigrator) getLastMigration(c *container.Container) int64 {
+func (m mockNextMigrator) getLastMigration(*container.Container) int64 {
 	return m.version
 }
 


### PR DESCRIPTION
## Pull Request Template


### Description:

-   Resolves #2111.

### Cause:
-   The issue was in the `getLastMigration` implementation for PubSub datasource. Unlike the other implementations, the PubSub migrator wasn't properly handling the migrator chain pattern:
```
- It would correctly get data from PubSub but didn't properly call the next migrator
- When a query error occurred, it would immediately error out without checking the next migrator
This broke the chain of migration checks, causing the system to only see PubSub's migration state (usually 0 for new setups) and ignore MySQL's migration state.
```
<img width="1024" height="178" alt="Screenshot 2025-08-04 at 12 28 41 PM" src="https://github.com/user-attachments/assets/d4d92d77-e8b6-4174-8322-81feb3f9f59f" />

### Fix:

-   Highlight the motivation behind the changes and the expected benefits.
- The getLastMigration method in pubsub.go was updated to:
```
- Get last migration version from PubSub
- Call the next migrator in the chain
- Return the higher of the two values
- Properly handle query errors by still checking the next migrator
```
Tests were added to verify this behavior across different scenarios, ensuring the migration chain works correctly with multiple datasources.

<img width="1024" height="178" alt="Screenshot 2025-08-04 at 12 28 08 PM" src="https://github.com/user-attachments/assets/bdce3c8c-8673-4b8a-939d-0af67e7a0e6c" />



**Checklist:**

-   [ ] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [ ] All new code is covered by unit tests.
-   [ ] This PR does not decrease the overall code coverage.
-   [ ] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

