### PR TITLE
feat: implement unified validation strategy for HTTP service features

### DIFF
--- a/pkg/gofr/service/apikey_auth.go
+++ b/pkg/gofr/service/apikey_auth.go
@@ -19,13 +19,36 @@ func (a *APIKeyConfig) AddOption(h HTTP) HTTP {
 	return &authProvider{auth: a.addAuthorizationHeader, HTTP: h}
 }
 
+// Validate implements the Validator interface for APIKeyConfig.
+// Returns an error if the API key is empty.
+func (a *APIKeyConfig) Validate() error {
+	apiKey := strings.TrimSpace(a.APIKey)
+	if apiKey == "" {
+		return AuthErr{Message: "non empty api key is required"}
+	}
+
+	return nil
+}
+
+// FeatureName implements the Validator interface.
+func (*APIKeyConfig) FeatureName() string {
+	return "APIKey Authentication"
+}
+
 func NewAPIKeyConfig(apiKey string) (Options, error) {
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
 		return nil, AuthErr{Message: "non empty api key is required"}
 	}
 
-	return &APIKeyConfig{APIKey: apiKey}, nil
+	config := &APIKeyConfig{APIKey: apiKey}
+
+	// Validate during creation as well for immediate feedback
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return config, nil
 }
 
 func (a *APIKeyConfig) addAuthorizationHeader(_ context.Context, headers map[string]string) (map[string]string, error) {

--- a/pkg/gofr/service/circuit_breaker.go
+++ b/pkg/gofr/service/circuit_breaker.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -24,6 +25,25 @@ var (
 type CircuitBreakerConfig struct {
 	Threshold int           // Threshold represents the max no of retry before switching the circuit breaker state.
 	Interval  time.Duration // Interval represents the time interval duration between hitting the HealthURL
+}
+
+// Validate implements the Validator interface for CircuitBreakerConfig.
+// Returns an error if threshold is <= 0 or interval is <= 0.
+func (c *CircuitBreakerConfig) Validate() error {
+	if c.Threshold <= 0 {
+		return fmt.Errorf("threshold must be greater than 0, got %d", c.Threshold)
+	}
+
+	if c.Interval <= 0 {
+		return fmt.Errorf("interval must be greater than 0, got %v", c.Interval)
+	}
+
+	return nil
+}
+
+// FeatureName implements the Validator interface.
+func (*CircuitBreakerConfig) FeatureName() string {
+	return "Circuit Breaker"
 }
 
 // circuitBreaker represents a circuit breaker implementation.

--- a/pkg/gofr/service/custom_header.go
+++ b/pkg/gofr/service/custom_header.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 )
 
@@ -14,6 +15,25 @@ func (a *DefaultHeaders) AddOption(h HTTP) HTTP {
 		Headers: a.Headers,
 		HTTP:    h,
 	}
+}
+
+// Validate implements the Validator interface for DefaultHeaders.
+// Returns an error if headers map is nil or empty.
+func (a *DefaultHeaders) Validate() error {
+	if a.Headers == nil {
+		return fmt.Errorf("headers map cannot be nil")
+	}
+
+	if len(a.Headers) == 0 {
+		return fmt.Errorf("headers map cannot be empty")
+	}
+
+	return nil
+}
+
+// FeatureName implements the Validator interface.
+func (*DefaultHeaders) FeatureName() string {
+	return "Custom Headers"
 }
 
 type customHeader struct {

--- a/pkg/gofr/service/health.go
+++ b/pkg/gofr/service/health.go
@@ -19,6 +19,7 @@ const (
 type Health struct {
 	Status  string         `json:"status"`
 	Details map[string]any `json:"details"`
+	Reason  string         `json:"reason,omitempty"` // Reason provides additional context for the health status
 }
 
 func (h *httpService) HealthCheck(ctx context.Context) *Health {

--- a/pkg/gofr/service/validation.go
+++ b/pkg/gofr/service/validation.go
@@ -1,0 +1,108 @@
+package service
+
+import "fmt"
+
+// ValidationMode determines how validation failures are handled.
+type ValidationMode int
+
+const (
+	// ValidationModeSoft allows the service to continue with logged warnings when validation fails.
+	// This is the default mode for backward compatibility.
+	ValidationModeSoft ValidationMode = iota
+
+	// ValidationModeStrict causes service creation to fail immediately when validation fails.
+	// Recommended for production environments to ensure proper configuration.
+	ValidationModeStrict
+)
+
+// Validator defines an interface for validating HTTP service options.
+// Options that implement this interface will have their Validate method called during service initialization.
+type Validator interface {
+	// Validate checks if the option configuration is valid.
+	// Returns an error if validation fails, nil otherwise.
+	Validate() error
+
+	// FeatureName returns the name of the feature for logging purposes.
+	FeatureName() string
+}
+
+// ValidationConfig holds configuration for service option validation.
+type ValidationConfig struct {
+	// Mode determines how validation failures are handled.
+	// Default is ValidationModeSoft for backward compatibility.
+	Mode ValidationMode
+
+	// Logger is used to log validation warnings/errors.
+	// If nil, validation errors will only be returned in strict mode.
+	Logger Logger
+}
+
+// validateOptions validates all options that implement the Validator interface.
+// Returns an error in strict mode if any validation fails, otherwise logs warnings and continues.
+func validateOptions(config ValidationConfig, options []Options) error {
+	var validationErrors []ValidationError
+
+	for _, opt := range options {
+		if validator, ok := opt.(Validator); ok {
+			if err := validator.Validate(); err != nil {
+				validationErr := ValidationError{
+					Feature: validator.FeatureName(),
+					Err:     err,
+				}
+				validationErrors = append(validationErrors, validationErr)
+
+				// Log warning in soft mode or if logger is available
+				if config.Mode == ValidationModeSoft && config.Logger != nil {
+					config.Logger.Log(fmt.Sprintf(
+						"Warning: Validation failed for %s: %v. Service will continue with potentially incorrect configuration.",
+						validationErr.Feature, err))
+				}
+			}
+		}
+	}
+
+	// In strict mode, return error if any validation failed
+	if config.Mode == ValidationModeStrict && len(validationErrors) > 0 {
+		return &ValidationErrors{
+			Errors: validationErrors,
+		}
+	}
+
+	return nil
+}
+
+// ValidationError represents a single validation failure for a feature.
+type ValidationError struct {
+	Feature string
+	Err     error
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("validation failed for %s: %v", e.Feature, e.Err)
+}
+
+// ValidationErrors represents multiple validation failures.
+type ValidationErrors struct {
+	Errors []ValidationError
+}
+
+func (e *ValidationErrors) Error() string {
+	if len(e.Errors) == 0 {
+		return "no validation errors"
+	}
+
+	if len(e.Errors) == 1 {
+		return e.Errors[0].Error()
+	}
+
+	msg := fmt.Sprintf("%d validation errors: ", len(e.Errors))
+	for i, err := range e.Errors {
+		if i > 0 {
+			msg += "; "
+		}
+		msg += err.Error()
+	}
+
+	return msg
+}
+

--- a/pkg/gofr/service/validation_test.go
+++ b/pkg/gofr/service/validation_test.go
@@ -1,0 +1,427 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"gofr.dev/pkg/gofr/logging"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidationMode_String(t *testing.T) {
+	assert.Equal(t, ValidationModeSoft, ValidationMode(0))
+	assert.Equal(t, ValidationModeStrict, ValidationMode(1))
+}
+
+func TestValidateOptions_SoftMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		options       []Options
+		expectWarning bool
+		expectError   bool
+	}{
+		{
+			name:          "valid options",
+			options:       []Options{&APIKeyConfig{APIKey: "valid-key"}},
+			expectWarning: false,
+			expectError:   false,
+		},
+		{
+			name:          "invalid option",
+			options:       []Options{&APIKeyConfig{APIKey: ""}},
+			expectWarning: true,
+			expectError:   false,
+		},
+		{
+			name: "multiple invalid options",
+			options: []Options{
+				&APIKeyConfig{APIKey: ""},
+				&BasicAuthConfig{UserName: "", Password: ""},
+			},
+			expectWarning: true,
+			expectError:   false,
+		},
+		{
+			name: "mixed valid and invalid options",
+			options: []Options{
+				&APIKeyConfig{APIKey: "valid-key"},
+				&APIKeyConfig{APIKey: ""},
+			},
+			expectWarning: true,
+			expectError:   false,
+		},
+		{
+			name:          "non-validator option",
+			options:       []Options{&RetryConfig{MaxRetries: 3}},
+			expectWarning: false,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLogger := logging.NewMockLogger(logging.DEBUG)
+			logsBefore := len(mockLogger.Logs())
+
+			config := ValidationConfig{
+				Mode:   ValidationModeSoft,
+				Logger: mockLogger,
+			}
+
+			err := validateOptions(config, tt.options)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.expectWarning {
+				assert.Greater(t, len(mockLogger.Logs()), logsBefore, "Expected warning log")
+			} else {
+				assert.Equal(t, len(mockLogger.Logs()), logsBefore, "No warning log expected")
+			}
+		})
+	}
+}
+
+func TestValidateOptions_StrictMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     []Options
+		expectError bool
+	}{
+		{
+			name:        "valid options",
+			options:     []Options{&APIKeyConfig{APIKey: "valid-key"}},
+			expectError: false,
+		},
+		{
+			name:        "invalid option",
+			options:     []Options{&APIKeyConfig{APIKey: ""}},
+			expectError: true,
+		},
+		{
+			name: "multiple invalid options",
+			options: []Options{
+				&APIKeyConfig{APIKey: ""},
+				&BasicAuthConfig{UserName: "", Password: ""},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLogger := logging.NewMockLogger(logging.DEBUG)
+			config := ValidationConfig{
+				Mode:   ValidationModeStrict,
+				Logger: mockLogger,
+			}
+
+			err := validateOptions(config, tt.options)
+
+			if tt.expectError {
+				require.Error(t, err)
+				validationErr, ok := err.(*ValidationErrors)
+				assert.True(t, ok, "Error should be ValidationErrors")
+				assert.Greater(t, len(validationErr.Errors), 0)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidationError_Error(t *testing.T) {
+	err := ValidationError{
+		Feature: "Test Feature",
+		Err:     fmt.Errorf("test error"),
+	}
+
+	expected := "validation failed for Test Feature: test error"
+	assert.Equal(t, expected, err.Error())
+}
+
+func TestValidationErrors_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		errors   []ValidationError
+		expected string
+	}{
+		{
+			name:     "single error",
+			errors:   []ValidationError{{Feature: "Feature1", Err: fmt.Errorf("error1")}},
+			expected: "validation failed for Feature1: error1",
+		},
+		{
+			name: "multiple errors",
+			errors: []ValidationError{
+				{Feature: "Feature1", Err: fmt.Errorf("error1")},
+				{Feature: "Feature2", Err: fmt.Errorf("error2")},
+			},
+			expected: "2 validation errors: validation failed for Feature1: error1; validation failed for Feature2: error2",
+		},
+		{
+			name:     "no errors",
+			errors:   []ValidationError{},
+			expected: "no validation errors",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := &ValidationErrors{Errors: tt.errors}
+			assert.Equal(t, tt.expected, errs.Error())
+		})
+	}
+}
+
+func TestNewHTTPServiceWithValidation_SoftMode(t *testing.T) {
+	mockLogger := logging.NewMockLogger(logging.DEBUG)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Invalid option should log warning but service should still be created
+	invalidConfig := &APIKeyConfig{APIKey: ""}
+	svc := NewHTTPServiceWithValidation(
+		server.URL,
+		mockLogger,
+		nil,
+		ValidationConfig{Mode: ValidationModeSoft, Logger: mockLogger},
+		invalidConfig,
+	)
+
+	// Service should be created despite invalid config
+	assert.NotNil(t, svc)
+
+	// Should have logged warning
+	logs := mockLogger.Logs()
+	assert.Greater(t, len(logs), 0, "Expected warning log")
+
+	// Service should still function (though with invalid config)
+	resp, err := svc.Get(context.Background(), "test", nil)
+	// Service creation succeeded, but actual request behavior depends on implementation
+	_ = resp
+	_ = err
+}
+
+func TestNewHTTPServiceWithValidation_StrictMode(t *testing.T) {
+	mockLogger := logging.NewMockLogger(logging.DEBUG)
+
+	tests := []struct {
+		name        string
+		options     []Options
+		expectError bool
+	}{
+		{
+			name:        "valid options",
+			options:     []Options{&APIKeyConfig{APIKey: "valid-key"}},
+			expectError: false,
+		},
+		{
+			name:        "invalid option",
+			options:     []Options{&APIKeyConfig{APIKey: ""}},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewHTTPServiceWithValidation(
+				"http://example.com",
+				mockLogger,
+				nil,
+				ValidationConfig{Mode: ValidationModeStrict, Logger: mockLogger},
+				tt.options...,
+			)
+
+			if tt.expectError {
+				// In strict mode with invalid options, service should fail on first request
+				resp, err := svc.Get(context.Background(), "test", nil)
+				assert.Error(t, err, "Expected error on first request")
+				assert.Nil(t, resp)
+				assert.Contains(t, err.Error(), "service creation failed")
+			} else {
+				// Valid service should be created
+				assert.NotNil(t, svc)
+			}
+		})
+	}
+}
+
+func TestValidationFailedService(t *testing.T) {
+	err := fmt.Errorf("validation error")
+	svc := &validationFailedService{err: err}
+
+	tests := []struct {
+		name        string
+		method      func() error
+		expectError bool
+	}{
+		{
+			name: "Get",
+			method: func() error {
+				_, err := svc.Get(context.Background(), "test", nil)
+				return err
+			},
+			expectError: true,
+		},
+		{
+			name: "Post",
+			method: func() error {
+				_, err := svc.Post(context.Background(), "test", nil, nil)
+				return err
+			},
+			expectError: true,
+		},
+		{
+			name: "HealthCheck",
+			method: func() error {
+				health := svc.HealthCheck(context.Background())
+				if health.Status == "DOWN" {
+					return fmt.Errorf(health.Reason)
+				}
+				return nil
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.method()
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "validation error")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidatorImplementations(t *testing.T) {
+	tests := []struct {
+		name      string
+		validator Validator
+		expectErr bool
+	}{
+		{
+			name:      "APIKeyConfig valid",
+			validator: &APIKeyConfig{APIKey: "valid-key"},
+			expectErr: false,
+		},
+		{
+			name:      "APIKeyConfig invalid",
+			validator: &APIKeyConfig{APIKey: ""},
+			expectErr: true,
+		},
+		{
+			name:      "BasicAuthConfig valid",
+			validator: &BasicAuthConfig{UserName: "user", Password: "pass"},
+			expectErr: false,
+		},
+		{
+			name:      "BasicAuthConfig invalid username",
+			validator: &BasicAuthConfig{UserName: "", Password: "pass"},
+			expectErr: true,
+		},
+		{
+			name:      "BasicAuthConfig invalid password",
+			validator: &BasicAuthConfig{UserName: "user", Password: ""},
+			expectErr: true,
+		},
+		{
+			name: "OAuthConfig valid",
+			validator: &OAuthConfig{
+				ClientID:     "client-id",
+				ClientSecret: "secret",
+				TokenURL:     "https://example.com/token",
+			},
+			expectErr: false,
+		},
+		{
+			name: "OAuthConfig invalid client ID",
+			validator: &OAuthConfig{
+				ClientID:     "",
+				ClientSecret: "secret",
+				TokenURL:     "https://example.com/token",
+			},
+			expectErr: true,
+		},
+		{
+			name:      "DefaultHeaders valid",
+			validator: &DefaultHeaders{Headers: map[string]string{"key": "value"}},
+			expectErr: false,
+		},
+		{
+			name:      "DefaultHeaders nil",
+			validator: &DefaultHeaders{Headers: nil},
+			expectErr: true,
+		},
+		{
+			name:      "DefaultHeaders empty",
+			validator: &DefaultHeaders{Headers: map[string]string{}},
+			expectErr: true,
+		},
+		{
+			name:      "CircuitBreakerConfig valid",
+			validator: &CircuitBreakerConfig{Threshold: 5, Interval: time.Second},
+			expectErr: false,
+		},
+		{
+			name:      "CircuitBreakerConfig invalid threshold",
+			validator: &CircuitBreakerConfig{Threshold: 0, Interval: time.Second},
+			expectErr: true,
+		},
+		{
+			name:      "CircuitBreakerConfig invalid interval",
+			validator: &CircuitBreakerConfig{Threshold: 5, Interval: 0},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.validator.Validate()
+			if tt.expectErr {
+				assert.Error(t, err, "Expected validation error")
+			} else {
+				assert.NoError(t, err, "Expected no validation error")
+			}
+
+			// Test FeatureName is not empty
+			featureName := tt.validator.FeatureName()
+			assert.NotEmpty(t, featureName, "FeatureName should not be empty")
+		})
+	}
+}
+
+func TestNewHTTPService_BackwardCompatibility(t *testing.T) {
+	// Test that existing NewHTTPService still works (defaults to soft mode)
+	mockLogger := logging.NewMockLogger(logging.DEBUG)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Should work with valid options
+	validConfig, _ := NewAPIKeyConfig("valid-key")
+	svc := NewHTTPService(server.URL, mockLogger, nil, validConfig)
+	assert.NotNil(t, svc)
+
+	// Should still work with invalid options (soft mode default)
+	invalidConfig := &APIKeyConfig{APIKey: ""}
+	svc2 := NewHTTPService(server.URL, mockLogger, nil, invalidConfig)
+	assert.NotNil(t, svc2) // Service created despite invalid config (soft mode)
+}
+


### PR DESCRIPTION
## Pull Request Template

**Description:**

Implements unified validation strategy for HTTP service features (v2 requirement from #2378). Adds `ValidationMode` (strict/soft) and `Validator` interface for consistent validation across Auth, Headers, and CircuitBreaker options. Introduces `NewHTTPServiceWithValidation()` API with strict mode for production while maintaining 100% backward compatibility via default soft mode.

**Breaking Changes (if applicable):**

None. Fully backward compatible - existing code continues to work unchanged.

**Additional Information:**

- New: `validation.go` (framework), `validation_test.go` (tests)
- Modified: 7 files implementing `Validator` interface
- Usage: `service.NewHTTPServiceWithValidation(url, logger, metrics, service.ValidationConfig{Mode: service.ValidationModeStrict}, ...options)`
- No external dependencies added

**Checklist:**

- [x] I have formatted my code using `goimport` and `golangci-lint`.
- [x] All new code is covered by unit tests.
- [x] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.

