### PR TITLE
Add latency unit field in JSON logs

### DIFF
--- a/pkg/gofr/grpc/log.go
+++ b/pkg/gofr/grpc/log.go
@@ -44,6 +44,7 @@ type gRPCLog struct {
 	ID           string `json:"id"`
 	StartTime    string `json:"startTime"`
 	ResponseTime int64  `json:"responseTime"`
+	ResponseUnit string `json:"responseUnit"`
 	Method       string `json:"method"`
 	StatusCode   int32  `json:"statusCode"`
 	StreamType   string `json:"streamType,omitempty"`

--- a/pkg/gofr/grpc/log.go
+++ b/pkg/gofr/grpc/log.go
@@ -212,6 +212,7 @@ func logStreamRPC(ctx context.Context, logger Logger, metrics Metrics, start tim
 		ID:           getTraceID(ctx),
 		StartTime:    start.Format("2006-01-02T15:04:05.999999999-07:00"),
 		ResponseTime: duration.Microseconds(),
+		ResponseUnit: "µs",
 		Method:       method,
 		StreamType:   streamType,
 	}
@@ -235,6 +236,7 @@ func logRPC(ctx context.Context, logger Logger, metrics Metrics, start time.Time
 		ID:           trace.SpanFromContext(ctx).SpanContext().TraceID().String(),
 		StartTime:    start.Format("2006-01-02T15:04:05.999999999-07:00"),
 		ResponseTime: duration.Microseconds(),
+		ResponseUnit: "µs",
 		Method:       method,
 	}
 

--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -121,6 +121,7 @@ func handleRequestLog(srw *StatusResponseWriter, r *http.Request, start time.Tim
 		SpanID:       spanID,
 		StartTime:    start.Format("2006-01-02T15:04:05.999999999-07:00"),
 		ResponseTime: time.Since(start).Nanoseconds() / 1000,
+		ResponseUnit: "µs",
 		Method:       r.Method,
 		UserAgent:    r.UserAgent(),
 		IP:           getIPAddress(r),

--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -53,6 +53,7 @@ type RequestLog struct {
 	SpanID       string `json:"span_id,omitempty"`
 	StartTime    string `json:"start_time,omitempty"`
 	ResponseTime int64  `json:"response_time,omitempty"`
+	ResponseUnit string `json:"latencyUnit,omitempty"`
 	Method       string `json:"method,omitempty"`
 	UserAgent    string `json:"user_agent,omitempty"`
 	IP           string `json:"ip,omitempty"`

--- a/pkg/gofr/service/logger.go
+++ b/pkg/gofr/service/logger.go
@@ -13,6 +13,7 @@ type Logger interface {
 type Log struct {
 	Timestamp     time.Time `json:"timestamp"`
 	ResponseTime  int64     `json:"latency"`
+	ResponseUnit  string    `json:"latencyUnit"`
 	CorrelationID string    `json:"correlationId"`
 	ResponseCode  int       `json:"responseCode"`
 	HTTPMethod    string    `json:"httpMethod"`

--- a/pkg/gofr/service/logger_test.go
+++ b/pkg/gofr/service/logger_test.go
@@ -11,7 +11,8 @@ func TestLog_PrettyPrint(t *testing.T) {
 	w := new(bytes.Buffer)
 
 	l := &Log{
-		ResponseTime:  100,
+		ResponseTime: 100,
+		ResponseUnit: "µs",
 		CorrelationID: "abc-test-correlation-id",
 		ResponseCode:  200,
 		HTTPMethod:    "GET",
@@ -29,7 +30,8 @@ func TestErrorLog_PrettyPrint(t *testing.T) {
 
 	l := &ErrorLog{
 		Log: &Log{
-			ResponseTime:  100,
+			ResponseTime: 100,
+			ResponseUnit: "µs",
 			CorrelationID: "abc-test-correlation-id",
 			ResponseCode:  200,
 			HTTPMethod:    "GET",


### PR DESCRIPTION
Added `latencyUnit` field in JSON logs to make latency values explicit.

### Changes made:

* Added `ResponseUnit` field in log struct
* Added `"µs"` in gRPC logs
* Added `"µs"` in HTTP middleware logs
* Updated related test files