### PR TITLE
feat: add OpenTelemetry span links to MQTT pub/sub

### DIFF
--- a/pkg/gofr/datasource/pubsub/mqtt/helper.go
+++ b/pkg/gofr/datasource/pubsub/mqtt/helper.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
-	"go.opentelemetry.io/otel"
 
 	"gofr.dev/pkg/gofr/datasource/pubsub"
 )
@@ -45,8 +44,10 @@ func (m *MQTT) createQueryMessageHandler(ctx context.Context, msgChan chan<- *pu
 		messageCtx := context.WithoutCancel(ctx)
 		message := pubsub.NewMessage(messageCtx)
 
+		_, payload := unwrapPayload(msg.Payload())
+
 		message.Topic = msg.Topic()
-		message.Value = msg.Payload()
+		message.Value = payload
 		message.MetaData = map[string]string{
 			"qos":       string(msg.Qos()),
 			"retained":  strconv.FormatBool(msg.Retained()),
@@ -136,8 +137,8 @@ func (*MQTT) handleContextDone(queryCtx context.Context, topicName string, buffe
 }
 func (m *MQTT) createMqttHandler(_ context.Context, topic string, msgs chan *pubsub.Message) mqtt.MessageHandler {
 	return func(_ mqtt.Client, msg mqtt.Message) {
-		ctx := context.Background()
-		ctx, span := otel.GetTracerProvider().Tracer("gofr").Start(ctx, "mqtt-subscribe")
+		traceHeaders, payload := unwrapPayload(msg.Payload())
+		ctx, span := startSubscribeSpan(context.Background(), topic, traceHeaders)
 
 		defer span.End()
 
@@ -146,7 +147,7 @@ func (m *MQTT) createMqttHandler(_ context.Context, topic string, msgs chan *pub
 		var messg = pubsub.NewMessage(context.WithoutCancel(ctx))
 
 		messg.Topic = msg.Topic()
-		messg.Value = msg.Payload()
+		messg.Value = payload
 		messg.MetaData = map[string]string{
 			"qos":       string(msg.Qos()),
 			"retained":  strconv.FormatBool(msg.Retained()),
@@ -161,7 +162,7 @@ func (m *MQTT) createMqttHandler(_ context.Context, topic string, msgs chan *pub
 		m.logger.Debug(&pubsub.Log{
 			Mode:          "SUB",
 			CorrelationID: span.SpanContext().TraceID().String(),
-			MessageValue:  string(msg.Payload()),
+			MessageValue:  string(payload),
 			Topic:         msg.Topic(),
 			Host:          m.config.Hostname,
 			PubSubBackend: "MQTT",
@@ -171,9 +172,11 @@ func (m *MQTT) createMqttHandler(_ context.Context, topic string, msgs chan *pub
 
 func getHandler(subscribeFunc SubscribeFunc) func(client mqtt.Client, msg mqtt.Message) {
 	return func(_ mqtt.Client, msg mqtt.Message) {
+		_, payload := unwrapPayload(msg.Payload())
+
 		pubsubMsg := &pubsub.Message{
 			Topic: msg.Topic(),
-			Value: msg.Payload(),
+			Value: payload,
 			MetaData: map[string]string{
 				"qos":       string(msg.Qos()),
 				"retained":  strconv.FormatBool(msg.Retained()),

--- a/pkg/gofr/datasource/pubsub/mqtt/mqtt.go
+++ b/pkg/gofr/datasource/pubsub/mqtt/mqtt.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
-	"go.opentelemetry.io/otel"
 
 	"gofr.dev/pkg/gofr/datasource"
 	"gofr.dev/pkg/gofr/datasource/pubsub"
@@ -177,14 +176,15 @@ func (m *MQTT) Query(ctx context.Context, query string, args ...any) ([]byte, er
 }
 
 func (m *MQTT) Publish(ctx context.Context, topic string, message []byte) error {
-	_, span := otel.GetTracerProvider().Tracer("gofr").Start(ctx, "mqtt-publish")
+	_, span, traceHeaders := startPublishSpan(ctx, topic)
 	defer span.End()
 
 	m.metrics.IncrementCounter(ctx, "app_pubsub_publish_total_count", "topic", topic)
 
 	s := time.Now()
 
-	token := m.Client.Publish(topic, m.config.QoS, m.config.RetrieveRetained, message)
+	wrappedMsg := wrapPayload(traceHeaders, message)
+	token := m.Client.Publish(topic, m.config.QoS, m.config.RetrieveRetained, wrappedMsg)
 
 	// Check for errors during publishing (More on error reporting
 	// https://pkg.go.dev/github.com/eclipse/paho.mqtt.golang#readme-error-handling)

--- a/pkg/gofr/datasource/pubsub/mqtt/mqtt_test.go
+++ b/pkg/gofr/datasource/pubsub/mqtt/mqtt_test.go
@@ -132,7 +132,7 @@ func TestMQTT_Disconnect(t *testing.T) {
 
 	mockClient.EXPECT().Disconnect(uint(1))
 
-	mockClient.EXPECT().Publish("test", mockConfigs.QoS, mockConfigs.RetrieveRetained, msg).Return(mockToken)
+	mockClient.EXPECT().Publish("test", mockConfigs.QoS, mockConfigs.RetrieveRetained, gomock.Any()).Return(mockToken)
 
 	mockToken.EXPECT().Wait().Return(true)
 	mockToken.EXPECT().Error().Return(errToken).Times(3)
@@ -181,7 +181,7 @@ func TestMQTT_PublishSuccess(t *testing.T) {
 		mockMetrics.EXPECT().
 			IncrementCounter(ctx, "app_pubsub_publish_success_count", "topic", "test/topic")
 
-		mockClient.EXPECT().Publish("test/topic", mockConfigs.QoS, mockConfigs.RetrieveRetained, msg).
+		mockClient.EXPECT().Publish("test/topic", mockConfigs.QoS, mockConfigs.RetrieveRetained, gomock.Any()).
 			Return(mockToken)
 
 		mockToken.EXPECT().Wait().Return(true)
@@ -211,7 +211,7 @@ func TestMQTT_PublishFailure(t *testing.T) {
 	// Disconnect the client
 	_ = client.Disconnect(1)
 
-	mockClient.EXPECT().Publish("test/topic", mockConfigs.QoS, mockConfigs.RetrieveRetained, msg).Return(mockToken)
+	mockClient.EXPECT().Publish("test/topic", mockConfigs.QoS, mockConfigs.RetrieveRetained, gomock.Any()).Return(mockToken)
 	mockToken.EXPECT().Wait().Return(true)
 	mockToken.EXPECT().Error().Return(errToken).Times(3)
 

--- a/pkg/gofr/datasource/pubsub/mqtt/tracing.go
+++ b/pkg/gofr/datasource/pubsub/mqtt/tracing.go
@@ -1,0 +1,177 @@
+package mqtt
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const tracerName = "gofr-mqtt"
+
+// traceEnvelope is the JSON structure used to wrap payloads with trace context.
+// MQTT v3.1.1 does not support message-level headers, so trace context is embedded in the payload.
+type traceEnvelope struct {
+	Marker      string `json:"_gofr_trace"`
+	Traceparent string `json:"tp,omitempty"`
+	Tracestate  string `json:"ts,omitempty"`
+	Data        string `json:"d"`
+}
+
+// headerCarrier implements propagation.TextMapCarrier for trace context propagation.
+type headerCarrier map[string]string
+
+// Ensure headerCarrier implements the interface at compile time.
+var _ propagation.TextMapCarrier = headerCarrier(nil)
+
+// Get returns the value for a given key.
+func (c headerCarrier) Get(key string) string {
+	return c[key]
+}
+
+// Set sets a key-value pair.
+func (c headerCarrier) Set(key, value string) {
+	c[key] = value
+}
+
+// Keys returns all keys.
+func (c headerCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+// injectTraceContext injects the current trace context into a string map.
+func injectTraceContext(ctx context.Context, headers map[string]string) map[string]string {
+	if headers == nil {
+		headers = make(map[string]string)
+	}
+
+	carrier := headerCarrier(headers)
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
+
+	return headers
+}
+
+// extractTraceLinks extracts the trace context from headers and returns span links to the producer span.
+// If no trace context is found, returns nil (creating an orphan span).
+func extractTraceLinks(headers map[string]string) []trace.Link {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	carrier := headerCarrier(headers)
+
+	extractedCtx := otel.GetTextMapPropagator().Extract(context.Background(), carrier)
+
+	spanCtx := trace.SpanContextFromContext(extractedCtx)
+
+	if spanCtx.IsValid() {
+		return []trace.Link{
+			{
+				SpanContext: spanCtx,
+			},
+		}
+	}
+
+	return nil
+}
+
+// startPublishSpan creates a new span for publishing with trace context injection.
+// Returns the updated context, span, and headers with injected trace context.
+func startPublishSpan(ctx context.Context, topic string) (context.Context, trace.Span, map[string]string) {
+	opts := []trace.SpanStartOption{
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "mqtt"),
+			attribute.String("messaging.destination.name", topic),
+			attribute.String("messaging.operation", "publish"),
+		),
+	}
+
+	ctx, span := otel.GetTracerProvider().Tracer(tracerName).Start(ctx, "mqtt-publish", opts...)
+
+	headers := injectTraceContext(ctx, nil)
+
+	return ctx, span, headers
+}
+
+// startSubscribeSpan creates a new span for subscribing with links to the producer span.
+// If trace context exists in headers, creates a span linked to the producer.
+// Otherwise, creates an orphan span (new trace).
+func startSubscribeSpan(ctx context.Context, topic string, headers map[string]string) (context.Context, trace.Span) {
+	links := extractTraceLinks(headers)
+
+	opts := []trace.SpanStartOption{
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "mqtt"),
+			attribute.String("messaging.destination.name", topic),
+			attribute.String("messaging.operation", "receive"),
+		),
+	}
+
+	if len(links) > 0 {
+		opts = append(opts, trace.WithLinks(links...))
+	}
+
+	ctx, span := otel.GetTracerProvider().Tracer(tracerName).Start(ctx, "mqtt-subscribe", opts...)
+
+	return ctx, span
+}
+
+// wrapPayload wraps the original payload with trace headers into a JSON envelope.
+// MQTT v3.1.1 has no message-level headers, so this embeds trace context in the payload.
+func wrapPayload(traceHeaders map[string]string, payload []byte) []byte {
+	env := traceEnvelope{
+		Marker:      "1",
+		Traceparent: traceHeaders["traceparent"],
+		Tracestate:  traceHeaders["tracestate"],
+		Data:        base64.StdEncoding.EncodeToString(payload),
+	}
+
+	data, err := json.Marshal(env)
+	if err != nil {
+		return payload
+	}
+
+	return data
+}
+
+// unwrapPayload extracts trace headers and the original payload from a JSON envelope.
+// If the data is not a wrapped payload, returns (nil, originalData) for backward compatibility.
+func unwrapPayload(data []byte) (headers map[string]string, payload []byte) {
+	var env traceEnvelope
+
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, data
+	}
+
+	if env.Marker != "1" {
+		return nil, data
+	}
+
+	payload, err := base64.StdEncoding.DecodeString(env.Data)
+	if err != nil {
+		return nil, data
+	}
+
+	headers = make(map[string]string)
+
+	if env.Traceparent != "" {
+		headers["traceparent"] = env.Traceparent
+	}
+
+	if env.Tracestate != "" {
+		headers["tracestate"] = env.Tracestate
+	}
+
+	return headers, payload
+}

--- a/pkg/gofr/datasource/pubsub/mqtt/tracing_test.go
+++ b/pkg/gofr/datasource/pubsub/mqtt/tracing_test.go
@@ -1,0 +1,236 @@
+package mqtt
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestHeaderCarrier_GetSetKeys(t *testing.T) {
+	carrier := make(headerCarrier)
+
+	// Test Set
+	carrier.Set("traceparent", "00-1234567890abcdef-fedcba0987654321-01")
+	carrier.Set("tracestate", "foo=bar")
+
+	// Test Get
+	assert.Equal(t, "00-1234567890abcdef-fedcba0987654321-01", carrier.Get("traceparent"))
+	assert.Equal(t, "foo=bar", carrier.Get("tracestate"))
+	assert.Empty(t, carrier.Get("nonexistent"))
+
+	// Test Keys
+	keys := carrier.Keys()
+	assert.Contains(t, keys, "traceparent")
+	assert.Contains(t, keys, "tracestate")
+
+	// Test Set updates existing key
+	carrier.Set("traceparent", "00-updated-value")
+	assert.Equal(t, "00-updated-value", carrier.Get("traceparent"))
+}
+
+func TestInjectTraceContext(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "test-span")
+	defer span.End()
+
+	attrs := injectTraceContext(ctx, nil)
+
+	require.NotNil(t, attrs)
+
+	traceparent, ok := attrs["traceparent"]
+	require.True(t, ok, "traceparent should be injected")
+	assert.Contains(t, traceparent, span.SpanContext().TraceID().String())
+}
+
+func TestExtractTraceLinks(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	ctx, producerSpan := tp.Tracer("test").Start(context.Background(), "producer-span")
+	attrs := injectTraceContext(ctx, nil)
+
+	producerSpan.End()
+
+	links := extractTraceLinks(attrs)
+
+	require.Len(t, links, 1, "should have one link")
+	assert.Equal(t, producerSpan.SpanContext().TraceID(), links[0].SpanContext.TraceID())
+	assert.Equal(t, producerSpan.SpanContext().SpanID(), links[0].SpanContext.SpanID())
+}
+
+func TestExtractTraceLinks_NoHeaders(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	assert.Nil(t, extractTraceLinks(nil), "should return nil for nil headers")
+}
+
+func TestStartPublishSpan(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	ctx, span, headers := startPublishSpan(context.Background(), "test-topic")
+	defer span.End()
+
+	require.NotNil(t, span)
+	assert.True(t, span.SpanContext().IsValid())
+	require.NotNil(t, ctx)
+
+	_, hasTraceparent := headers["traceparent"]
+	assert.True(t, hasTraceparent, "headers should contain traceparent")
+}
+
+func TestStartSubscribeSpan_WithLinks(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	_, producerSpan, headers := startPublishSpan(context.Background(), "test-topic")
+	producerSpan.End()
+
+	_, subscribeSpan := startSubscribeSpan(context.Background(), "test-topic", headers)
+	subscribeSpan.End()
+
+	spans := exporter.GetSpans()
+	require.GreaterOrEqual(t, len(spans), 2)
+
+	var subSpan *tracetest.SpanStub
+
+	for i := range spans {
+		if spans[i].Name == "mqtt-subscribe" {
+			subSpan = &spans[i]
+			break
+		}
+	}
+
+	require.NotNil(t, subSpan, "subscribe span should exist")
+	require.Len(t, subSpan.Links, 1, "subscribe span should have one link")
+	assert.Equal(t, producerSpan.SpanContext().TraceID(), subSpan.Links[0].SpanContext.TraceID())
+	assert.Equal(t, producerSpan.SpanContext().SpanID(), subSpan.Links[0].SpanContext.SpanID())
+}
+
+func TestStartSubscribeSpan_NoLinks(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+	}()
+
+	_, subscribeSpan := startSubscribeSpan(context.Background(), "test-topic", nil)
+	subscribeSpan.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+
+	assert.Empty(t, spans[0].Links, "orphan span should have no links")
+}
+
+func TestWrapPayload(t *testing.T) {
+	headers := map[string]string{
+		"traceparent": "00-abc123-def456-01",
+		"tracestate":  "foo=bar",
+	}
+
+	original := []byte("hello world")
+
+	wrapped := wrapPayload(headers, original)
+
+	var env traceEnvelope
+
+	err := json.Unmarshal(wrapped, &env)
+	require.NoError(t, err)
+	assert.Equal(t, "1", env.Marker)
+	assert.Equal(t, "00-abc123-def456-01", env.Traceparent)
+	assert.Equal(t, "foo=bar", env.Tracestate)
+
+	decoded, err := base64.StdEncoding.DecodeString(env.Data)
+	require.NoError(t, err)
+	assert.Equal(t, original, decoded)
+}
+
+func TestUnwrapPayload(t *testing.T) {
+	headers := map[string]string{
+		"traceparent": "00-abc123-def456-01",
+		"tracestate":  "foo=bar",
+	}
+
+	original := []byte("hello world")
+
+	wrapped := wrapPayload(headers, original)
+
+	extractedHeaders, payload := unwrapPayload(wrapped)
+
+	assert.Equal(t, original, payload)
+	assert.Equal(t, "00-abc123-def456-01", extractedHeaders["traceparent"])
+	assert.Equal(t, "foo=bar", extractedHeaders["tracestate"])
+}
+
+func TestUnwrapPayload_NonWrapped(t *testing.T) {
+	// Plain text
+	data := []byte("plain text message")
+	headers, payload := unwrapPayload(data)
+	assert.Nil(t, headers)
+	assert.Equal(t, data, payload)
+
+	// JSON without marker
+	jsonData := []byte(`{"key":"value"}`)
+	headers, payload = unwrapPayload(jsonData)
+	assert.Nil(t, headers)
+	assert.JSONEq(t, string(jsonData), string(payload))
+}
+
+func TestWrapUnwrap_RoundTrip(t *testing.T) {
+	headers := map[string]string{
+		"traceparent": "00-abc-def-01",
+	}
+
+	original := []byte("test payload with special chars: !@#$%^&*()")
+
+	wrapped := wrapPayload(headers, original)
+
+	_, payload := unwrapPayload(wrapped)
+
+	assert.Equal(t, original, payload)
+}


### PR DESCRIPTION
## Pull Request Template

**Description:**

- Fixes #3012
- Add OpenTelemetry span links to MQTT pub/sub, mirroring the Kafka (PR #2952) and Google PubSub trace propagation patterns.
- MQTT v3.1.1 does not support message-level headers, so trace context is propagated via payload wrapping: publisher injects W3C trace context into a JSON envelope, subscriber extracts it and creates span links to the producer span.
- New file `tracing.go` provides `headerCarrier` (implementing `propagation.TextMapCarrier`), payload wrap/unwrap, and span creation helpers.
- Backward compatible: non-wrapped payloads pass through unchanged.

**Breaking Changes (if applicable):**

- None. Published payloads are now wrapped in a JSON envelope with trace context, but subscribers transparently unwrap them. Legacy consumers receiving wrapped messages will see the JSON envelope as the payload.

**Additional Information:**

- Uses `go.opentelemetry.io/otel` and `go.opentelemetry.io/otel/trace` (already project dependencies).
- Pattern mirrors `pkg/gofr/datasource/pubsub/kafka/tracing.go` and `pkg/gofr/datasource/pubsub/google/tracing.go`.

**Checklist:**

- [x] I have formatted my code using `goimport` and `golangci-lint`.
- [x] All new code is covered by unit tests.
- [x] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**