### PR TITLE
Docs: added Go version prerequisite before running example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ go get -u gofr.dev/pkg/gofr
 ## 🏃 **Running GoFr**
 
 Here's a simple example to get a GoFr application up and running:
+Make sure you have Go 1.24+ installed and added to your PATH before running these commands.
 
 ```go
 package main


### PR DESCRIPTION
Added a small prerequisite note to ensure users have Go 1.24+ installed before running the example. Improves clarity for beginners.
