### PR TITLE
docs: add package-level GoDoc for undocumented pkg/gofr subdirectories

### DIFF
--- a/pkg/gofr/cmd/doc.go
+++ b/pkg/gofr/cmd/doc.go
@@ -1,0 +1,8 @@
+// Package cmd provides abstractions for building command-line applications
+// within the GoFr framework.
+//
+// It mirrors the HTTP handler pattern by parsing CLI flags into a [Request]
+// that supports Param, PathParam, and struct Bind operations. The [Responder]
+// writes successful output to stdout and errors to stderr, giving CLI
+// applications the same handler-based structure used by GoFr HTTP services.
+package cmd

--- a/pkg/gofr/config/doc.go
+++ b/pkg/gofr/config/doc.go
@@ -1,0 +1,8 @@
+// Package config defines the configuration interface used throughout the
+// GoFr framework.
+//
+// It provides a minimal key-value abstraction with [Config.Get] and
+// [Config.GetOrDefault] methods, allowing application components to retrieve
+// configuration values without coupling to a specific source such as
+// environment variables or files.
+package config

--- a/pkg/gofr/migration/doc.go
+++ b/pkg/gofr/migration/doc.go
@@ -1,0 +1,11 @@
+// Package migration provides a framework for running versioned data migrations
+// across the datasource backends supported by GoFr.
+//
+// It coordinates migration execution with distributed locking, transaction
+// management where supported, and metadata tracking. Supported backends
+// include SQL, Redis, MongoDB, ClickHouse, Cassandra, ArangoDB, DGraph,
+// SurrealDB, ScyllaDB, Elasticsearch, OpenTSDB, and others.
+//
+// Migrations are registered as a map of version numbers to [Migrate]
+// implementations and executed via [Run].
+package migration

--- a/pkg/gofr/rbac/doc.go
+++ b/pkg/gofr/rbac/doc.go
@@ -1,0 +1,8 @@
+// Package rbac implements Role-Based Access Control for GoFr applications.
+//
+// It supports file-driven configuration (JSON or YAML) for defining roles
+// with permissions and inheritance, mapping endpoints to required permissions,
+// and provides HTTP middleware that resolves routes, extracts roles from JWT
+// claims or headers, and enforces permission checks with optional audit
+// logging and tracing.
+package rbac

--- a/pkg/gofr/static/doc.go
+++ b/pkg/gofr/static/doc.go
@@ -1,0 +1,6 @@
+// Package static provides embedded static assets for the GoFr framework.
+//
+// It uses Go's embed directive to bundle files at compile time, making them
+// available for serving or inclusion in the application binary without
+// external file dependencies.
+package static

--- a/pkg/gofr/testutil/doc.go
+++ b/pkg/gofr/testutil/doc.go
@@ -1,0 +1,6 @@
+// Package testutil provides test helper utilities for GoFr applications.
+//
+// It includes functions for allocating ephemeral TCP ports, stubbing
+// configuration values, capturing stdout and stderr output, and setting up
+// service configurations suitable for integration tests.
+package testutil

--- a/pkg/gofr/version/doc.go
+++ b/pkg/gofr/version/doc.go
@@ -1,0 +1,5 @@
+// Package version holds the framework version constant for GoFr.
+//
+// The [Framework] constant contains the current release version string
+// and is used for telemetry, logging, and build metadata.
+package version

--- a/pkg/gofr/websocket/doc.go
+++ b/pkg/gofr/websocket/doc.go
@@ -1,0 +1,7 @@
+// Package websocket provides WebSocket support for the GoFr framework.
+//
+// It offers a configurable [Upgrader], a thread-safe [Connection] wrapper
+// with JSON and text binding, and a [Manager] that tracks active WebSocket
+// connections by ID for lifecycle management including upgrade, list,
+// retrieve, and close operations.
+package websocket


### PR DESCRIPTION
## Pull Request Template

**Description:**

- Adds `doc.go` files with package-level GoDoc comments for the 8 subdirectories under `pkg/gofr/` that were missing documentation: `cmd`, `config`, `migration`, `rbac`, `static`, `testutil`, `version`, and `websocket`.
- Closes #995.
- These directories previously appeared with no synopsis on [pkg.go.dev](https://pkg.go.dev/gofr.dev/pkg/gofr) and in `go doc` output. With these additions, all 16 subdirectories now have meaningful descriptions.

**Breaking Changes (if applicable):**

- None. This is a documentation-only change with no code modifications.

**Additional Information:**

- Comments follow existing project conventions (`// Package <name> ...` style) and reference exported types using Go doc link syntax (e.g., `[Request]`, `[Migrate]`).
- The 8 directories that already had package-level comments in source files (container, datasource, file, grpc, http, logging, metrics, service) are untouched.

**Checklist:**

- [x] I have formatted my code using `goimport` and `golangci-lint`.
- [x] All new code is covered by unit tests.
- [x] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**