### PR TITLE
Respect custom content type and set default if not present

### DIFF
--- a/pkg/gofr/http/responder.go
+++ b/pkg/gofr/http/responder.go
@@ -74,7 +74,9 @@ func (r Responder) Respond(data any, err error) {
 		resp = response{Data: data, Error: errorObj}
 	}
 
-	r.w.Header().Set("Content-Type", "application/json")
+	if r.w.Header().Get("Content-Type") == "" {
+		r.w.Header().Set("Content-Type", "application/json")
+	}
 
 	r.w.WriteHeader(statusCode)
 


### PR DESCRIPTION
## Pull Request Template


**Description:**

-   Fixes #2393.
- Added a check to set default content type only in case if not present already.
- Added test for the same.

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

