### PR TITLE
Release/v1.56.3

### DIFF
--- a/docs/advanced-guide/using-publisher-subscriber/page.md
+++ b/docs/advanced-guide/using-publisher-subscriber/page.md
@@ -186,6 +186,7 @@ KAFKA_TLS_CERT_FILE=/path/to/cert.pem
 KAFKA_TLS_KEY_FILE=/path/to/key.pem
 KAFKA_TLS_CA_CERT_FILE=/path/to/ca.pem
 KAFKA_TLS_INSECURE_SKIP_VERIFY=true
+```
 
 #### Docker setup
 ```shell

--- a/pkg/gofr/version/version.go
+++ b/pkg/gofr/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Framework = "v1.54.3"
+const Framework = "dev"

--- a/pkg/gofr/version/version.go
+++ b/pkg/gofr/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Framework = "dev"
+const Framework = "v1.56.3"


### PR DESCRIPTION
# Release v1.56.3


## 🛠️Fixes
                                                                                                                                                                                     
  - **Docs Build Prerender Crash** — Fixed an unclosed dotenv code block in the Pub/Sub advanced guide (`/docs/advanced-guide/using-publisher-subscriber`) that causediNext.jsftort throw `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` during prerendering, breaking the `Dockerize` step of the v1.56.2 release workflow. 