### PR TITLE
docs: add sample project structure to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,26 @@ Visit [`localhost:8000/greet`](http://localhost:8000/greet) to see the result.
 
 ---
 
+## 📁 Sample Project Structure
+
+A typical GoFr microservice project may follow this structure:
+
+```
+.
+├── main.go              # Application entry point
+├── go.mod               # Go module file
+├── configs/             # Environment-specific configurations
+├── handlers/            # HTTP / gRPC request handlers
+├── middleware/          # Custom middlewares
+├── migrations/          # Database migration files
+├── cron/                # Cron job definitions
+└── README.md
+```
+
+This structure helps keep the application modular, scalable, and production-ready.
+
+---
+
 ## 📂 **More Examples**
 
 Explore a variety of ready-to-run examples in the [GoFr examples directory](https://github.com/gofr-dev/gofr/tree/development/examples).


### PR DESCRIPTION
### What does this PR do?
Adds a Sample Project Structure section to the README to help new users understand how a typical GoFr microservice can be organized.

### Why is this change needed?
While the README explains how to run GoFr, it does not currently show how a real-world project is structured. This addition improves onboarding and clarity for beginners.

### Type of change
- Documentation improvement
