### PR TITLE
fix: add deprecation warning for zipkin trace exporter

### DIFF
--- a/pkg/gofr/otel.go
+++ b/pkg/gofr/otel.go
@@ -8,7 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/exporters/zipkin"
+	"go.opentelemetry.io/otel/exporters/zipkin" //nolint:staticcheck // deprecated but kept for backward compatibility
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -140,6 +140,9 @@ func (a *App) getExporter(name, host, port, url string) (sdktrace.SpanExporter, 
 	case "otlp", "jaeger":
 		exporter, err = buildOtlpExporter(a.Logger(), name, url, host, port, headers)
 	case "zipkin":
+		a.Logger().Warn("TRACE_EXPORTER=zipkin is deprecated and will be removed in a future release. " +
+			"Consider using TRACE_EXPORTER=otlp instead. See https://opentelemetry.io/blog/2025/deprecating-zipkin-exporters/")
+
 		exporter, err = buildZipkinExporter(a.Logger(), url, host, port, headers)
 	case gofrTraceExporter:
 		exporter = buildGoFrExporter(a.Logger(), url)


### PR DESCRIPTION
## Summary
- The OpenTelemetry zipkin exporter (`go.opentelemetry.io/otel/exporters/zipkin`) is [deprecated](https://opentelemetry.io/blog/2025/deprecating-zipkin-exporters/) as of December 2025 and will be removed from the OTel specification by December 2026.
- Adds a runtime `WARN` log when users configure `TRACE_EXPORTER=zipkin`, guiding them to migrate to `TRACE_EXPORTER=otlp` (which GoFr already supports).
- Suppresses the `staticcheck SA1019` lint warning on the import with `//nolint:staticcheck` since we intentionally keep backward compatibility until removal.

## Test plan
- [x] `golangci-lint run ./pkg/gofr/` — 0 issues
- [x] `go test ./pkg/gofr/` — all tests pass