### PR TITLE
Fix config Overloading & its tests

### DIFF
--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -34,42 +34,96 @@ func NewEnvFile(configFolder string, logger logger) Config {
 }
 
 func (e *EnvLoader) read(folder string) {
-	var (
-		defaultFile  = folder + defaultFileName
-		overrideFile = folder + defaultOverrideFileName
-		env          = e.Get("APP_ENV")
-	)
+	// Capture initial system environment keys
+	initialEnv := e.captureInitialEnv()
 
-	err := godotenv.Load(defaultFile)
-	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			e.logger.Fatalf("Failed to load config from file: %v, Err: %v", defaultFile, err)
-		}
+	// Load environment files with proper precedence
+	envMap := e.loadEnvironmentFiles(folder)
 
-		e.logger.Warnf("Failed to load config from file: %v, Err: %v", defaultFile, err)
-	} else {
-		e.logger.Infof("Loaded config from file: %v", defaultFile)
-	}
+	// Apply to environment variables, respecting system env precedence
+	e.applyEnvironmentVariables(envMap, initialEnv)
+}
 
-	if env != "" {
-		// If 'APP_ENV' is set to x, then GoFr will read '.env' from configs directory, and then it will be overwritten
-		// by configs present in file '.x.env'
-		overrideFile = fmt.Sprintf("%s/.%s.env", folder, env)
-	}
+// captureInitialEnv captures the initial system environment keys.
+func (*EnvLoader) captureInitialEnv() map[string]bool {
+	initialEnv := make(map[string]bool)
 
-	err = godotenv.Overload(overrideFile)
-	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			e.logger.Fatalf("Failed to load config from file: %v, Err: %v", overrideFile, err)
-		}
-	} else {
-		e.logger.Infof("Loaded config from file: %v", overrideFile)
-	}
-
-	// Reload system environment variables to ensure they override any previously loaded values
 	for _, envVar := range os.Environ() {
-		key, value, found := strings.Cut(envVar, "=")
-		if found {
+		key, _, _ := strings.Cut(envVar, "=")
+		initialEnv[key] = true
+	}
+
+	return initialEnv
+}
+
+// loadEnvironmentFiles loads all environment files with proper precedence.
+func (e *EnvLoader) loadEnvironmentFiles(folder string) map[string]string {
+	envMap := make(map[string]string)
+
+	// Load base .env file (lowest precedence)
+	e.loadBaseEnvFile(folder, envMap)
+
+	// Load default override (.local.env) if exists (medium precedence)
+	e.loadLocalOverrideFile(folder, envMap)
+
+	// Load app-env specific override (highest file precedence)
+	e.loadEnvSpecificFile(folder, envMap)
+
+	return envMap
+}
+
+// loadBaseEnvFile loads the base .env file.
+func (e *EnvLoader) loadBaseEnvFile(folder string, envMap map[string]string) {
+	defaultFile := folder + defaultFileName
+
+	if content, err := godotenv.Read(defaultFile); err == nil {
+		for k, v := range content {
+			envMap[k] = v
+		}
+
+		e.logger.Infof("Loaded config from file: %v", defaultFile)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		e.logger.Warnf("Failed to load config from file: %v, Err: %v", defaultFile, err)
+	}
+}
+
+// loadLocalOverrideFile loads the .local.env override file.
+func (e *EnvLoader) loadLocalOverrideFile(folder string, envMap map[string]string) {
+	localOverridePath := folder + defaultOverrideFileName
+
+	if content, err := godotenv.Read(localOverridePath); err == nil {
+		for k, v := range content {
+			envMap[k] = v
+		}
+
+		e.logger.Debugf("Applied override config: %v", localOverridePath)
+	}
+}
+
+// loadEnvSpecificFile loads the app-env specific override file.
+func (e *EnvLoader) loadEnvSpecificFile(folder string, envMap map[string]string) {
+	env := os.Getenv("APP_ENV")
+
+	if env == "" {
+		return
+	}
+
+	envSpecificFile := fmt.Sprintf("%s/.%s.env", folder, env)
+
+	if content, err := godotenv.Read(envSpecificFile); err == nil {
+		for k, v := range content {
+			envMap[k] = v
+		}
+
+		e.logger.Debugf("Applied app-env override config: %v", envSpecificFile)
+	}
+}
+
+// applyEnvironmentVariables applies environment variables respecting system precedence.
+func (*EnvLoader) applyEnvironmentVariables(envMap map[string]string, initialEnv map[string]bool) {
+	for key, value := range envMap {
+		// Only set if not in initial system environment
+		if !initialEnv[key] {
 			os.Setenv(key, value)
 		}
 	}

--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -40,7 +40,7 @@ func (e *EnvLoader) read(folder string) {
 		env          = e.Get("APP_ENV")
 	)
 
-	// Capture initial system environment before any file loading
+	// Only Capture initial system environment before any file loading
 	initialEnv := e.captureInitialEnv()
 
 	err := godotenv.Load(defaultFile)
@@ -72,21 +72,20 @@ func (e *EnvLoader) read(folder string) {
 	}
 
 	// Reload system environment variables to ensure they override any previously loaded values
-	for _, envVar := range os.Environ() {
-		key, value, found := strings.Cut(envVar, "=")
-		if found {
-			os.Setenv(key, value)
-		}
+	for key, envVar := range initialEnv {
+		os.Setenv(key, envVar)
 	}
 }
 
 // captureInitialEnv captures the initial system environment keys.
-func (*EnvLoader) captureInitialEnv() map[string]bool {
-	initialEnv := make(map[string]bool)
+func (*EnvLoader) captureInitialEnv() map[string]string {
+	initialEnv := make(map[string]string)
 
 	for _, envVar := range os.Environ() {
-		key, _, _ := strings.Cut(envVar, "=")
-		initialEnv[key] = true
+		key, value, found := strings.Cut(envVar, "=")
+		if found {
+			initialEnv[key] = value
+		}
 	}
 
 	return initialEnv
@@ -94,7 +93,7 @@ func (*EnvLoader) captureInitialEnv() map[string]bool {
 
 // overloadEnvFile loads and applies environment variables from a file, similar to godotenv.Overload
 // but with better control over the application process and respect for system environment precedence.
-func (*EnvLoader) overloadEnvFile(filePath string, initialEnv map[string]bool) error {
+func (*EnvLoader) overloadEnvFile(filePath string, initialEnv map[string]string) error {
 	content, err := godotenv.Read(filePath)
 	if err != nil {
 		return err
@@ -102,7 +101,8 @@ func (*EnvLoader) overloadEnvFile(filePath string, initialEnv map[string]bool) e
 
 	// Apply the environment variables from the file only if they're not already set in system environment
 	for key, value := range content {
-		if !initialEnv[key] {
+		_, found := initialEnv[key]
+		if !found {
 			os.Setenv(key, value)
 		}
 	}

--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -69,7 +69,8 @@ func (e *EnvLoader) read(folder string) {
 		e.logger.Infof("Loaded config from file: %v", overrideFile)
 	}
 
-	// Reload system environment variables to ensure they override any previously loaded values
+	// Reload system environment variables to ensure they take precedence over values loaded from files.
+	// This is required because Overload replaces the original system variables, which we need to restore.
 	for key, envVar := range initialEnv {
 		os.Setenv(key, envVar)
 	}

--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -34,17 +34,50 @@ func NewEnvFile(configFolder string, logger logger) Config {
 }
 
 func (e *EnvLoader) read(folder string) {
-	// Capture initial system environment keys
+	var (
+		defaultFile  = folder + defaultFileName
+		overrideFile = folder + defaultOverrideFileName
+		env          = e.Get("APP_ENV")
+	)
+
+	// Capture initial system environment before any file loading
 	initialEnv := e.captureInitialEnv()
 
-	// Capture APP_ENV before loading files to ensure proper environment-specific file loading
-	appEnv := os.Getenv("APP_ENV")
+	err := godotenv.Load(defaultFile)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			e.logger.Fatalf("Failed to load config from file: %v, Err: %v", defaultFile, err)
+		}
 
-	// Load environment files with proper precedence
-	envMap := e.loadEnvironmentFiles(folder, appEnv)
+		e.logger.Warnf("Failed to load config from file: %v, Err: %v", defaultFile, err)
+	} else {
+		e.logger.Infof("Loaded config from file: %v", defaultFile)
+	}
 
-	// Apply to environment variables, respecting system env precedence
-	e.applyEnvironmentVariables(envMap, initialEnv)
+	if env != "" {
+		// If 'APP_ENV' is set to x, then GoFr will read '.env' from configs directory, and then it will be overwritten
+		// by configs present in file '.x.env'
+		overrideFile = fmt.Sprintf("%s/.%s.env", folder, env)
+	}
+
+	// Use Read + manual application instead of Overload
+	// but only apply if the variable is not already set in system environment
+	err = e.overloadEnvFile(overrideFile, initialEnv)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			e.logger.Fatalf("Failed to load config from file: %v, Err: %v", overrideFile, err)
+		}
+	} else {
+		e.logger.Infof("Loaded config from file: %v", overrideFile)
+	}
+
+	// Reload system environment variables to ensure they override any previously loaded values
+	for _, envVar := range os.Environ() {
+		key, value, found := strings.Cut(envVar, "=")
+		if found {
+			os.Setenv(key, value)
+		}
+	}
 }
 
 // captureInitialEnv captures the initial system environment keys.
@@ -59,79 +92,22 @@ func (*EnvLoader) captureInitialEnv() map[string]bool {
 	return initialEnv
 }
 
-// loadEnvironmentFiles loads all environment files with proper precedence.
-func (e *EnvLoader) loadEnvironmentFiles(folder, appEnv string) map[string]string {
-	envMap := make(map[string]string)
-
-	// Load base .env file (lowest precedence)
-	e.loadBaseEnvFile(folder, envMap)
-
-	// Load default override (.local.env) if exists (medium precedence)
-	e.loadLocalOverrideFile(folder, envMap)
-
-	// Load app-env specific override (highest file precedence)
-	e.loadEnvSpecificFile(folder, envMap, appEnv)
-
-	return envMap
-}
-
-// loadBaseEnvFile loads the base .env file.
-func (e *EnvLoader) loadBaseEnvFile(folder string, envMap map[string]string) {
-	defaultFile := folder + defaultFileName
-
-	if content, err := godotenv.Read(defaultFile); err == nil {
-		for k, v := range content {
-			envMap[k] = v
-		}
-
-		e.logger.Infof("Loaded config from file: %v", defaultFile)
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		// CRITICAL: Fatal error for non-file-not-found errors (permissions, corruption, etc.)
-		e.logger.Fatalf("Failed to load config from file: %v, Err: %v", defaultFile, err)
-	}
-}
-
-// loadLocalOverrideFile loads the .local.env override file.
-func (e *EnvLoader) loadLocalOverrideFile(folder string, envMap map[string]string) {
-	localOverridePath := folder + defaultOverrideFileName
-
-	if content, err := godotenv.Read(localOverridePath); err == nil {
-		for k, v := range content {
-			envMap[k] = v
-		}
-
-		e.logger.Debugf("Applied override config: %v", localOverridePath)
-	}
-}
-
-// loadEnvSpecificFile loads the app-env specific override file.
-func (e *EnvLoader) loadEnvSpecificFile(folder string, envMap map[string]string, appEnv string) {
-	if appEnv == "" {
-		return
+// overloadEnvFile loads and applies environment variables from a file, similar to godotenv.Overload
+// but with better control over the application process and respect for system environment precedence
+func (e *EnvLoader) overloadEnvFile(filePath string, initialEnv map[string]bool) error {
+	content, err := godotenv.Read(filePath)
+	if err != nil {
+		return err
 	}
 
-	envSpecificFile := fmt.Sprintf("%s/.%s.env", folder, appEnv)
-
-	if content, err := godotenv.Read(envSpecificFile); err == nil {
-		for k, v := range content {
-			envMap[k] = v
-		}
-
-		e.logger.Debugf("Applied app-env override config: %v", envSpecificFile)
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		// CRITICAL: Fatal error for non-file-not-found errors (permissions, corruption, etc.)
-		e.logger.Fatalf("Failed to load config from file: %v, Err: %v", envSpecificFile, err)
-	}
-}
-
-// applyEnvironmentVariables applies environment variables respecting system precedence.
-func (*EnvLoader) applyEnvironmentVariables(envMap map[string]string, initialEnv map[string]bool) {
-	for key, value := range envMap {
-		// Only set if not in initial system environment
+	// Apply the environment variables from the file only if they're not already set in system environment
+	for key, value := range content {
 		if !initialEnv[key] {
 			os.Setenv(key, value)
 		}
 	}
+
+	return nil
 }
 
 func (*EnvLoader) Get(key string) string {

--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -60,7 +60,7 @@ func (*EnvLoader) captureInitialEnv() map[string]bool {
 }
 
 // loadEnvironmentFiles loads all environment files with proper precedence.
-func (e *EnvLoader) loadEnvironmentFiles(folder string, appEnv string) map[string]string {
+func (e *EnvLoader) loadEnvironmentFiles(folder, appEnv string) map[string]string {
 	envMap := make(map[string]string)
 
 	// Load base .env file (lowest precedence)

--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -60,9 +60,7 @@ func (e *EnvLoader) read(folder string) {
 		overrideFile = fmt.Sprintf("%s/.%s.env", folder, env)
 	}
 
-	// Use Read + manual application instead of Overload
-	// but only apply if the variable is not already set in system environment
-	err = e.overloadEnvFile(overrideFile, initialEnv)
+	err = godotenv.Overload(overrideFile)
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			e.logger.Fatalf("Failed to load config from file: %v, Err: %v", overrideFile, err)
@@ -89,25 +87,6 @@ func (*EnvLoader) captureInitialEnv() map[string]string {
 	}
 
 	return initialEnv
-}
-
-// overloadEnvFile loads and applies environment variables from a file, similar to godotenv.Overload
-// but with better control over the application process and respect for system environment precedence.
-func (*EnvLoader) overloadEnvFile(filePath string, initialEnv map[string]string) error {
-	content, err := godotenv.Read(filePath)
-	if err != nil {
-		return err
-	}
-
-	// Apply the environment variables from the file only if they're not already set in system environment
-	for key, value := range content {
-		_, found := initialEnv[key]
-		if !found {
-			os.Setenv(key, value)
-		}
-	}
-
-	return nil
 }
 
 func (*EnvLoader) Get(key string) string {

--- a/pkg/gofr/config/godotenv.go
+++ b/pkg/gofr/config/godotenv.go
@@ -93,8 +93,8 @@ func (*EnvLoader) captureInitialEnv() map[string]bool {
 }
 
 // overloadEnvFile loads and applies environment variables from a file, similar to godotenv.Overload
-// but with better control over the application process and respect for system environment precedence
-func (e *EnvLoader) overloadEnvFile(filePath string, initialEnv map[string]bool) error {
+// but with better control over the application process and respect for system environment precedence.
+func (*EnvLoader) overloadEnvFile(filePath string, initialEnv map[string]bool) error {
 	content, err := godotenv.Read(filePath)
 	if err != nil {
 		return err

--- a/pkg/gofr/config/godotenv_test.go
+++ b/pkg/gofr/config/godotenv_test.go
@@ -48,6 +48,7 @@ func Test_EnvSuccess(t *testing.T) {
 }
 
 func Test_EnvSuccess_AppEnv_Override(t *testing.T) {
+	clearAllEnv()
 	t.Setenv("APP_ENV", "prod")
 
 	envData := map[string]string{

--- a/pkg/gofr/config/godotenv_test.go
+++ b/pkg/gofr/config/godotenv_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,12 +11,21 @@ import (
 	"gofr.dev/pkg/gofr/logging"
 )
 
+func clearAllEnv() {
+	for _, envVar := range os.Environ() {
+		key, _, _ := strings.Cut(envVar, "=")
+		_ = os.Unsetenv(key)
+	}
+}
+
 func TestMain(m *testing.M) {
 	os.Setenv("GOFR_TELEMETRY", "false")
-	m.Run()
+	os.Exit(m.Run())
 }
 
 func Test_EnvSuccess(t *testing.T) {
+	clearAllEnv()
+
 	envData := map[string]string{
 		"DB_URL":     "localhost:5432",
 		"API_KEY":    "your_api_key_here",
@@ -60,7 +70,7 @@ func Test_EnvSuccess_AppEnv_Override(t *testing.T) {
 }
 
 func Test_EnvSuccess_Local_Override(t *testing.T) {
-	t.Setenv("APP_ENV", "")
+	clearAllEnv()
 
 	envData := map[string]string{
 		"API_KEY": "your_api_key_here",
@@ -82,6 +92,8 @@ func Test_EnvSuccess_Local_Override(t *testing.T) {
 }
 
 func Test_EnvSuccess_SystemEnv_Override(t *testing.T) {
+	clearAllEnv()
+
 	// Set initial environment variables
 	envData := map[string]string{
 		"TEST_ENV": "env",


### PR DESCRIPTION
 - Currently, we are using Overload for overriding. This causes the system environment variables to be overwritten. To handle this, we now run a manual loop that skips all environment variables initially loaded from the system.