### PR TITLE
apply correct default for azure eventhub consumer group

### DIFF
--- a/pkg/gofr/datasource/pubsub/eventhub/go.mod
+++ b/pkg/gofr/datasource/pubsub/eventhub/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.1
+	github.com/coder/websocket v1.8.13
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.39.0
 	go.opentelemetry.io/otel/trace v1.39.0
 	go.uber.org/mock v0.6.0
 	gofr.dev v1.54.0
-	nhooyr.io/websocket v1.8.17
 )
 
 require (

--- a/pkg/gofr/datasource/pubsub/eventhub/go.sum
+++ b/pkg/gofr/datasource/pubsub/eventhub/go.sum
@@ -82,5 +82,3 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
-nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=


### PR DESCRIPTION
## Pull Request Template


**Description:**

-   Fixes: #2853
-   Resolves an issue where providing `CONSUMER_GROUP=$Default `(or **leaving it empty**) resulted in connection failures. 
- Previously, if the consumer group was empty, the client would generate a dynamic unique name (e.g., gofr-hostname-123). **Azure Event Hubs does not support dynamic consumer group creation; groups must be pre-provisioned.**

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

