### PR TITLE
Fix panic in sendOpeartionStats in db.go by adding nil checks

### DIFF
--- a/pkg/gofr/datasource/sql/db.go
+++ b/pkg/gofr/datasource/sql/db.go
@@ -44,18 +44,27 @@ func clean(query string) string {
 	return query
 }
 
-func (d *DB) sendOperationStats(start time.Time, queryType, query string, args ...any) {
+func sendStats(logger datasource.Logger, metrics Metrics, config *DBConfig, start time.Time, queryType, query string, args ...any) {
 	duration := time.Since(start).Milliseconds()
 
-	d.logger.Debug(&Log{
-		Type:     queryType,
-		Query:    query,
-		Duration: duration,
-		Args:     args,
-	})
+	if logger != nil {
+		logger.Debug(&Log{
+			Type:     queryType,
+			Query:    query,
+			Duration: duration,
+			Args:     args,
+		})
+	}
 
-	d.metrics.RecordHistogram(context.Background(), "app_sql_stats", float64(duration), "hostname", d.config.HostName,
-		"database", d.config.Database, "type", getOperationType(query))
+	// This contains the fix for the nil pointer dereference
+	if metrics != nil {
+		metrics.RecordHistogram(context.Background(), "app_sql_stats", float64(duration), "hostname", config.HostName,
+			"database", config.Database, "type", getOperationType(query))
+	}
+}
+
+func (d *DB) sendOperationStats(start time.Time, queryType, query string, args ...any) {
+	sendStats(d.logger, d.metrics, d.config, start, queryType, query, args...)
 }
 
 func getOperationType(query string) string {
@@ -129,17 +138,7 @@ type Tx struct {
 }
 
 func (t *Tx) sendOperationStats(start time.Time, queryType, query string, args ...any) {
-	duration := time.Since(start).Milliseconds()
-
-	t.logger.Debug(&Log{
-		Type:     queryType,
-		Query:    query,
-		Duration: duration,
-		Args:     args,
-	})
-
-	t.metrics.RecordHistogram(context.Background(), "app_sql_stats", float64(duration), "hostname", t.config.HostName,
-		"database", t.config.Database, "type", getOperationType(query))
+	sendStats(t.logger, t.metrics, t.config, start, queryType, query, args...)
 }
 
 func (t *Tx) Query(query string, args ...any) (*sql.Rows, error) {

--- a/pkg/gofr/datasource/sql/db_test.go
+++ b/pkg/gofr/datasource/sql/db_test.go
@@ -1251,3 +1251,26 @@ func TestDB_sendOperationStats_RecordsMilliseconds(t *testing.T) {
 	duration := time.Since(start).Milliseconds()
 	assert.Equal(t, int64(1500), duration)
 }
+
+func TestTx_Exec_SafeWithNilMetrics(t *testing.T) {
+	db, mock := getDB(t, logging.INFO)
+	defer db.DB.Close()
+
+	// 2. FORCE nil metrics (Simulating the bug scenario)
+	db.metrics = nil
+
+	// 3. Begin transaction
+	mock.ExpectBegin()
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	mock.ExpectExec("INSERT INTO users VALUES(.*)").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	assert.NotPanics(t, func() {
+		_, err = tx.Exec("INSERT INTO users VALUES(.*)", 1, "test")
+	}, "Tx.Exec should NOT panic when metrics are nil")
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Pull Request Template


**Description:**

-   Fixed a panic that occurred when performing database operations (such as migrations) before the metrics subsystem was fully initialized. The SQL client now safely handles uninitialized metrics/loggers without crashing. Refactored internal telemetry logic to improve maintainability.


**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

