### PR TITLE
improve heatmap readability by capping y-axis at 100ms

### DIFF
--- a/examples/http-server/docker/provisioning/dashboards/gofr-dashboard/dashboards.json
+++ b/examples/http-server/docker/provisioning/dashboards/gofr-dashboard/dashboards.json
@@ -781,7 +781,8 @@
         "yAxis": {
           "axisPlacement": "left",
           "reverse": false,
-          "unit": "s"
+          "unit": "s",
+          "max": 0.1
         }
       },
       "pluginVersion": "10.3.3",
@@ -794,7 +795,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(app_http_response_bucket{}[$__rate_interval])) by (le)",
+          "expr": "sum(increase(app_http_response_bucket{le!~\"10|30|\\\\+Inf\"}[$__rate_interval])) by (le)",
           "format": "heatmap",
           "instant": false,
           "legendFormat": "{{le}}",
@@ -1740,7 +1741,8 @@
         "yAxis": {
           "axisPlacement": "left",
           "reverse": false,
-          "unit": "s"
+          "unit": "s",
+          "max": 0.1
         }
       },
       "pluginVersion": "10.3.3",
@@ -1752,7 +1754,7 @@
             "uid": "${DataSource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(app_http_service_response_bucket{}[$__rate_interval])) by (le)",
+          "expr": "sum(increase(app_http_service_response_bucket{le!~\"10|30|\\\\+Inf\"}[$__rate_interval])) by (le)",
           "format": "heatmap",
           "legendFormat": "__auto",
           "range": true,


### PR DESCRIPTION
## Pull Request Template


**Description:**

Fixes #3147
-   Modified the PromQL expressions for the Inbound (panel ID 2) and Outbound (panel ID 94) "Request Latency Distribution" heatmap panels to explicitly exclude the larger histogram buckets (`10`, `30`, and `+Inf`).
-   Configured a maximum Y-axis visible range (`yAxis.max: 0.1` / 100ms) on both heatmap configurations.


**Breaking Changes (if applicable):**

None

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

