### PR TITLE
refactor: consolidate datasource observability with instrumentOp pattern

### DIFF
--- a/pkg/gofr/container/datasources.go
+++ b/pkg/gofr/container/datasources.go
@@ -187,8 +187,6 @@ type CassandraBatchWithContext interface {
 	ExecuteBatchCASWithCtx(ctx context.Context, name string, dest ...any) (bool, error)
 }
 
-// Deprecated: Use CassandraWithContext instead. Setup methods (UseLogger/UseMetrics/UseTracer/Connect)
-// are called automatically by App.AddCassandra.
 type CassandraProvider interface {
 	CassandraWithContext
 
@@ -203,7 +201,6 @@ type Clickhouse interface {
 	HealthChecker
 }
 
-// Deprecated: Use Clickhouse instead. Setup methods are called automatically by App.AddClickhouse.
 type ClickhouseProvider interface {
 	Clickhouse
 
@@ -225,7 +222,6 @@ type OracleTx interface {
 	Rollback() error
 }
 
-// Deprecated: Use OracleDB instead. Setup methods are called automatically by App.AddOracle.
 type OracleProvider interface {
 	OracleDB
 
@@ -294,7 +290,8 @@ type Transaction interface {
 	EndSession(context.Context)
 }
 
-// Deprecated: Use Mongo instead. Setup methods are called automatically by App.AddMongo.
+// MongoProvider is an interface that extends Mongo with additional methods for logging, metrics, and connection management.
+// Which is used for initializing datasource.
 type MongoProvider interface {
 	Mongo
 
@@ -338,19 +335,25 @@ type SurrealDB interface {
 	HealthChecker
 }
 
-// Deprecated: Use SurrealDB instead. Setup methods are called automatically by App.AddSurrealDB.
+// SurrealBDProvider is an interface that extends SurrealDB with additional methods for logging, metrics, or connection management.
+// It is typically used for initializing and managing SurrealDB-based data sources.
 type SurrealBDProvider interface {
 	SurrealDB
 
 	provider
 }
 
-// Deprecated: Setup methods are called automatically by App.Add* methods via duck typing.
-// Datasources only need to implement their behavior interface (e.g., Mongo, ArangoDB).
 type provider interface {
+	// UseLogger sets the logger for the Cassandra client.
 	UseLogger(logger any)
+
+	// UseMetrics sets the metrics for the Cassandra client.
 	UseMetrics(metrics any)
+
+	// UseTracer sets the tracer for the Cassandra client.
 	UseTracer(tracer any)
+
+	// Connect establishes a connection to Cassandra and registers metrics using the provided configuration when the client was Created.
 	Connect()
 }
 
@@ -368,14 +371,12 @@ type KVStore interface {
 	HealthChecker
 }
 
-// Deprecated: Use KVStore instead. Setup methods are called automatically by App.AddKVStore.
 type KVStoreProvider interface {
 	KVStore
 
 	provider
 }
 
-// Deprecated: Use pubsub.Client instead. Setup methods are called automatically by App.AddPubSub.
 type PubSubProvider interface {
 	pubsub.Client
 
@@ -397,7 +398,6 @@ type Solr interface {
 	HealthChecker
 }
 
-// Deprecated: Use Solr instead. Setup methods are called automatically by App.AddSolr.
 type SolrProvider interface {
 	Solr
 
@@ -484,13 +484,12 @@ type Dgraph interface {
 	HealthChecker
 }
 
-// Deprecated: Use Dgraph instead. Setup methods are called automatically by App.AddDgraph.
+// DgraphProvider extends Dgraph with connection management capabilities.
 type DgraphProvider interface {
 	Dgraph
 	provider
 }
 
-// Deprecated: Use OpenTSDB instead. Setup methods are called automatically by App.AddOpenTSDB.
 type OpenTSDBProvider interface {
 	OpenTSDB
 	provider
@@ -630,7 +629,6 @@ type ScyllaDB interface {
 	HealthChecker
 }
 
-// Deprecated: Use ScyllaDB instead. Setup methods are called automatically by App.AddScyllaDB.
 type ScyllaDBProvider interface {
 	ScyllaDB
 	provider
@@ -699,7 +697,7 @@ type ArangoDB interface {
 	HealthChecker
 }
 
-// Deprecated: Use ArangoDB instead. Setup methods are called automatically by App.AddArangoDB.
+// ArangoDBProvider is an interface that extends ArangoDB with additional methods for logging, metrics, and connection management.
 type ArangoDBProvider interface {
 	ArangoDB
 
@@ -739,7 +737,7 @@ type Elasticsearch interface {
 	HealthChecker
 }
 
-// Deprecated: Use Elasticsearch instead. Setup methods are called automatically by App.AddElasticsearch.
+// ElasticsearchProvider an interface that extends Elasticsearch with additional methods for logging, metrics, and connection management.
 type ElasticsearchProvider interface {
 	Elasticsearch
 
@@ -779,7 +777,9 @@ type Couchbase interface {
 	HealthChecker
 }
 
-// Deprecated: Use Couchbase instead. Setup methods are called automatically by App.AddCouchbase.
+// CouchbaseProvider is an interface that extends Couchbase with additional methods
+// for logging, metrics, tracing, and connection management, aligning with other
+// data source providers in your package.
 type CouchbaseProvider interface {
 	Couchbase
 
@@ -831,7 +831,7 @@ type InfluxDB interface {
 	HealthChecker
 }
 
-// Deprecated: Use InfluxDB instead. Setup methods are called automatically by App.AddInfluxDB.
+// InfluxDBProvider an interface that extends InfluxDB with additional methods for logging, metrics, and connection management.
 type InfluxDBProvider interface {
 	InfluxDB
 

--- a/pkg/gofr/container/datasources.go
+++ b/pkg/gofr/container/datasources.go
@@ -187,6 +187,8 @@ type CassandraBatchWithContext interface {
 	ExecuteBatchCASWithCtx(ctx context.Context, name string, dest ...any) (bool, error)
 }
 
+// Deprecated: Use CassandraWithContext instead. Setup methods (UseLogger/UseMetrics/UseTracer/Connect)
+// are called automatically by App.AddCassandra.
 type CassandraProvider interface {
 	CassandraWithContext
 
@@ -201,6 +203,7 @@ type Clickhouse interface {
 	HealthChecker
 }
 
+// Deprecated: Use Clickhouse instead. Setup methods are called automatically by App.AddClickhouse.
 type ClickhouseProvider interface {
 	Clickhouse
 
@@ -222,6 +225,7 @@ type OracleTx interface {
 	Rollback() error
 }
 
+// Deprecated: Use OracleDB instead. Setup methods are called automatically by App.AddOracle.
 type OracleProvider interface {
 	OracleDB
 
@@ -290,8 +294,7 @@ type Transaction interface {
 	EndSession(context.Context)
 }
 
-// MongoProvider is an interface that extends Mongo with additional methods for logging, metrics, and connection management.
-// Which is used for initializing datasource.
+// Deprecated: Use Mongo instead. Setup methods are called automatically by App.AddMongo.
 type MongoProvider interface {
 	Mongo
 
@@ -335,25 +338,19 @@ type SurrealDB interface {
 	HealthChecker
 }
 
-// SurrealBDProvider is an interface that extends SurrealDB with additional methods for logging, metrics, or connection management.
-// It is typically used for initializing and managing SurrealDB-based data sources.
+// Deprecated: Use SurrealDB instead. Setup methods are called automatically by App.AddSurrealDB.
 type SurrealBDProvider interface {
 	SurrealDB
 
 	provider
 }
 
+// Deprecated: Setup methods are called automatically by App.Add* methods via duck typing.
+// Datasources only need to implement their behavior interface (e.g., Mongo, ArangoDB).
 type provider interface {
-	// UseLogger sets the logger for the Cassandra client.
 	UseLogger(logger any)
-
-	// UseMetrics sets the metrics for the Cassandra client.
 	UseMetrics(metrics any)
-
-	// UseTracer sets the tracer for the Cassandra client.
 	UseTracer(tracer any)
-
-	// Connect establishes a connection to Cassandra and registers metrics using the provided configuration when the client was Created.
 	Connect()
 }
 
@@ -371,12 +368,14 @@ type KVStore interface {
 	HealthChecker
 }
 
+// Deprecated: Use KVStore instead. Setup methods are called automatically by App.AddKVStore.
 type KVStoreProvider interface {
 	KVStore
 
 	provider
 }
 
+// Deprecated: Use pubsub.Client instead. Setup methods are called automatically by App.AddPubSub.
 type PubSubProvider interface {
 	pubsub.Client
 
@@ -398,6 +397,7 @@ type Solr interface {
 	HealthChecker
 }
 
+// Deprecated: Use Solr instead. Setup methods are called automatically by App.AddSolr.
 type SolrProvider interface {
 	Solr
 
@@ -484,12 +484,13 @@ type Dgraph interface {
 	HealthChecker
 }
 
-// DgraphProvider extends Dgraph with connection management capabilities.
+// Deprecated: Use Dgraph instead. Setup methods are called automatically by App.AddDgraph.
 type DgraphProvider interface {
 	Dgraph
 	provider
 }
 
+// Deprecated: Use OpenTSDB instead. Setup methods are called automatically by App.AddOpenTSDB.
 type OpenTSDBProvider interface {
 	OpenTSDB
 	provider
@@ -629,6 +630,7 @@ type ScyllaDB interface {
 	HealthChecker
 }
 
+// Deprecated: Use ScyllaDB instead. Setup methods are called automatically by App.AddScyllaDB.
 type ScyllaDBProvider interface {
 	ScyllaDB
 	provider
@@ -697,7 +699,7 @@ type ArangoDB interface {
 	HealthChecker
 }
 
-// ArangoDBProvider is an interface that extends ArangoDB with additional methods for logging, metrics, and connection management.
+// Deprecated: Use ArangoDB instead. Setup methods are called automatically by App.AddArangoDB.
 type ArangoDBProvider interface {
 	ArangoDB
 
@@ -737,7 +739,7 @@ type Elasticsearch interface {
 	HealthChecker
 }
 
-// ElasticsearchProvider an interface that extends Elasticsearch with additional methods for logging, metrics, and connection management.
+// Deprecated: Use Elasticsearch instead. Setup methods are called automatically by App.AddElasticsearch.
 type ElasticsearchProvider interface {
 	Elasticsearch
 
@@ -777,9 +779,7 @@ type Couchbase interface {
 	HealthChecker
 }
 
-// CouchbaseProvider is an interface that extends Couchbase with additional methods
-// for logging, metrics, tracing, and connection management, aligning with other
-// data source providers in your package.
+// Deprecated: Use Couchbase instead. Setup methods are called automatically by App.AddCouchbase.
 type CouchbaseProvider interface {
 	Couchbase
 
@@ -831,7 +831,7 @@ type InfluxDB interface {
 	HealthChecker
 }
 
-// InfluxDBProvider an interface that extends InfluxDB with additional methods for logging, metrics, and connection management.
+// Deprecated: Use InfluxDB instead. Setup methods are called automatically by App.AddInfluxDB.
 type InfluxDBProvider interface {
 	InfluxDB
 

--- a/pkg/gofr/datasource/arangodb/arango.go
+++ b/pkg/gofr/datasource/arangodb/arango.go
@@ -233,13 +233,10 @@ func (c *Client) validateConfig() error {
 //	    fmt.Printf("User: %+v\n", doc)
 //	}
 func (c *Client) Query(ctx context.Context, dbName, query string, bindVars map[string]any, result any, options ...map[string]any) error {
-	tracerCtx, span := c.addTrace(ctx, "query", map[string]string{"DB": dbName})
-	startTime := time.Now()
+	ctx, done := c.instrumentOp(ctx, &QueryLog{Operation: "query", Database: dbName, Query: query})
+	defer done()
 
-	defer c.sendOperationStats(&QueryLog{Operation: "query",
-		Database: dbName, Query: query}, startTime, "query", span)
-
-	db, err := c.client.GetDatabase(tracerCtx, dbName, nil)
+	db, err := c.client.GetDatabase(ctx, dbName, nil)
 	if err != nil {
 		return err
 	}
@@ -253,7 +250,7 @@ func (c *Client) Query(ctx context.Context, dbName, query string, bindVars map[s
 
 	queryOptions.BindVars = bindVars
 
-	cursor, err := db.Query(tracerCtx, query, &queryOptions)
+	cursor, err := db.Query(ctx, query, &queryOptions)
 	if err != nil {
 		return err
 	}
@@ -268,7 +265,7 @@ func (c *Client) Query(ctx context.Context, dbName, query string, bindVars map[s
 	for {
 		var doc map[string]any
 
-		_, err = cursor.ReadDocument(tracerCtx, &doc)
+		_, err = cursor.ReadDocument(ctx, &doc)
 		if arangoShared.IsNoMoreDocuments(err) {
 			break
 		}
@@ -326,21 +323,26 @@ func (c *Client) addTrace(ctx context.Context, operation string, attributes map[
 	return ctx, nil
 }
 
-func (c *Client) sendOperationStats(ql *QueryLog, startTime time.Time, method string, span trace.Span) {
-	duration := time.Since(startTime).Microseconds()
-	ql.Duration = duration
+// instrumentOp starts a trace span, captures the start time, and returns the traced context
+// along with a cleanup function. The cleanup function logs the operation, records metrics,
+// and ends the span. It should be deferred immediately after calling instrumentOp.
+func (c *Client) instrumentOp(ctx context.Context, ql *QueryLog) (context.Context, func()) {
+	tracerCtx, span := c.addTrace(ctx, ql.Operation, ql.traceAttrs())
+	startTime := time.Now()
 
-	c.logger.Debug(ql)
+	return tracerCtx, func() {
+		duration := time.Since(startTime).Microseconds()
+		ql.Duration = duration
 
-	c.metrics.RecordHistogram(context.Background(), "app_arango_stats", float64(duration),
-		"endpoint", c.endpoint,
-		"type", ql.Query,
-	)
+		c.logger.Debug(ql)
 
-	if span != nil {
-		defer span.End()
+		c.metrics.RecordHistogram(context.Background(), "app_arango_stats", float64(duration),
+			"endpoint", c.endpoint, "type", ql.Operation)
 
-		span.SetAttributes(attribute.Int64(fmt.Sprintf("arangodb.%v.duration", method), duration))
+		if span != nil {
+			span.SetAttributes(attribute.Int64(fmt.Sprintf("arangodb.%v.duration", ql.Operation), duration))
+			span.End()
+		}
 	}
 }
 

--- a/pkg/gofr/datasource/arangodb/arango_db.go
+++ b/pkg/gofr/datasource/arangodb/arango_db.go
@@ -2,7 +2,6 @@ package arangodb
 
 import (
 	"context"
-	"time"
 
 	"github.com/arangodb/go-driver/v2/arangodb"
 )
@@ -15,13 +14,11 @@ type DB struct {
 // It first checks if the database already exists before attempting to create it.
 // Returns ErrDatabaseExists if the database already exists.
 func (d *DB) CreateDB(ctx context.Context, database string) error {
-	tracerCtx, span := d.client.addTrace(ctx, "createDB", map[string]string{"DB": database})
-	startTime := time.Now()
-
-	defer d.client.sendOperationStats(&QueryLog{Operation: "createDB", Database: database}, startTime, "createDB", span)
+	ctx, done := d.client.instrumentOp(ctx, &QueryLog{Operation: "createDB", Database: database})
+	defer done()
 
 	// Check if the database already exists
-	exists, err := d.client.client.DatabaseExists(tracerCtx, database)
+	exists, err := d.client.client.DatabaseExists(ctx, database)
 	if err != nil {
 		return err
 	}
@@ -31,24 +28,22 @@ func (d *DB) CreateDB(ctx context.Context, database string) error {
 		return ErrDatabaseExists
 	}
 
-	_, err = d.client.client.CreateDatabase(tracerCtx, database, nil)
+	_, err = d.client.client.CreateDatabase(ctx, database, nil)
 
 	return err
 }
 
 // DropDB deletes a database from ArangoDB.
 func (d *DB) DropDB(ctx context.Context, database string) error {
-	tracerCtx, span := d.client.addTrace(ctx, "dropDB", map[string]string{"DB": database})
-	startTime := time.Now()
+	ctx, done := d.client.instrumentOp(ctx, &QueryLog{Operation: "dropDB", Database: database})
+	defer done()
 
-	defer d.client.sendOperationStats(&QueryLog{Operation: "dropDB", Database: database}, startTime, "dropDB", span)
-
-	db, err := d.client.client.GetDatabase(tracerCtx, database, &arangodb.GetDatabaseOptions{})
+	db, err := d.client.client.GetDatabase(ctx, database, &arangodb.GetDatabaseOptions{})
 	if err != nil {
 		return err
 	}
 
-	err = db.Remove(tracerCtx)
+	err = db.Remove(ctx)
 	if err != nil {
 		return err
 	}
@@ -60,19 +55,17 @@ func (d *DB) DropDB(ctx context.Context, database string) error {
 // It first checks if the collection already exists before attempting to create it.
 // Returns ErrCollectionExists if the collection already exists.
 func (d *DB) CreateCollection(ctx context.Context, database, collection string, isEdge bool) error {
-	tracerCtx, span := d.client.addTrace(ctx, "createCollection", map[string]string{"collection": collection})
-	startTime := time.Now()
+	ctx, done := d.client.instrumentOp(ctx, &QueryLog{Operation: "createCollection", Database: database,
+		Collection: collection, Filter: isEdge})
+	defer done()
 
-	defer d.client.sendOperationStats(&QueryLog{Operation: "createCollection", Database: database,
-		Collection: collection, Filter: isEdge}, startTime, "createCollection", span)
-
-	db, err := d.client.client.GetDatabase(tracerCtx, database, nil)
+	db, err := d.client.client.GetDatabase(ctx, database, nil)
 	if err != nil {
 		return err
 	}
 
 	// Check if the collection already exists
-	exists, err := db.CollectionExists(tracerCtx, collection)
+	exists, err := db.CollectionExists(ctx, collection)
 	if err != nil {
 		return err
 	}
@@ -89,16 +82,23 @@ func (d *DB) CreateCollection(ctx context.Context, database, collection string, 
 
 	options := arangodb.CreateCollectionPropertiesV2{Type: &collectionType}
 
-	_, err = db.CreateCollectionV2(tracerCtx, collection, &options)
+	_, err = db.CreateCollectionV2(ctx, collection, &options)
 
 	return err
 }
 
 // DropCollection deletes an existing collection from a database.
 func (d *DB) DropCollection(ctx context.Context, database, collectionName string) error {
-	return d.handleCollectionOperation(ctx, "dropCollection", database, collectionName, func(collection arangodb.Collection) error {
-		return collection.Remove(ctx)
-	})
+	ctx, done := d.client.instrumentOp(ctx, &QueryLog{Operation: "dropCollection", Database: database,
+		Collection: collectionName})
+	defer done()
+
+	collection, err := d.getCollection(ctx, database, collectionName)
+	if err != nil {
+		return err
+	}
+
+	return collection.Remove(ctx)
 }
 
 func (d *DB) getCollection(ctx context.Context, dbName, collectionName string) (arangodb.Collection, error) {
@@ -113,21 +113,4 @@ func (d *DB) getCollection(ctx context.Context, dbName, collectionName string) (
 	}
 
 	return collection, nil
-}
-
-// handleCollectionOperation handles common logic for collection operations.
-func (d *DB) handleCollectionOperation(ctx context.Context, operation, database, collectionName string,
-	action func(arangodb.Collection) error) error {
-	tracerCtx, span := d.client.addTrace(ctx, operation, map[string]string{"collection": collectionName})
-	startTime := time.Now()
-
-	defer d.client.sendOperationStats(&QueryLog{Operation: operation, Database: database,
-		Collection: collectionName}, startTime, operation, span)
-
-	collection, err := d.getCollection(tracerCtx, database, collectionName)
-	if err != nil {
-		return err
-	}
-
-	return action(collection)
 }

--- a/pkg/gofr/datasource/arangodb/arango_document.go
+++ b/pkg/gofr/datasource/arangodb/arango_document.go
@@ -3,9 +3,6 @@ package arangodb
 import (
 	"context"
 	"errors"
-	"time"
-
-	"github.com/arangodb/go-driver/v2/arangodb"
 )
 
 var (
@@ -49,8 +46,11 @@ type Document struct {
 //
 // id, err := client.CreateDocument(ctx, "myDB", "edges", edgeDoc).
 func (d *Document) CreateDocument(ctx context.Context, dbName, collectionName string, document any) (string, error) {
-	collection, tracerCtx, err := executeCollectionOperation(ctx, *d, dbName, collectionName,
-		"createDocument", "")
+	ctx, done := d.client.instrumentOp(ctx, &QueryLog{Operation: "createDocument",
+		Database: dbName, Collection: collectionName})
+	defer done()
+
+	collection, err := d.client.getCollection(ctx, dbName, collectionName)
 	if err != nil {
 		return "", err
 	}
@@ -72,7 +72,7 @@ func (d *Document) CreateDocument(ctx context.Context, dbName, collectionName st
 	}
 
 	// Create the document in ArangoDB
-	meta, err := collection.CreateDocument(tracerCtx, document)
+	meta, err := collection.CreateDocument(ctx, document)
 	if err != nil {
 		return "", err
 	}
@@ -82,39 +82,48 @@ func (d *Document) CreateDocument(ctx context.Context, dbName, collectionName st
 
 // GetDocument retrieves a document by its ID from the specified collection.
 func (d *Document) GetDocument(ctx context.Context, dbName, collectionName, documentID string, result any) error {
-	collection, tracerCtx, err := executeCollectionOperation(ctx, *d, dbName, collectionName,
-		"getDocument", documentID)
+	ctx, done := d.client.instrumentOp(ctx, &QueryLog{Operation: "getDocument",
+		Database: dbName, Collection: collectionName, ID: documentID})
+	defer done()
+
+	collection, err := d.client.getCollection(ctx, dbName, collectionName)
 	if err != nil {
 		return err
 	}
 
-	_, err = collection.ReadDocument(tracerCtx, documentID, result)
+	_, err = collection.ReadDocument(ctx, documentID, result)
 
 	return err
 }
 
 // UpdateDocument updates an existing document in the specified collection.
 func (d *Document) UpdateDocument(ctx context.Context, dbName, collectionName, documentID string, document any) error {
-	collection, tracerCtx, err := executeCollectionOperation(ctx, *d, dbName, collectionName,
-		"updateDocument", documentID)
+	ctx, done := d.client.instrumentOp(ctx, &QueryLog{Operation: "updateDocument",
+		Database: dbName, Collection: collectionName, ID: documentID})
+	defer done()
+
+	collection, err := d.client.getCollection(ctx, dbName, collectionName)
 	if err != nil {
 		return err
 	}
 
-	_, err = collection.UpdateDocument(tracerCtx, documentID, document)
+	_, err = collection.UpdateDocument(ctx, documentID, document)
 
 	return err
 }
 
 // DeleteDocument deletes a document by its ID from the specified collection.
 func (d *Document) DeleteDocument(ctx context.Context, dbName, collectionName, documentID string) error {
-	collection, tracerCtx, err := executeCollectionOperation(ctx, *d, dbName, collectionName,
-		"deleteDocument", documentID)
+	ctx, done := d.client.instrumentOp(ctx, &QueryLog{Operation: "deleteDocument",
+		Database: dbName, Collection: collectionName, ID: documentID})
+	defer done()
+
+	collection, err := d.client.getCollection(ctx, dbName, collectionName)
 	if err != nil {
 		return err
 	}
 
-	_, err = collection.DeleteDocument(tracerCtx, documentID)
+	_, err = collection.DeleteDocument(ctx, documentID)
 
 	return err
 }
@@ -133,29 +142,6 @@ func (d *Document) isEdgeCollection(ctx context.Context, dbName, collectionName 
 
 	// ArangoDB type: 3 = Edge Collection, 2 = Document Collection
 	return properties.Type == arangoEdgeCollectionType, nil
-}
-
-func executeCollectionOperation(ctx context.Context, d Document, dbName, collectionName,
-	operation string, documentID string) (arangodb.Collection, context.Context, error) {
-	tracerCtx, span := d.client.addTrace(ctx, operation, map[string]string{"collection": collectionName})
-	startTime := time.Now()
-
-	ql := &QueryLog{Operation: operation,
-		Database:   dbName,
-		Collection: collectionName}
-
-	if documentID != "" {
-		ql.ID = documentID
-	}
-
-	defer d.client.sendOperationStats(ql, startTime, operation, span)
-
-	collection, err := d.client.getCollection(tracerCtx, dbName, collectionName)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return collection, tracerCtx, nil
 }
 
 // validateEdgeDocument ensures the document contains valid `_from` and `_to` fields when creating an edge.

--- a/pkg/gofr/datasource/arangodb/arango_document_test.go
+++ b/pkg/gofr/datasource/arangodb/arango_document_test.go
@@ -178,40 +178,6 @@ func Test_Client_DeleteDocument_Error(t *testing.T) {
 	require.ErrorIs(t, err, errDocumentNotFound, "Expected error while updating the document")
 }
 
-func TestExecuteCollectionOperation(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockLogger := NewMockLogger(ctrl)
-	mockMetrics := NewMockMetrics(ctrl)
-	mockArango := NewMockClient(ctrl)
-	mockDatabase := NewMockDatabase(ctrl)
-	mockCollection := NewMockCollection(ctrl)
-
-	client := New(Config{Host: "localhost", Port: 8527, User: "root", Password: "root"})
-	client.UseLogger(mockLogger)
-	client.UseMetrics(mockMetrics)
-
-	client.client = mockArango
-	d := Document{client: client}
-
-	ctx := context.Background()
-	dbName := "testDB"
-	collectionName := "testCollection"
-	operation := "createDocument"
-	documentID := "doc123"
-
-	mockArango.EXPECT().GetDatabase(gomock.Any(), "testDB", nil).
-		Return(mockDatabase, nil).AnyTimes()
-	mockDatabase.EXPECT().GetCollection(gomock.Any(), "testCollection", nil).
-		Return(mockCollection, nil).AnyTimes()
-	mockLogger.EXPECT().Debug(gomock.Any())
-	mockMetrics.EXPECT().RecordHistogram(ctx, "app_arango_stats", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-
-	_, _, err := executeCollectionOperation(ctx, d, dbName, collectionName, operation, documentID)
-	require.NoError(t, err)
-}
-
 func TestValidateEdgeDocument(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/gofr/datasource/arangodb/arango_graph.go
+++ b/pkg/gofr/datasource/arangodb/arango_graph.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/arangodb/go-driver/v2/arangodb"
 )
@@ -33,19 +32,17 @@ type Graph struct {
 // Returns ErrGraphExists if the graph already exists.
 // Returns an error if the edgeDefinitions parameter is not of type *EdgeDefinition or is nil.
 func (g *Graph) CreateGraph(ctx context.Context, database, graph string, edgeDefinitions any) error {
-	tracerCtx, span := g.client.addTrace(ctx, "createGraph", map[string]string{"graph": graph})
-	startTime := time.Now()
+	ctx, done := g.client.instrumentOp(ctx, &QueryLog{Operation: "createGraph",
+		Database: database, Graph: graph})
+	defer done()
 
-	defer g.client.sendOperationStats(&QueryLog{Operation: "createGraph",
-		Database: database, Collection: graph}, startTime, "createGraph", span)
-
-	db, err := g.client.client.GetDatabase(tracerCtx, database, nil)
+	db, err := g.client.client.GetDatabase(ctx, database, nil)
 	if err != nil {
 		return err
 	}
 
 	// Check if the graph already exists
-	exists, err := db.GraphExists(tracerCtx, graph)
+	exists, err := db.GraphExists(ctx, graph)
 	if err != nil {
 		return err
 	}
@@ -77,7 +74,7 @@ func (g *Graph) CreateGraph(ctx context.Context, database, graph string, edgeDef
 		EdgeDefinitions: arangoEdgeDefs,
 	}
 
-	_, err = db.CreateGraph(tracerCtx, graph, options, nil)
+	_, err = db.CreateGraph(ctx, graph, options, nil)
 
 	return err
 }
@@ -90,23 +87,21 @@ func (g *Graph) CreateGraph(ctx context.Context, database, graph string, edgeDef
 //
 // Returns an error if the graph does not exist or if there is an issue with the database connection.
 func (g *Graph) DropGraph(ctx context.Context, database, graphName string) error {
-	tracerCtx, span := g.client.addTrace(ctx, "dropGraph", map[string]string{"graph": graphName})
-	startTime := time.Now()
+	ctx, done := g.client.instrumentOp(ctx, &QueryLog{Operation: "dropGraph",
+		Database: database, Graph: graphName})
+	defer done()
 
-	defer g.client.sendOperationStats(&QueryLog{Operation: "dropGraph",
-		Database: database}, startTime, "dropGraph", span)
-
-	db, err := g.client.client.GetDatabase(tracerCtx, database, nil)
+	db, err := g.client.client.GetDatabase(ctx, database, nil)
 	if err != nil {
 		return err
 	}
 
-	graph, err := db.Graph(tracerCtx, graphName, nil)
+	graph, err := db.Graph(ctx, graphName, nil)
 	if err != nil {
 		return err
 	}
 
-	err = graph.Remove(tracerCtx, &arangodb.RemoveGraphOptions{DropCollections: true})
+	err = graph.Remove(ctx, &arangodb.RemoveGraphOptions{DropCollections: true})
 	if err != nil {
 		return err
 	}
@@ -137,23 +132,20 @@ func (c *Client) GetEdges(ctx context.Context, dbName, graphName, edgeCollection
 		return fmt.Errorf("%w: must be *[]arangodb.EdgeDetails", errInvalidResponseType)
 	}
 
-	tracerCtx, span := c.addTrace(ctx, "getEdges", map[string]string{
-		"DB": dbName, "Graph": graphName, "Collection": edgeCollection, "Vertex": vertexID,
-	})
-	startTime := time.Now()
-
-	defer c.sendOperationStats(&QueryLog{
+	ctx, done := c.instrumentOp(ctx, &QueryLog{
 		Operation:  "getEdges",
 		Database:   dbName,
+		Graph:      graphName,
 		Collection: edgeCollection,
-	}, startTime, "getEdges", span)
+	})
+	defer done()
 
-	db, err := c.client.GetDatabase(tracerCtx, dbName, nil)
+	db, err := c.client.GetDatabase(ctx, dbName, nil)
 	if err != nil {
 		return err
 	}
 
-	edges, err := db.GetEdges(tracerCtx, edgeCollection, vertexID, nil)
+	edges, err := db.GetEdges(ctx, edgeCollection, vertexID, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/gofr/datasource/arangodb/arango_helper.go
+++ b/pkg/gofr/datasource/arangodb/arango_helper.go
@@ -3,7 +3,6 @@ package arangodb
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/arangodb/go-driver/v2/arangodb"
 )
@@ -18,18 +17,15 @@ func (c *Client) database(ctx context.Context, name string) (arangodb.Database, 
 
 // createUser creates a new user in ArangoDB.
 func (c *Client) createUser(ctx context.Context, username string, options any) error {
-	tracerCtx, span := c.addTrace(ctx, "createUser", map[string]string{"user": username})
-	startTime := time.Now()
-
-	defer c.sendOperationStats(&QueryLog{Operation: "createUser", ID: username},
-		startTime, "createUser", span)
+	ctx, done := c.instrumentOp(ctx, &QueryLog{Operation: "createUser", ID: username})
+	defer done()
 
 	userOptions, ok := options.(UserOptions)
 	if !ok {
 		return fmt.Errorf("%w", errInvalidUserOptionsType)
 	}
 
-	_, err := c.client.CreateUser(tracerCtx, username, userOptions.toArangoUserOptions())
+	_, err := c.client.CreateUser(ctx, username, userOptions.toArangoUserOptions())
 	if err != nil {
 		return err
 	}
@@ -39,13 +35,10 @@ func (c *Client) createUser(ctx context.Context, username string, options any) e
 
 // dropUser deletes a user from ArangoDB.
 func (c *Client) dropUser(ctx context.Context, username string) error {
-	tracerCtx, span := c.addTrace(ctx, "dropUser", map[string]string{"user": username})
-	startTime := time.Now()
+	ctx, done := c.instrumentOp(ctx, &QueryLog{Operation: "dropUser", ID: username})
+	defer done()
 
-	defer c.sendOperationStats(&QueryLog{Operation: "dropUser",
-		ID: username}, startTime, "dropUser", span)
-
-	err := c.client.RemoveUser(tracerCtx, username)
+	err := c.client.RemoveUser(ctx, username)
 	if err != nil {
 		return err
 	}
@@ -55,37 +48,31 @@ func (c *Client) dropUser(ctx context.Context, username string) error {
 
 // grantDB grants permissions for a database to a user.
 func (c *Client) grantDB(ctx context.Context, database, username, permission string) error {
-	tracerCtx, span := c.addTrace(ctx, "grantDB", map[string]string{"DB": database})
-	startTime := time.Now()
+	ctx, done := c.instrumentOp(ctx, &QueryLog{Operation: "grantDB", Database: database, ID: username})
+	defer done()
 
-	defer c.sendOperationStats(&QueryLog{Operation: "grantDB",
-		Database: database, ID: username}, startTime, "grantDB", span)
-
-	user, err := c.client.User(tracerCtx, username)
+	user, err := c.client.User(ctx, username)
 	if err != nil {
 		return err
 	}
 
-	err = user.SetDatabaseAccess(tracerCtx, database, arangodb.Grant(permission))
+	err = user.SetDatabaseAccess(ctx, database, arangodb.Grant(permission))
 
 	return err
 }
 
 // grantCollection grants permissions for a collection to a user.
 func (c *Client) grantCollection(ctx context.Context, database, collection, username, permission string) error {
-	tracerCtx, span := c.addTrace(ctx, "GrantCollection", map[string]string{"collection": collection})
-	startTime := time.Now()
+	ctx, done := c.instrumentOp(ctx, &QueryLog{Operation: "GrantCollection",
+		Database: database, Collection: collection, ID: username})
+	defer done()
 
-	defer c.sendOperationStats(&QueryLog{Operation: "GrantCollection",
-		Database: database, Collection: collection, ID: username}, startTime,
-		"GrantCollection", span)
-
-	user, err := c.client.User(tracerCtx, username)
+	user, err := c.client.User(ctx, username)
 	if err != nil {
 		return err
 	}
 
-	err = user.SetCollectionAccess(tracerCtx, database, collection, arangodb.Grant(permission))
+	err = user.SetCollectionAccess(ctx, database, collection, arangodb.Grant(permission))
 
 	return err
 }

--- a/pkg/gofr/datasource/arangodb/logger.go
+++ b/pkg/gofr/datasource/arangodb/logger.go
@@ -19,9 +19,29 @@ type QueryLog struct {
 	Duration   int64  `json:"duration"`
 	Database   string `json:"database,omitempty"`
 	Collection string `json:"collection,omitempty"`
+	Graph      string `json:"graph,omitempty"`
 	Filter     any    `json:"filter,omitempty"`
 	ID         any    `json:"id,omitempty"`
 	Operation  string `json:"operation,omitempty"`
+}
+
+// traceAttrs returns a map of non-empty trace attributes from the QueryLog.
+func (ql *QueryLog) traceAttrs() map[string]string {
+	attrs := map[string]string{}
+
+	if ql.Database != "" {
+		attrs["DB"] = ql.Database
+	}
+
+	if ql.Collection != "" {
+		attrs["collection"] = ql.Collection
+	}
+
+	if ql.Graph != "" {
+		attrs["graph"] = ql.Graph
+	}
+
+	return attrs
 }
 
 // PrettyPrint formats the QueryLog for output.

--- a/pkg/gofr/datasource/mongo/mongo.go
+++ b/pkg/gofr/datasource/mongo/mongo.go
@@ -179,185 +179,168 @@ func getDBHost(uri string) (host string, err error) {
 	return parsedURL.Hostname(), nil
 }
 
+// instrumentOp starts tracing and returns a cleanup function that logs the query,
+// records metrics, and ends the span. The cleanup captures time.Now() before the
+// operation, ensuring accurate duration measurement.
+func (c *Client) instrumentOp(ctx context.Context, ql *QueryLog) (context.Context, func()) {
+	tracerCtx, span := c.addTrace(ctx, ql.Query, ql.Collection)
+	startTime := time.Now()
+
+	return tracerCtx, func() {
+		duration := time.Since(startTime).Microseconds()
+		ql.Duration = duration
+
+		c.logger.Debug(ql)
+
+		c.metrics.RecordHistogram(context.Background(), "app_mongo_stats", float64(duration),
+			"hostname", c.uri, "database", c.database, "type", ql.Query)
+
+		if span != nil {
+			span.SetAttributes(attribute.Int64(fmt.Sprintf("mongo.%v.duration", ql.Query), duration))
+			span.End()
+		}
+	}
+}
+
+// instrumentQuery builds a QueryLog and instruments the operation.
+func (c *Client) instrumentQuery(ctx context.Context, collection, operation string, filter, id, update any) (
+	context.Context, func()) {
+	return c.instrumentOp(ctx, &QueryLog{
+		Query:      operation,
+		Collection: collection,
+		Filter:     filter,
+		ID:         id,
+		Update:     update,
+	})
+}
+
 // InsertOne inserts a single document into the specified collection.
 func (c *Client) InsertOne(ctx context.Context, collection string, document any) (any, error) {
-	tracerCtx, span := c.addTrace(ctx, "insertOne", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "insertOne", document, nil, nil)
+	defer done()
 
-	result, err := c.Database.Collection(collection).InsertOne(tracerCtx, document)
-
-	defer c.sendOperationStats(&QueryLog{Query: "insertOne", Collection: collection, Filter: document}, time.Now(),
-		"insert", span)
-
-	return result, err
+	return c.Database.Collection(collection).InsertOne(ctx, document)
 }
 
 // InsertMany inserts multiple documents into the specified collection.
 func (c *Client) InsertMany(ctx context.Context, collection string, documents []any) ([]any, error) {
-	tracerCtx, span := c.addTrace(ctx, "insertMany", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "insertMany", documents, nil, nil)
+	defer done()
 
-	res, err := c.Database.Collection(collection).InsertMany(tracerCtx, documents)
+	res, err := c.Database.Collection(collection).InsertMany(ctx, documents)
 	if err != nil {
 		return nil, err
 	}
-
-	defer c.sendOperationStats(&QueryLog{Query: "insertMany", Collection: collection, Filter: documents}, time.Now(),
-		"insertMany", span)
 
 	return res.InsertedIDs, nil
 }
 
 // Find retrieves documents from the specified collection based on the provided filter and binds response to result.
 func (c *Client) Find(ctx context.Context, collection string, filter, results any) error {
-	tracerCtx, span := c.addTrace(ctx, "find", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "find", filter, nil, nil)
+	defer done()
 
-	cur, err := c.Database.Collection(collection).Find(tracerCtx, filter)
+	cur, err := c.Database.Collection(collection).Find(ctx, filter)
 	if err != nil {
 		return err
 	}
 
 	defer cur.Close(ctx)
 
-	if err := cur.All(ctx, results); err != nil {
-		return err
-	}
-
-	defer c.sendOperationStats(&QueryLog{Query: "find", Collection: collection, Filter: filter}, time.Now(), "find",
-		span)
-
-	return nil
+	return cur.All(ctx, results)
 }
 
 // FindOne retrieves a single document from the specified collection based on the provided filter and binds response to result.
 func (c *Client) FindOne(ctx context.Context, collection string, filter, result any) error {
-	tracerCtx, span := c.addTrace(ctx, "findOne", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "findOne", filter, nil, nil)
+	defer done()
 
-	b, err := c.Database.Collection(collection).FindOne(tracerCtx, filter).Raw()
+	b, err := c.Database.Collection(collection).FindOne(ctx, filter).Raw()
 	if err != nil {
 		return err
 	}
-
-	defer c.sendOperationStats(&QueryLog{Query: "findOne", Collection: collection, Filter: filter}, time.Now(),
-		"findOne", span)
 
 	return bson.Unmarshal(b, result)
 }
 
 // UpdateByID updates a document in the specified collection by its ID.
 func (c *Client) UpdateByID(ctx context.Context, collection string, id, update any) (int64, error) {
-	tracerCtx, span := c.addTrace(ctx, "updateByID", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "updateByID", nil, id, update)
+	defer done()
 
-	res, err := c.Database.Collection(collection).UpdateByID(tracerCtx, id, update)
-
-	defer c.sendOperationStats(&QueryLog{Query: "updateByID", Collection: collection, ID: id, Update: update}, time.Now(),
-		"updateByID", span)
+	res, err := c.Database.Collection(collection).UpdateByID(ctx, id, update)
 
 	return res.ModifiedCount, err
 }
 
 // UpdateOne updates a single document in the specified collection based on the provided filter.
 func (c *Client) UpdateOne(ctx context.Context, collection string, filter, update any) error {
-	tracerCtx, span := c.addTrace(ctx, "updateOne", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "updateOne", filter, nil, update)
+	defer done()
 
-	_, err := c.Database.Collection(collection).UpdateOne(tracerCtx, filter, update)
-
-	defer c.sendOperationStats(&QueryLog{Query: "updateOne", Collection: collection, Filter: filter, Update: update},
-		time.Now(), "updateOne", span)
+	_, err := c.Database.Collection(collection).UpdateOne(ctx, filter, update)
 
 	return err
 }
 
 // UpdateMany updates multiple documents in the specified collection based on the provided filter.
 func (c *Client) UpdateMany(ctx context.Context, collection string, filter, update any) (int64, error) {
-	tracerCtx, span := c.addTrace(ctx, "updateMany", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "updateMany", filter, nil, update)
+	defer done()
 
-	res, err := c.Database.Collection(collection).UpdateMany(tracerCtx, filter, update)
-
-	defer c.sendOperationStats(&QueryLog{Query: "updateMany", Collection: collection, Filter: filter, Update: update}, time.Now(),
-		"updateMany", span)
+	res, err := c.Database.Collection(collection).UpdateMany(ctx, filter, update)
 
 	return res.ModifiedCount, err
 }
 
 // CountDocuments counts the number of documents in the specified collection based on the provided filter.
 func (c *Client) CountDocuments(ctx context.Context, collection string, filter any) (int64, error) {
-	tracerCtx, span := c.addTrace(ctx, "countDocuments", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "countDocuments", filter, nil, nil)
+	defer done()
 
-	result, err := c.Database.Collection(collection).CountDocuments(tracerCtx, filter)
-
-	defer c.sendOperationStats(&QueryLog{Query: "countDocuments", Collection: collection, Filter: filter}, time.Now(),
-		"countDocuments", span)
-
-	return result, err
+	return c.Database.Collection(collection).CountDocuments(ctx, filter)
 }
 
 // DeleteOne deletes a single document from the specified collection based on the provided filter.
 func (c *Client) DeleteOne(ctx context.Context, collection string, filter any) (int64, error) {
-	tracerCtx, span := c.addTrace(ctx, "deleteOne", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "deleteOne", filter, nil, nil)
+	defer done()
 
-	res, err := c.Database.Collection(collection).DeleteOne(tracerCtx, filter)
+	res, err := c.Database.Collection(collection).DeleteOne(ctx, filter)
 	if err != nil {
 		return 0, err
 	}
-
-	defer c.sendOperationStats(&QueryLog{Query: "deleteOne", Collection: collection, Filter: filter}, time.Now(),
-		"deleteOne", span)
 
 	return res.DeletedCount, nil
 }
 
 // DeleteMany deletes multiple documents from the specified collection based on the provided filter.
 func (c *Client) DeleteMany(ctx context.Context, collection string, filter any) (int64, error) {
-	tracerCtx, span := c.addTrace(ctx, "deleteMany", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "deleteMany", filter, nil, nil)
+	defer done()
 
-	res, err := c.Database.Collection(collection).DeleteMany(tracerCtx, filter)
+	res, err := c.Database.Collection(collection).DeleteMany(ctx, filter)
 	if err != nil {
 		return 0, err
 	}
-
-	defer c.sendOperationStats(&QueryLog{Query: "deleteMany", Collection: collection, Filter: filter}, time.Now(),
-		"deleteMany", span)
 
 	return res.DeletedCount, nil
 }
 
 // Drop drops the specified collection from the database.
 func (c *Client) Drop(ctx context.Context, collection string) error {
-	tracerCtx, span := c.addTrace(ctx, "drop", collection)
+	ctx, done := c.instrumentQuery(ctx, collection, "drop", nil, nil, nil)
+	defer done()
 
-	err := c.Database.Collection(collection).Drop(tracerCtx)
-
-	defer c.sendOperationStats(&QueryLog{Query: "drop", Collection: collection}, time.Now(), "drop", span)
-
-	return err
+	return c.Database.Collection(collection).Drop(ctx)
 }
 
 // CreateCollection creates the specified collection in the database.
 func (c *Client) CreateCollection(ctx context.Context, name string) error {
-	tracerCtx, span := c.addTrace(ctx, "createCollection", name)
+	ctx, done := c.instrumentQuery(ctx, name, "createCollection", nil, nil, nil)
+	defer done()
 
-	err := c.Database.CreateCollection(tracerCtx, name)
-
-	defer c.sendOperationStats(&QueryLog{Query: "createCollection", Collection: name}, time.Now(), "createCollection",
-		span)
-
-	return err
-}
-
-func (c *Client) sendOperationStats(ql *QueryLog, startTime time.Time, method string, span trace.Span) {
-	duration := time.Since(startTime).Microseconds()
-
-	ql.Duration = duration
-
-	c.logger.Debug(ql)
-
-	c.metrics.RecordHistogram(context.Background(), "app_mongo_stats", float64(duration), "hostname", c.uri,
-		"database", c.database, "type", ql.Query)
-
-	if span != nil {
-		defer span.End()
-
-		span.SetAttributes(attribute.Int64(fmt.Sprintf("mongo.%v.duration", method), duration))
-	}
+	return c.Database.CreateCollection(ctx, name)
 }
 
 type Health struct {
@@ -387,7 +370,8 @@ func (c *Client) HealthCheck(ctx context.Context) (any, error) {
 }
 
 func (c *Client) StartSession() (any, error) {
-	defer c.sendOperationStats(&QueryLog{Query: "startSession"}, time.Now(), "", nil)
+	_, done := c.instrumentQuery(context.Background(), "", "startSession", nil, nil, nil)
+	defer done()
 
 	s, err := c.Client().StartSession()
 	ses := &session{s}

--- a/pkg/gofr/datasource/mongo/mongo_test.go
+++ b/pkg/gofr/datasource/mongo/mongo_test.go
@@ -215,9 +215,9 @@ func Test_InsertCommands(t *testing.T) {
 	cl := Client{metrics: metrics, tracer: otel.GetTracerProvider().Tracer("gofr-mongo")}
 
 	metrics.EXPECT().RecordHistogram(context.Background(), "app_mongo_stats", gomock.Any(), "hostname",
-		gomock.Any(), "database", gomock.Any(), "type", gomock.Any()).Times(3)
+		gomock.Any(), "database", gomock.Any(), "type", gomock.Any()).Times(4)
 
-	logger.EXPECT().Debug(gomock.Any()).Times(3)
+	logger.EXPECT().Debug(gomock.Any()).Times(4)
 
 	cl.logger = logger
 
@@ -320,9 +320,9 @@ func Test_FindMultipleCommands(t *testing.T) {
 	cl := Client{metrics: metrics, tracer: otel.GetTracerProvider().Tracer("gofr-mongo")}
 
 	metrics.EXPECT().RecordHistogram(context.Background(), "app_mongo_stats", gomock.Any(), "hostname",
-		gomock.Any(), "database", gomock.Any(), "type", gomock.Any())
+		gomock.Any(), "database", gomock.Any(), "type", gomock.Any()).Times(3)
 
-	logger.EXPECT().Debug(gomock.Any())
+	logger.EXPECT().Debug(gomock.Any()).Times(3)
 
 	cl.logger = logger
 
@@ -394,9 +394,9 @@ func Test_FindOneCommands(t *testing.T) {
 	cl := Client{metrics: metrics, tracer: otel.GetTracerProvider().Tracer("gofr-mongo")}
 
 	metrics.EXPECT().RecordHistogram(context.Background(), "app_mongo_stats", gomock.Any(), "hostname",
-		gomock.Any(), "database", gomock.Any(), "type", gomock.Any())
+		gomock.Any(), "database", gomock.Any(), "type", gomock.Any()).Times(2)
 
-	logger.EXPECT().Debug(gomock.Any())
+	logger.EXPECT().Debug(gomock.Any()).Times(2)
 
 	cl.logger = logger
 
@@ -554,9 +554,9 @@ func Test_DeleteCommands(t *testing.T) {
 	cl := Client{metrics: metrics, tracer: otel.GetTracerProvider().Tracer("gofr-mongo")}
 
 	metrics.EXPECT().RecordHistogram(context.Background(), "app_mongo_stats", gomock.Any(), "hostname",
-		gomock.Any(), "database", gomock.Any(), "type", gomock.Any()).Times(2)
+		gomock.Any(), "database", gomock.Any(), "type", gomock.Any()).Times(4)
 
-	logger.EXPECT().Debug(gomock.Any()).Times(2)
+	logger.EXPECT().Debug(gomock.Any()).Times(4)
 
 	cl.logger = logger
 

--- a/pkg/gofr/external_db.go
+++ b/pkg/gofr/external_db.go
@@ -5,80 +5,106 @@ import (
 
 	"gofr.dev/pkg/gofr/container"
 	"gofr.dev/pkg/gofr/datasource/file"
+	"gofr.dev/pkg/gofr/datasource/pubsub"
 )
 
+// tracerName returns the OpenTelemetry tracer name for a datasource.
+// Returns empty string if tracing is not applicable for the type.
+//
+//nolint:cyclop // complexity from datasource count, not logic
+func tracerName(ds any) string {
+	switch ds.(type) {
+	case container.Mongo:
+		return "gofr-mongo"
+	case container.ArangoDB:
+		return "gofr-arangodb"
+	case container.Clickhouse:
+		return "gofr-clickhouse"
+	case container.OracleDB:
+		return "gofr-oracle"
+	case container.CassandraWithContext:
+		return "gofr-cassandra"
+	case container.KVStore:
+		return "gofr-kvstore"
+	case container.Solr:
+		return "gofr-solr"
+	case container.Dgraph:
+		return "gofr-dgraph"
+	case container.OpenTSDB:
+		return "gofr-opentsdb"
+	case container.ScyllaDB:
+		return "gofr-scylladb"
+	case container.SurrealDB:
+		return "gofr-surrealdb"
+	case container.Elasticsearch:
+		return "gofr-elasticsearch"
+	case container.Couchbase:
+		return "gofr-couchbase"
+	case container.InfluxDB:
+		return "gofr-influxdb"
+	default:
+		return ""
+	}
+}
+
+// instrumentDatasource sets up logging, metrics, tracing, and connection for a datasource
+// using duck typing. Each datasource only needs to implement the methods it supports.
+func (a *App) instrumentDatasource(ds any) {
+	if l, ok := ds.(interface{ UseLogger(any) }); ok {
+		l.UseLogger(a.Logger())
+	}
+
+	if m, ok := ds.(interface{ UseMetrics(any) }); ok {
+		m.UseMetrics(a.Metrics())
+	}
+
+	if name := tracerName(ds); name != "" {
+		if t, ok := ds.(interface{ UseTracer(any) }); ok {
+			t.UseTracer(otel.GetTracerProvider().Tracer(name))
+		}
+	}
+
+	if c, ok := ds.(interface{ Connect() }); ok {
+		c.Connect()
+	}
+}
+
 // AddMongo sets the Mongo datasource in the app's container.
-func (a *App) AddMongo(db container.MongoProvider) {
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-mongo")
-
-	db.UseTracer(tracer)
-
-	db.Connect()
-
+func (a *App) AddMongo(db container.Mongo) {
+	a.instrumentDatasource(db)
 	a.container.Mongo = db
 }
 
 // AddFTP sets the FTP datasource in the app's container.
-// Deprecated: Use the AddFile method instead.
+// Deprecated: Use the AddFileStore method instead.
 func (a *App) AddFTP(fs file.FileSystemProvider) {
-	fs.UseLogger(a.Logger())
-	fs.UseMetrics(a.Metrics())
-
-	fs.Connect()
-
+	a.instrumentDatasource(fs)
 	a.container.File = fs
 }
 
 // AddPubSub sets the PubSub client in the app's container.
-func (a *App) AddPubSub(pubsub container.PubSubProvider) {
-	pubsub.UseLogger(a.Logger())
-	pubsub.UseMetrics(a.Metrics())
-
-	pubsub.Connect()
-
-	a.container.PubSub = pubsub
+func (a *App) AddPubSub(ps pubsub.Client) {
+	a.instrumentDatasource(ps)
+	a.container.PubSub = ps
 }
 
 // AddFileStore sets the FTP, SFTP, S3, GCS, or Azure File Storage datasource in the app's container.
 func (a *App) AddFileStore(fs file.FileSystemProvider) {
-	fs.UseLogger(a.Logger())
-	fs.UseMetrics(a.Metrics())
-
-	fs.Connect()
-
+	a.instrumentDatasource(fs)
 	a.container.File = fs
 }
 
 // AddClickhouse initializes the clickhouse client.
-// Official implementation is available in the package : gofr.dev/pkg/gofr/datasource/clickhouse .
-func (a *App) AddClickhouse(db container.ClickhouseProvider) {
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-clickhouse")
-
-	db.UseTracer(tracer)
-
-	db.Connect()
-
+// Official implementation is available in the package: gofr.dev/pkg/gofr/datasource/clickhouse.
+func (a *App) AddClickhouse(db container.Clickhouse) {
+	a.instrumentDatasource(db)
 	a.container.Clickhouse = db
 }
 
 // AddOracle initializes the OracleDB client.
 // Official implementation is available in the package: gofr.dev/pkg/gofr/datasource/oracle.
-func (a *App) AddOracle(db container.OracleProvider) {
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-oracle")
-
-	db.UseTracer(tracer)
-
-	db.Connect()
-
+func (a *App) AddOracle(db container.OracleDB) {
+	a.instrumentDatasource(db)
 	a.container.Oracle = db
 }
 
@@ -89,171 +115,85 @@ func (a *App) UseMongo(db container.Mongo) {
 }
 
 // AddCassandra sets the Cassandra datasource in the app's container.
-func (a *App) AddCassandra(db container.CassandraProvider) {
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-cassandra")
-
-	db.UseTracer(tracer)
-
-	db.Connect()
-
+func (a *App) AddCassandra(db container.CassandraWithContext) {
+	a.instrumentDatasource(db)
 	a.container.Cassandra = db
 }
 
 // AddKVStore sets the KV-Store datasource in the app's container.
-func (a *App) AddKVStore(db container.KVStoreProvider) {
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-kvstore")
-
-	db.UseTracer(tracer)
-
-	db.Connect()
-
+func (a *App) AddKVStore(db container.KVStore) {
+	a.instrumentDatasource(db)
 	a.container.KVStore = db
 }
 
 // AddSolr sets the Solr datasource in the app's container.
-func (a *App) AddSolr(db container.SolrProvider) {
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-solr")
-
-	db.UseTracer(tracer)
-
-	db.Connect()
-
+func (a *App) AddSolr(db container.Solr) {
+	a.instrumentDatasource(db)
 	a.container.Solr = db
 }
 
 // AddDgraph sets the Dgraph datasource in the app's container.
-func (a *App) AddDgraph(db container.DgraphProvider) {
-	// Create the Dgraph client with the provided configuration
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-dgraph")
-
-	db.UseTracer(tracer)
-
-	db.Connect()
-
+func (a *App) AddDgraph(db container.Dgraph) {
+	a.instrumentDatasource(db)
 	a.container.DGraph = db
 }
 
 // AddOpenTSDB sets the OpenTSDB datasource in the app's container.
-func (a *App) AddOpenTSDB(db container.OpenTSDBProvider) {
-	// Create the Opentsdb client with the provided configuration
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-opentsdb")
-
-	db.UseTracer(tracer)
-
-	db.Connect()
-
+func (a *App) AddOpenTSDB(db container.OpenTSDB) {
+	a.instrumentDatasource(db)
 	a.container.OpenTSDB = db
 }
 
 // AddScyllaDB sets the ScyllaDB datasource in the app's container.
-func (a *App) AddScyllaDB(db container.ScyllaDBProvider) {
-	// Create the ScyllaDB client with the provided configuration
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-scylladb")
-	db.UseTracer(tracer)
-	db.Connect()
+func (a *App) AddScyllaDB(db container.ScyllaDB) {
+	a.instrumentDatasource(db)
 	a.container.ScyllaDB = db
 }
 
 // AddArangoDB sets the ArangoDB datasource in the app's container.
-func (a *App) AddArangoDB(db container.ArangoDBProvider) {
-	// Set up logger, metrics, and tracer
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	// Get tracer from OpenTelemetry
-	tracer := otel.GetTracerProvider().Tracer("gofr-arangodb")
-	db.UseTracer(tracer)
-
-	// Connect to ArangoDB
-	db.Connect()
-
-	// Add the ArangoDB provider to the container
+func (a *App) AddArangoDB(db container.ArangoDB) {
+	a.instrumentDatasource(db)
 	a.container.ArangoDB = db
 }
 
-func (a *App) AddSurrealDB(db container.SurrealBDProvider) {
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-surrealdb")
-	db.UseTracer(tracer)
-	db.Connect()
+// AddSurrealDB sets the SurrealDB datasource in the app's container.
+func (a *App) AddSurrealDB(db container.SurrealDB) {
+	a.instrumentDatasource(db)
 	a.container.SurrealDB = db
 }
 
-func (a *App) AddElasticsearch(db container.ElasticsearchProvider) {
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-elasticsearch")
-	db.UseTracer(tracer)
-	db.Connect()
-
+// AddElasticsearch sets the Elasticsearch datasource in the app's container.
+func (a *App) AddElasticsearch(db container.Elasticsearch) {
+	a.instrumentDatasource(db)
 	a.container.Elasticsearch = db
 }
 
-func (a *App) AddCouchbase(db container.CouchbaseProvider) {
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-couchbase")
-	db.UseTracer(tracer)
-	db.Connect()
-
+// AddCouchbase sets the Couchbase datasource in the app's container.
+func (a *App) AddCouchbase(db container.Couchbase) {
+	a.instrumentDatasource(db)
 	a.container.Couchbase = db
 }
 
 // AddDBResolver sets up database resolver with read/write splitting.
 func (a *App) AddDBResolver(resolver container.DBResolverProvider) {
-	// Validate primary SQL exists
 	if a.container.SQL == nil {
 		a.Logger().Fatal("Primary SQL connection must be configured before adding DBResolver")
 		return
 	}
 
-	resolver.UseLogger(a.Logger())
-	resolver.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-dbresolver")
-	resolver.UseTracer(tracer)
-
-	resolver.Connect()
-
-	// Replace the SQL connection with the resolver
+	a.instrumentDatasource(resolver)
 	a.container.SQL = resolver.GetResolver()
 
 	a.Logger().Logf("DB Resolver initialized successfully")
 }
 
-func (a *App) AddInfluxDB(db container.InfluxDBProvider) {
-	db.UseLogger(a.Logger())
-	db.UseMetrics(a.Metrics())
-
-	tracer := otel.GetTracerProvider().Tracer("gofr-influxdb")
-	db.UseTracer(tracer)
-	db.Connect()
-
+// AddInfluxDB sets the InfluxDB datasource in the app's container.
+func (a *App) AddInfluxDB(db container.InfluxDB) {
+	a.instrumentDatasource(db)
 	a.container.InfluxDB = db
 }
 
+// GetSQL returns the SQL datasource from the container.
 func (a *App) GetSQL() container.DB {
 	return a.container.SQL
 }

--- a/pkg/gofr/external_db_test.go
+++ b/pkg/gofr/external_db_test.go
@@ -13,240 +13,265 @@ import (
 	"gofr.dev/pkg/gofr/testutil"
 )
 
-func TestApp_AddKVStore(t *testing.T) {
-	t.Run("Adding KV-Store", func(t *testing.T) {
-		testutil.NewServerConfigs(t)
+func Test_tracerName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-		app := New()
+	tests := []struct {
+		name     string
+		ds       any
+		expected string
+	}{
+		{"Mongo", container.NewMockMongo(ctrl), "gofr-mongo"},
+		{"ArangoDB", container.NewMockArangoDB(ctrl), "gofr-arangodb"},
+		{"Clickhouse", container.NewMockClickhouse(ctrl), "gofr-clickhouse"},
+		{"Oracle", container.NewMockOracleDB(ctrl), "gofr-oracle"},
+		{"Cassandra", container.NewMockCassandraWithContext(ctrl), "gofr-cassandra"},
+		{"KVStore", container.NewMockKVStore(ctrl), "gofr-kvstore"},
+		{"Solr", container.NewMockSolr(ctrl), "gofr-solr"},
+		{"ScyllaDB", container.NewMockScyllaDB(ctrl), "gofr-scylladb"},
+		{"SurrealDB", container.NewMockSurrealDB(ctrl), "gofr-surrealdb"},
+		{"Elasticsearch", container.NewMockElasticsearch(ctrl), "gofr-elasticsearch"},
+		{"Couchbase", container.NewMockCouchbase(ctrl), "gofr-couchbase"},
+		{"InfluxDB", container.NewMockInfluxDB(ctrl), "gofr-influxdb"},
+		{"Unknown", "not-a-datasource", ""},
+	}
 
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tracerName(tt.ds))
+		})
+	}
+}
 
-		mock := container.NewMockKVStoreProvider(ctrl)
+func Test_instrumentDatasource(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
 
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-kvstore"))
-		mock.EXPECT().Connect()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-		app.AddKVStore(mock)
+	// MockMongoProvider implements UseLogger/UseMetrics/UseTracer/Connect via provider interface
+	mock := container.NewMockMongoProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-mongo"))
+	mock.EXPECT().Connect()
 
-		assert.Equal(t, mock, app.container.KVStore)
-	})
+	app.instrumentDatasource(mock)
+}
+
+func Test_instrumentDatasource_PartialImplementation(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// FileSystemProvider has UseLogger/UseMetrics/Connect but no UseTracer
+	mock := file.NewMockFileSystemProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().Connect()
+
+	// Should not panic — UseTracer is simply skipped
+	app.instrumentDatasource(mock)
 }
 
 func TestApp_AddMongo(t *testing.T) {
-	t.Run("Adding MongoDB", func(t *testing.T) {
-		testutil.NewServerConfigs(t)
+	testutil.NewServerConfigs(t)
+	app := New()
 
-		app := New()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+	mock := container.NewMockMongoProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().UseTracer(gomock.Any())
+	mock.EXPECT().Connect()
 
-		mock := container.NewMockMongoProvider(ctrl)
+	app.AddMongo(mock)
 
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().UseTracer(gomock.Any())
-		mock.EXPECT().Connect()
-
-		app.AddMongo(mock)
-
-		assert.Equal(t, mock, app.container.Mongo)
-	})
-}
-
-func TestApp_AddCassandra(t *testing.T) {
-	t.Run("Adding Cassandra", func(t *testing.T) {
-		testutil.NewServerConfigs(t)
-
-		app := New()
-
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mock := container.NewMockCassandraProvider(ctrl)
-
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-cassandra"))
-		mock.EXPECT().Connect()
-
-		app.AddCassandra(mock)
-
-		assert.Equal(t, mock, app.container.Cassandra)
-	})
-}
-
-func TestApp_AddClickhouse(t *testing.T) {
-	t.Run("Adding Clickhouse", func(t *testing.T) {
-		testutil.NewServerConfigs(t)
-
-		app := New()
-
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mock := container.NewMockClickhouseProvider(ctrl)
-
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-clickhouse"))
-		mock.EXPECT().Connect()
-
-		app.AddClickhouse(mock)
-
-		assert.Equal(t, mock, app.container.Clickhouse)
-	})
-}
-
-func TestApp_AddOracle(t *testing.T) {
-	t.Run("Adding OracleDB", func(t *testing.T) {
-		testutil.NewServerConfigs(t)
-
-		app := New()
-
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mock := container.NewMockOracleProvider(ctrl)
-
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-oracle"))
-		mock.EXPECT().Connect()
-
-		app.AddOracle(mock)
-
-		assert.Equal(t, mock, app.container.Oracle)
-	})
-}
-
-func TestApp_AddFTP(t *testing.T) {
-	t.Run("Adding FTP", func(t *testing.T) {
-		testutil.NewServerConfigs(t)
-
-		app := New()
-
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mock := file.NewMockFileSystemProvider(ctrl)
-
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().Connect()
-
-		app.AddFTP(mock)
-
-		assert.Equal(t, mock, app.container.File)
-	})
-
-	t.Run("Adding FTP", func(t *testing.T) {
-		testutil.NewServerConfigs(t)
-
-		app := New()
-
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mock := file.NewMockFileSystemProvider(ctrl)
-
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().Connect()
-
-		app.AddFileStore(mock)
-
-		assert.Equal(t, mock, app.container.File)
-	})
-}
-
-func TestApp_AddS3(t *testing.T) {
-	t.Run("Adding S3", func(t *testing.T) {
-		testutil.NewServerConfigs(t)
-
-		app := New()
-
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mock := file.NewMockFileSystemProvider(ctrl)
-
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().Connect()
-
-		app.AddFileStore(mock)
-
-		assert.Equal(t, mock, app.container.File)
-	})
-}
-
-func TestApp_AddOpenTSDB(t *testing.T) {
-	t.Run("Adding OpenTSDB", func(t *testing.T) {
-		testutil.NewServerConfigs(t)
-
-		app := New()
-
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mock := container.NewMockOpenTSDBProvider(ctrl)
-
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().UseTracer(gomock.Any())
-		mock.EXPECT().Connect()
-
-		app.AddOpenTSDB(mock)
-
-		assert.Equal(t, mock, app.container.OpenTSDB)
-	})
-}
-
-func TestApp_AddScyllaDB(t *testing.T) {
-	t.Run("Adding ScyllaDB", func(t *testing.T) {
-		testutil.NewServerConfigs(t)
-
-		app := New()
-
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mock := container.NewMockScyllaDBProvider(ctrl)
-
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().UseTracer(gomock.Any())
-		mock.EXPECT().Connect()
-
-		app.AddScyllaDB(mock)
-
-		assert.Equal(t, mock, app.container.ScyllaDB)
-	})
+	assert.Equal(t, mock, app.container.Mongo)
 }
 
 func TestApp_AddArangoDB(t *testing.T) {
-	t.Run("Adding ArangoDB", func(t *testing.T) {
-		port := testutil.GetFreePort(t)
-		t.Setenv("METRICS_PORT", strconv.Itoa(port))
+	port := testutil.GetFreePort(t)
+	t.Setenv("METRICS_PORT", strconv.Itoa(port))
 
-		app := New()
+	app := New()
 
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-		mock := container.NewMockArangoDBProvider(ctrl)
+	mock := container.NewMockArangoDBProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-arangodb"))
+	mock.EXPECT().Connect()
 
-		mock.EXPECT().UseLogger(app.Logger())
-		mock.EXPECT().UseMetrics(app.Metrics())
-		mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-arangodb"))
-		mock.EXPECT().Connect()
+	app.AddArangoDB(mock)
 
-		app.AddArangoDB(mock)
+	assert.Equal(t, mock, app.container.ArangoDB)
+}
 
-		assert.Equal(t, mock, app.container.ArangoDB)
-	})
+func TestApp_AddClickhouse(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := container.NewMockClickhouseProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-clickhouse"))
+	mock.EXPECT().Connect()
+
+	app.AddClickhouse(mock)
+
+	assert.Equal(t, mock, app.container.Clickhouse)
+}
+
+func TestApp_AddCassandra(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := container.NewMockCassandraProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-cassandra"))
+	mock.EXPECT().Connect()
+
+	app.AddCassandra(mock)
+
+	assert.Equal(t, mock, app.container.Cassandra)
+}
+
+func TestApp_AddOracle(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := container.NewMockOracleProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-oracle"))
+	mock.EXPECT().Connect()
+
+	app.AddOracle(mock)
+
+	assert.Equal(t, mock, app.container.Oracle)
+}
+
+func TestApp_AddKVStore(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := container.NewMockKVStoreProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().UseTracer(otel.GetTracerProvider().Tracer("gofr-kvstore"))
+	mock.EXPECT().Connect()
+
+	app.AddKVStore(mock)
+
+	assert.Equal(t, mock, app.container.KVStore)
+}
+
+func TestApp_AddSolr(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := container.NewMockSolrProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().UseTracer(gomock.Any())
+	mock.EXPECT().Connect()
+
+	app.AddSolr(mock)
+
+	assert.Equal(t, mock, app.container.Solr)
+}
+
+func TestApp_AddFTP(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := file.NewMockFileSystemProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().Connect()
+
+	app.AddFTP(mock)
+
+	assert.Equal(t, mock, app.container.File)
+}
+
+func TestApp_AddFileStore(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := file.NewMockFileSystemProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().Connect()
+
+	app.AddFileStore(mock)
+
+	assert.Equal(t, mock, app.container.File)
+}
+
+func TestApp_AddOpenTSDB(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := container.NewMockOpenTSDBProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().UseTracer(gomock.Any())
+	mock.EXPECT().Connect()
+
+	app.AddOpenTSDB(mock)
+
+	assert.Equal(t, mock, app.container.OpenTSDB)
+}
+
+func TestApp_AddScyllaDB(t *testing.T) {
+	testutil.NewServerConfigs(t)
+	app := New()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := container.NewMockScyllaDBProvider(ctrl)
+	mock.EXPECT().UseLogger(app.Logger())
+	mock.EXPECT().UseMetrics(app.Metrics())
+	mock.EXPECT().UseTracer(gomock.Any())
+	mock.EXPECT().Connect()
+
+	app.AddScyllaDB(mock)
+
+	assert.Equal(t, mock, app.container.ScyllaDB)
 }


### PR DESCRIPTION
- Consolidate 15+ identical Add* methods in external_db.go into a single instrumentDatasource() helper using duck typing
- Change Add* signatures from *Provider to behavior interfaces (e.g., MongoProvider → Mongo) for cleaner API surface
- Add instrumentOp/instrumentQuery pattern to mongo and arangodb that fixes defer timing bugs: time.Now() captured before operations, done() always fires even on error paths
- Remove sendOperationStats and executeCollectionOperation (arango timing bug: measured getCollection instead of full operation)
- Add QueryLog.traceAttrs() helper for arangodb trace attributes
- Deprecate all *Provider interfaces in container/datasources.go

## Pull Request Template


**Description:**

-   Provide a concise explanation of the changes made.
-   Mention the issue number(s) this PR addresses (if applicable).
-   Highlight the motivation behind the changes and the expected benefits.


**Breaking Changes (if applicable):**

-   List any breaking changes introduced by this PR.
-   Explain the rationale behind these changes and how they will impact users.

**Additional Information:**

-   Mention any relevant dependencies or external libraries used.
-   Include screenshots or code snippets (if necessary) to clarify the changes.

**Checklist:**

-   [ ] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [ ] All new code is covered by unit tests.
-   [ ] This PR does not decrease the overall code coverage.
-   [ ] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**

