### PR TITLE
fix(kafka): reconnect stale admin conn instead of failing forever

### DIFF
--- a/docs/advanced-guide/using-publisher-subscriber/page.md
+++ b/docs/advanced-guide/using-publisher-subscriber/page.md
@@ -832,7 +832,7 @@ When the message is delivered to a subscriber registered with `app.Subscribe(top
 
 The result is that an end-to-end flow such as `HTTP → publish → subscribe → publish → subscribe` shows up as **one connected trace** in any tracing UI, with the full waterfall visible:
 
-```
+```text
 [api-gateway          ] POST /order         (root)
 [api-gateway          ] kafka-publish       child of POST /order
 [order-service        ] kafka-subscribe     child of api-gateway's publish   [+1 link]

--- a/pkg/gofr/datasource/pubsub/kafka/conn.go
+++ b/pkg/gofr/datasource/pubsub/kafka/conn.go
@@ -46,13 +46,20 @@ func (k *kafkaClient) initialize(ctx context.Context) error {
 }
 
 func (k *kafkaClient) getNewReader(topic string) Reader {
+	// Snapshot the dialer under connMu — reconnectAdminLocked may swap it
+	// concurrently. Once handed to kafka.NewReader, the reader keeps its
+	// own reference; later reconnects do not affect existing readers.
+	k.connMu.RLock()
+	dialer := k.dialer
+	k.connMu.RUnlock()
+
 	reader := kafka.NewReader(kafka.ReaderConfig{
 		GroupID:     k.config.ConsumerGroupID,
 		Brokers:     k.config.Brokers,
 		Topic:       topic,
 		MinBytes:    defaultMinBytes,
 		MaxBytes:    defaultMaxBytes,
-		Dialer:      k.dialer,
+		Dialer:      dialer,
 		StartOffset: int64(k.config.OffSet),
 	})
 

--- a/pkg/gofr/datasource/pubsub/kafka/conn.go
+++ b/pkg/gofr/datasource/pubsub/kafka/conn.go
@@ -60,14 +60,35 @@ func (k *kafkaClient) getNewReader(topic string) Reader {
 }
 
 func (k *kafkaClient) DeleteTopic(_ context.Context, name string) error {
+	k.connMu.RLock()
+	defer k.connMu.RUnlock()
+
+	if k.conn == nil {
+		return errClientNotConnected
+	}
+
 	return k.conn.DeleteTopics(name)
 }
 
 func (k *kafkaClient) Controller() (broker kafka.Broker, err error) {
+	k.connMu.RLock()
+	defer k.connMu.RUnlock()
+
+	if k.conn == nil {
+		return kafka.Broker{}, errClientNotConnected
+	}
+
 	return k.conn.Controller()
 }
 
 func (k *kafkaClient) CreateTopic(_ context.Context, name string) error {
+	k.connMu.RLock()
+	defer k.connMu.RUnlock()
+
+	if k.conn == nil {
+		return errClientNotConnected
+	}
+
 	topics := kafka.TopicConfig{Topic: name, NumPartitions: 1, ReplicationFactor: 1}
 
 	return k.conn.CreateTopics(topics)

--- a/pkg/gofr/datasource/pubsub/kafka/conn.go
+++ b/pkg/gofr/datasource/pubsub/kafka/conn.go
@@ -16,6 +16,12 @@ type Conn struct {
 }
 
 // initialize creates and configures all Kafka client components.
+//
+// initialize is called once from New() before the client is returned, and
+// again from retryConnect() in a goroutine if the first attempt fails.
+// Because retryConnect runs concurrently with user-facing calls, the
+// k.conn / k.dialer writes must be serialized against the readers that
+// take connMu (Health, Controller, ensureConnected, getNewReader, ...).
 func (k *kafkaClient) initialize(ctx context.Context) error {
 	dialer, err := setupDialer(&k.config)
 	if err != nil {
@@ -37,8 +43,13 @@ func (k *kafkaClient) initialize(ctx context.Context) error {
 
 	k.logger.Logf("connected to %d Kafka brokers", len(conns))
 
+	k.connMu.Lock()
 	k.dialer = dialer
 	k.conn = multi
+	k.connMu.Unlock()
+
+	// writer and reader are not guarded by connMu — k.mu protects the
+	// reader map; writer is set once and never swapped.
 	k.writer = writer
 	k.reader = reader
 

--- a/pkg/gofr/datasource/pubsub/kafka/health.go
+++ b/pkg/gofr/datasource/pubsub/kafka/health.go
@@ -15,6 +15,11 @@ func (k *kafkaClient) Health() datasource.Health {
 		Details: make(map[string]any),
 	}
 
+	// Hold connMu across the whole health probe so reconnectAdmin cannot
+	// swap and close the conn we are reading from underneath us.
+	k.connMu.RLock()
+	defer k.connMu.RUnlock()
+
 	if k.conn == nil {
 		health.Details["error"] = "invalid connection type"
 		return health

--- a/pkg/gofr/datasource/pubsub/kafka/helper.go
+++ b/pkg/gofr/datasource/pubsub/kafka/helper.go
@@ -79,6 +79,16 @@ func (k *kafkaClient) retryConnect(ctx context.Context) {
 }
 
 func (k *kafkaClient) isConnected() bool {
+	k.connMu.RLock()
+	defer k.connMu.RUnlock()
+
+	return k.isConnectedLocked()
+}
+
+// isConnectedLocked probes the admin connection. The caller must already hold
+// connMu (read or write); used by ensureConnected to avoid re-acquiring the
+// lock between the unlocked fast path and the locked double-check.
+func (k *kafkaClient) isConnectedLocked() bool {
 	if k.conn == nil {
 		return false
 	}
@@ -86,6 +96,80 @@ func (k *kafkaClient) isConnected() bool {
 	_, err := k.conn.Controller()
 
 	return err == nil
+}
+
+// ensureConnected verifies the admin connection is alive and, if not, makes a
+// single attempt to re-dial the brokers. Kafka brokers silently drop idle TCP
+// connections after their configured idle timeout (default
+// connections.max.idle.ms = 10 min), so without a runtime reconnect path the
+// admin conn pool dialed once in initialize() stays stale forever and every
+// Subscribe/Query call returns errClientNotConnected even though the cluster
+// is healthy.
+//
+// The reconnect is serialized on connMu — a dedicated lock that does not
+// block subscribers holding the reader-map lock (k.mu). Only k.conn and
+// k.dialer are refreshed; in-flight writers and per-topic readers manage
+// their own connections via segmentio/kafka-go.
+func (k *kafkaClient) ensureConnected(ctx context.Context) bool {
+	if k.isConnected() {
+		return true
+	}
+
+	k.connMu.Lock()
+	defer k.connMu.Unlock()
+
+	// Re-check inside the write lock — another goroutine may have
+	// already reconnected while we were waiting on the mutex.
+	if k.isConnectedLocked() {
+		return true
+	}
+
+	if err := k.reconnectAdminLocked(ctx); err != nil {
+		k.logger.Errorf("kafka admin reconnect failed: %v", err)
+
+		return false
+	}
+
+	k.logger.Log("reconnected to kafka after stale admin connection")
+
+	return true
+}
+
+// reconnectAdminLocked re-dials the broker-facing admin connections used for
+// Controller/CreateTopic/DeleteTopic and the isConnected health probe. The
+// caller MUST hold connMu for writing. It deliberately does not touch the
+// writer or reader map — those keep their own connections.
+func (k *kafkaClient) reconnectAdminLocked(ctx context.Context) error {
+	dialer := k.dialer
+	if dialer == nil {
+		d, err := setupDialer(&k.config)
+		if err != nil {
+			return err
+		}
+
+		dialer = d
+	}
+
+	conns, err := connectToBrokers(ctx, k.config.Brokers, dialer, k.logger)
+	if err != nil {
+		return err
+	}
+
+	old := k.conn
+	k.conn = &multiConn{
+		conns:  conns,
+		dialer: dialer,
+	}
+	k.dialer = dialer
+
+	// Safe to close while holding the write lock: no other goroutine can
+	// be using the old multiConn because admin entry points all take
+	// connMu.RLock before touching k.conn.
+	if old != nil {
+		_ = old.Close()
+	}
+
+	return nil
 }
 
 func setupDialer(conf *Config) (*kafka.Dialer, error) {

--- a/pkg/gofr/datasource/pubsub/kafka/helper.go
+++ b/pkg/gofr/datasource/pubsub/kafka/helper.go
@@ -125,11 +125,24 @@ func (k *kafkaClient) ensureConnected(ctx context.Context) bool {
 	}
 
 	if err := k.reconnectAdminLocked(ctx); err != nil {
-		k.logger.Errorf("kafka admin reconnect failed: %v", err)
+		// Throttle error-level logs: in a high-QPS service every
+		// failed Subscribe/Query would otherwise log Errorf, swamping
+		// the log pipeline while the cluster is unreachable. Log at
+		// error once per reconnectErrLogInterval; in between, log at
+		// debug so the failure is still observable when needed.
+		now := time.Now()
+		if now.After(k.reconnectErrLogAt) {
+			k.logger.Errorf("kafka admin reconnect failed: %v", err)
+			k.reconnectErrLogAt = now.Add(reconnectErrLogInterval)
+		} else {
+			k.logger.Debugf("kafka admin reconnect failed: %v", err)
+		}
 
 		return false
 	}
 
+	// Reset the throttle so the next outage starts with an Errorf again.
+	k.reconnectErrLogAt = time.Time{}
 	k.logger.Log("reconnected to kafka after stale admin connection")
 
 	return true
@@ -200,7 +213,13 @@ func setupDialer(conf *Config) (*kafka.Dialer, error) {
 }
 
 // connectToBrokers connects to Kafka brokers with context support.
-func connectToBrokers(ctx context.Context, brokers []string, dialer *kafka.Dialer, logger pubsub.Logger) ([]Connection, error) {
+//
+// Exposed as a var so tests can stub the network dial in reconnectAdminLocked
+// and initialize without spinning up a real broker. Production callers must
+// not reassign this.
+//
+//nolint:gochecknoglobals // Test seam — see doc above. Reassigned only from tests via t.Cleanup.
+var connectToBrokers = func(ctx context.Context, brokers []string, dialer *kafka.Dialer, logger pubsub.Logger) ([]Connection, error) {
 	conns := make([]Connection, 0)
 
 	if len(brokers) == 0 {

--- a/pkg/gofr/datasource/pubsub/kafka/kafka.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka.go
@@ -55,7 +55,15 @@ type kafkaClient struct {
 	writer Writer
 	reader map[string]Reader
 
+	// mu guards the reader map.
 	mu *sync.RWMutex
+	// connMu guards conn/dialer pointer swaps performed by reconnectAdmin.
+	// Read-lock holders use the admin connection concurrently; the
+	// write-lock holder swaps the pointer and closes the old multiConn.
+	// It is intentionally separate from mu so a stuck network probe inside
+	// ensureConnected cannot starve subscribers that hold mu for the
+	// reader map.
+	connMu sync.RWMutex
 
 	logger  pubsub.Logger
 	config  Config
@@ -147,7 +155,7 @@ func (k *kafkaClient) Publish(ctx context.Context, topic string, message []byte)
 }
 
 func (k *kafkaClient) Query(ctx context.Context, query string, args ...any) ([]byte, error) {
-	if !k.isConnected() {
+	if !k.ensureConnected(ctx) {
 		return nil, errClientNotConnected
 	}
 
@@ -169,7 +177,7 @@ func (k *kafkaClient) Query(ctx context.Context, query string, args ...any) ([]b
 }
 
 func (k *kafkaClient) Subscribe(ctx context.Context, topic string) (*pubsub.Message, error) {
-	if !k.isConnected() {
+	if !k.ensureConnected(ctx) {
 		time.Sleep(defaultRetryTimeout)
 
 		return nil, errClientNotConnected
@@ -254,9 +262,12 @@ func (k *kafkaClient) Close() (err error) {
 		err = errors.Join(err, k.writer.Close())
 	}
 
+	k.connMu.Lock()
 	if k.conn != nil {
 		err = errors.Join(k.conn.Close())
+		k.conn = nil
 	}
+	k.connMu.Unlock()
 
 	return err
 }

--- a/pkg/gofr/datasource/pubsub/kafka/kafka.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka.go
@@ -263,10 +263,12 @@ func (k *kafkaClient) Close() (err error) {
 	}
 
 	k.connMu.Lock()
+
 	if k.conn != nil {
 		err = errors.Join(k.conn.Close())
 		k.conn = nil
 	}
+
 	k.connMu.Unlock()
 
 	return err

--- a/pkg/gofr/datasource/pubsub/kafka/kafka.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka.go
@@ -15,19 +15,24 @@ import (
 )
 
 const (
-	DefaultBatchSize       = 100
-	DefaultBatchBytes      = 1048576
-	DefaultBatchTimeout    = 1000
-	defaultMaxBytes        = 10e6 // 10MB
-	defaultMinBytes        = 10e3
-	defaultRetryTimeout    = 10 * time.Second
-	defaultReadTimeout     = 30 * time.Second
-	protocolPlainText      = "PLAINTEXT"
-	protocolSASL           = "SASL_PLAINTEXT"
-	protocolSSL            = "SSL"
-	protocolSASLSSL        = "SASL_SSL"
-	messageMultipleBrokers = "MULTIPLE_BROKERS"
-	brokerStatusUp         = "UP"
+	DefaultBatchSize    = 100
+	DefaultBatchBytes   = 1048576
+	DefaultBatchTimeout = 1000
+	defaultMaxBytes     = 10e6 // 10MB
+	defaultMinBytes     = 10e3
+	defaultRetryTimeout = 10 * time.Second
+	defaultReadTimeout  = 30 * time.Second
+	// reconnectErrLogInterval throttles error-level logs emitted when
+	// ensureConnected repeatedly fails to re-dial the broker. Repeated
+	// failures within this window are logged at debug level instead, so a
+	// long unreachable cluster does not spam stderr at request rate.
+	reconnectErrLogInterval = 60 * time.Second
+	protocolPlainText       = "PLAINTEXT"
+	protocolSASL            = "SASL_PLAINTEXT"
+	protocolSSL             = "SSL"
+	protocolSASLSSL         = "SASL_SSL"
+	messageMultipleBrokers  = "MULTIPLE_BROKERS"
+	brokerStatusUp          = "UP"
 )
 
 var errEmptyTopicName = errors.New("topic name cannot be empty")
@@ -64,6 +69,11 @@ type kafkaClient struct {
 	// ensureConnected cannot starve subscribers that hold mu for the
 	// reader map.
 	connMu sync.RWMutex
+	// reconnectErrLogAt is the earliest time at which the next reconnect
+	// failure may be logged at error level. Updated under connMu write lock
+	// in ensureConnected to throttle log spam when the cluster is
+	// unreachable for a sustained period.
+	reconnectErrLogAt time.Time
 
 	logger  pubsub.Logger
 	config  Config
@@ -155,12 +165,14 @@ func (k *kafkaClient) Publish(ctx context.Context, topic string, message []byte)
 }
 
 func (k *kafkaClient) Query(ctx context.Context, query string, args ...any) ([]byte, error) {
-	if !k.ensureConnected(ctx) {
-		return nil, errClientNotConnected
-	}
-
+	// Validate input before touching the network — no point re-dialing the
+	// broker for an obviously bad call.
 	if query == "" {
 		return nil, errEmptyTopicName
+	}
+
+	if !k.ensureConnected(ctx) {
+		return nil, errClientNotConnected
 	}
 
 	offset, limit := k.parseQueryArgs(args...)
@@ -265,7 +277,7 @@ func (k *kafkaClient) Close() (err error) {
 	k.connMu.Lock()
 
 	if k.conn != nil {
-		err = errors.Join(k.conn.Close())
+		err = errors.Join(err, k.conn.Close())
 		k.conn = nil
 	}
 

--- a/pkg/gofr/datasource/pubsub/kafka/kafka_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka_test.go
@@ -694,15 +694,53 @@ func TestKafkaClient_Subscribe_NotConnected(t *testing.T) {
 			},
 		},
 		logger: logging.NewMockLogger(logging.DEBUG),
+		mu:     &sync.RWMutex{},
 	}
 
-	mockConnection.EXPECT().Controller().Return(kafka.Broker{}, errClientNotConnected)
+	// ensureConnected probes Controller in the unlocked fast path and
+	// again under the write lock before attempting to reconnect.
+	mockConnection.EXPECT().Controller().Return(kafka.Broker{}, errClientNotConnected).AnyTimes()
 
 	msg, err = k.Subscribe(ctx, "test")
 
 	require.Error(t, err)
 	assert.Nil(t, msg)
 	assert.Equal(t, errClientNotConnected, err)
+}
+
+// TestEnsureConnected_ReconnectsAfterStaleAdminConn pins the runtime recovery
+// path: when the admin conn goes stale (broker idle timeout),
+// ensureConnected must replace k.conn instead of staying not-connected
+// forever. The brokers list uses the RFC 6761 reserved TLD ".invalid", which
+// is guaranteed unresolvable — so the re-dial fails deterministically. The
+// test asserts that the attempt is made and the failure surfaces.
+func TestEnsureConnected_ReconnectsAfterStaleAdminConn(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	staleConn := NewMockConnection(ctrl)
+	staleConn.EXPECT().Controller().Return(kafka.Broker{}, errClientNotConnected).AnyTimes()
+
+	k := &kafkaClient{
+		dialer: &kafka.Dialer{Timeout: time.Millisecond},
+		config: Config{Brokers: []string{"broker.invalid:0"}},
+		conn: &multiConn{
+			conns: []Connection{staleConn},
+		},
+		logger: logging.NewMockLogger(logging.DEBUG),
+		mu:     &sync.RWMutex{},
+	}
+
+	// Stale conn is detected, reconnect is attempted, but the unresolvable
+	// broker makes connectToBrokers fail — ensureConnected returns false.
+	assert.False(t, k.ensureConnected(t.Context()))
+
+	// reconnectAdminLocked itself surfaces the dial error; the caller must
+	// hold connMu for writing.
+	k.connMu.Lock()
+	err := k.reconnectAdminLocked(t.Context())
+	k.connMu.Unlock()
+	require.Error(t, err)
 }
 
 func TestKafkaClient_Query_Failures(t *testing.T) {
@@ -718,12 +756,14 @@ func TestKafkaClient_Query_Failures(t *testing.T) {
 			setupClient: func() *kafkaClient {
 				ctrl := gomock.NewController(t)
 				mockConnection := NewMockConnection(ctrl)
-				mockConnection.EXPECT().Controller().Return(kafka.Broker{}, errClientNotConnected)
+				mockConnection.EXPECT().Controller().Return(kafka.Broker{}, errClientNotConnected).AnyTimes()
 
 				return &kafkaClient{
 					conn: &multiConn{
 						conns: []Connection{mockConnection},
 					},
+					logger: logging.NewMockLogger(logging.DEBUG),
+					mu:     &sync.RWMutex{},
 				}
 			},
 			topic:       "test-topic",

--- a/pkg/gofr/datasource/pubsub/kafka/kafka_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka_test.go
@@ -774,7 +774,11 @@ func TestKafkaClient_Query_Failures(t *testing.T) {
 			setupClient: func() *kafkaClient {
 				ctrl := gomock.NewController(t)
 				mockConnection := NewMockConnection(ctrl)
-				mockConnection.EXPECT().Controller().Return(kafka.Broker{}, nil)
+				// Query short-circuits on the empty-topic check before
+				// ever touching ensureConnected, so Controller() must
+				// not be called. Allow zero or more calls so the test
+				// stays robust if the order is revisited.
+				mockConnection.EXPECT().Controller().Return(kafka.Broker{}, nil).AnyTimes()
 
 				return &kafkaClient{
 					conn: &multiConn{

--- a/pkg/gofr/datasource/pubsub/kafka/reconnect_concurrency_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/reconnect_concurrency_test.go
@@ -252,6 +252,7 @@ func TestClose_ConcurrentEnsureConnected_NoRace(t *testing.T) {
 		// Stagger Close slightly so it lands during the ensureConnected
 		// loop above.
 		time.Sleep(time.Millisecond)
+
 		_ = k.Close()
 	}()
 

--- a/pkg/gofr/datasource/pubsub/kafka/reconnect_concurrency_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/reconnect_concurrency_test.go
@@ -1,0 +1,266 @@
+package kafka
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"gofr.dev/pkg/gofr/logging"
+)
+
+// newStaleClient builds a kafkaClient whose admin probe always fails (stale
+// conn) and whose configured broker is RFC 6761 ".invalid", so the reconnect
+// path runs deterministically and fast against an unresolvable host.
+func newStaleClient(t *testing.T) (*kafkaClient, *MockConnection) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	stale := NewMockConnection(ctrl)
+	stale.EXPECT().Controller().Return(kafka.Broker{}, errClientNotConnected).AnyTimes()
+
+	k := &kafkaClient{
+		dialer: &kafka.Dialer{Timeout: time.Millisecond},
+		config: Config{Brokers: []string{"broker.invalid:0"}},
+		conn: &multiConn{
+			conns: []Connection{stale},
+		},
+		logger: logging.NewMockLogger(logging.DEBUG),
+		mu:     &sync.RWMutex{},
+	}
+
+	return k, stale
+}
+
+// TestEnsureConnected_ConcurrentCallers_NoRace fans out many goroutines into
+// ensureConnected at once. The reconnect always fails (unresolvable host),
+// but the test pins down two properties: (a) -race finds no data race on
+// k.conn / k.dialer despite concurrent reads via isConnected and writes via
+// reconnectAdminLocked, and (b) every caller sees a consistent boolean
+// result rather than a torn state.
+func TestEnsureConnected_ConcurrentCallers_NoRace(t *testing.T) {
+	k, _ := newStaleClient(t)
+
+	const goroutines = 64
+
+	var (
+		wg     sync.WaitGroup
+		falses int64
+	)
+
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+
+			if !k.ensureConnected(t.Context()) {
+				atomic.AddInt64(&falses, 1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Reconnect can never succeed against an unresolvable broker, so every
+	// caller must observe false — never true (which would indicate the
+	// double-checked locking misclassified state).
+	assert.Equal(t, int64(goroutines), atomic.LoadInt64(&falses))
+}
+
+// TestEnsureConnected_AdminMethods_NoRace exercises the admin entry points
+// (Controller, CreateTopic, DeleteTopic) concurrently with ensureConnected.
+// reconnectAdminLocked swaps and closes k.conn under connMu.Lock; the admin
+// methods take connMu.RLock. -race is the actual assertion: a missing lock
+// on either side would be flagged.
+func TestEnsureConnected_AdminMethods_NoRace(t *testing.T) {
+	k, _ := newStaleClient(t)
+
+	const iters = 200
+
+	var wg sync.WaitGroup
+
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < iters; i++ {
+			_ = k.ensureConnected(t.Context())
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < iters; i++ {
+			_, _ = k.Controller()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < iters; i++ {
+			_ = k.CreateTopic(t.Context(), "x")
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < iters; i++ {
+			_ = k.DeleteTopic(t.Context(), "x")
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestEnsureConnected_HealthConcurrent_NoRace pins that Health() — which
+// reads k.conn and the inner k.conn.mu lock — does not race with the swap
+// performed by reconnectAdminLocked. Without connMu around the Health body,
+// the reconnect path could free the multiConn while Health was still reading
+// it.
+func TestEnsureConnected_HealthConcurrent_NoRace(t *testing.T) {
+	k, stale := newStaleClient(t)
+
+	// Health walks each broker conn and calls ReadPartitions / RemoteAddr
+	// / Controller. The mock from newStaleClient only stubs Controller, so
+	// flesh out the rest with permissive expectations.
+	stale.EXPECT().ReadPartitions(gomock.Any()).Return(nil, errClientNotConnected).AnyTimes()
+	stale.EXPECT().RemoteAddr().Return(&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9092}).AnyTimes()
+
+	// Health uses k.writer.Stats(); supply a no-op writer so the call
+	// path completes without nil deref.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	w := NewMockWriter(ctrl)
+	w.EXPECT().Stats().Return(kafka.WriterStats{}).AnyTimes()
+	k.writer = w
+
+	const iters = 100
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < iters; i++ {
+			_ = k.ensureConnected(t.Context())
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < iters; i++ {
+			_ = k.Health()
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestGetNewReader_ConcurrentReconnect_NoRace exercises getNewReader (which
+// reads k.dialer) concurrently with reconnectAdminLocked (which writes it).
+// Subscribe routes through getNewReader while holding the reader-map lock,
+// so this is the realistic interleaving we need -race to clear. Calling
+// getNewReader directly also avoids Subscribe's 10 s sleep-on-retry, which
+// would make a goroutine-storm test impractically slow.
+func TestGetNewReader_ConcurrentReconnect_NoRace(t *testing.T) {
+	k, _ := newStaleClient(t)
+	k.config.ConsumerGroupID = "g1"
+
+	const iters = 200
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < iters; i++ {
+			r := k.getNewReader("t")
+			_ = r.Close()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < iters; i++ {
+			_ = k.ensureConnected(t.Context())
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestClose_ConcurrentEnsureConnected_NoRace runs Close while ensureConnected
+// is in flight. Close takes connMu.Lock and nils k.conn; ensureConnected
+// must see either the live or nil pointer atomically — never a torn read —
+// and must not double-close.
+func TestClose_ConcurrentEnsureConnected_NoRace(t *testing.T) {
+	k, _ := newStaleClient(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	w := NewMockWriter(ctrl)
+	w.EXPECT().Close().Return(nil).AnyTimes()
+	w.EXPECT().Stats().Return(kafka.WriterStats{}).AnyTimes()
+	k.writer = w
+
+	// The mock Connection in newStaleClient must accept a Close call from
+	// the multiConn shutdown path triggered by k.Close().
+	for _, c := range k.conn.conns {
+		mc, ok := c.(*MockConnection)
+		if !ok {
+			continue
+		}
+
+		mc.EXPECT().Close().Return(nil).AnyTimes()
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < 50; i++ {
+			_ = k.ensureConnected(t.Context())
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// Stagger Close slightly so it lands during the ensureConnected
+		// loop above.
+		time.Sleep(time.Millisecond)
+		_ = k.Close()
+	}()
+
+	wg.Wait()
+
+	// After Close, k.conn must be nil — confirms the lock-protected swap
+	// landed and was not undone by a concurrent reconnectAdmin.
+	k.connMu.RLock()
+	defer k.connMu.RUnlock()
+
+	assert.Nil(t, k.conn)
+}

--- a/pkg/gofr/datasource/pubsub/kafka/reconnect_success_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/reconnect_success_test.go
@@ -1,0 +1,130 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"gofr.dev/pkg/gofr/datasource/pubsub"
+	"gofr.dev/pkg/gofr/logging"
+)
+
+// stubConnectToBrokers replaces the package-level connectToBrokers var for
+// the duration of the test. The replacement returns the supplied conns and
+// nil error; production-side validation (empty broker list, all-fail, ...)
+// is bypassed because we want to exercise the post-dial swap path.
+func stubConnectToBrokers(t *testing.T, conns []Connection) {
+	t.Helper()
+
+	original := connectToBrokers
+
+	t.Cleanup(func() { connectToBrokers = original })
+
+	connectToBrokers = func(_ context.Context, _ []string, _ *kafka.Dialer, _ pubsub.Logger) ([]Connection, error) {
+		return conns, nil
+	}
+}
+
+// TestEnsureConnected_ReconnectSuccess pins the success path that
+// TestEnsureConnected_ReconnectsAfterStaleAdminConn does NOT cover: the
+// re-dial actually returns a healthy conn, ensureConnected returns true,
+// k.conn is swapped to the fresh multiConn, and the stale conn is closed
+// exactly once.
+func TestEnsureConnected_ReconnectSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Stale conn: probe fails, must be Closed by reconnectAdminLocked.
+	stale := NewMockConnection(ctrl)
+	stale.EXPECT().Controller().Return(kafka.Broker{}, errClientNotConnected).AnyTimes()
+	stale.EXPECT().Close().Return(nil).Times(1)
+
+	// Fresh conn returned by the stubbed connectToBrokers — Controller
+	// must succeed so the post-swap isConnected probe sees the healed
+	// state on the next call.
+	fresh := NewMockConnection(ctrl)
+	fresh.EXPECT().Controller().Return(kafka.Broker{Host: "broker", Port: 9092}, nil).AnyTimes()
+
+	stubConnectToBrokers(t, []Connection{fresh})
+
+	k := &kafkaClient{
+		dialer: &kafka.Dialer{Timeout: time.Millisecond},
+		config: Config{Brokers: []string{"broker.invalid:0"}},
+		conn: &multiConn{
+			conns: []Connection{stale},
+		},
+		logger: logging.NewMockLogger(logging.DEBUG),
+		mu:     &sync.RWMutex{},
+		// Pre-arm the throttle so we can assert it gets reset on
+		// successful reconnect.
+		reconnectErrLogAt: time.Now().Add(time.Hour),
+	}
+
+	oldConn := k.conn
+
+	// First call: stale → reconnect succeeds → returns true.
+	assert.True(t, k.ensureConnected(t.Context()))
+
+	// k.conn must point at a new multiConn whose conns slice contains
+	// fresh, not stale.
+	require.NotSame(t, oldConn, k.conn, "k.conn was not swapped")
+	require.Len(t, k.conn.conns, 1)
+	assert.Same(t, fresh, k.conn.conns[0])
+
+	// Throttle reset on success.
+	assert.True(t, k.reconnectErrLogAt.IsZero(), "reconnectErrLogAt should reset on success")
+
+	// Second call: must hit the fast path via isConnected without a
+	// second reconnect. (If it tried to reconnect, gomock's Times(1) on
+	// stale.Close() would fire twice and fail.)
+	assert.True(t, k.ensureConnected(t.Context()))
+}
+
+// TestEnsureConnected_ReconnectFailureLogThrottled covers the log-spam
+// throttle Copilot asked for: repeated failed reconnect attempts inside the
+// throttle window must NOT all be logged at error level.
+func TestEnsureConnected_ReconnectFailureLogThrottled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	stale := NewMockConnection(ctrl)
+	stale.EXPECT().Controller().Return(kafka.Broker{}, errClientNotConnected).AnyTimes()
+
+	// Stub connectToBrokers to always fail so each ensureConnected tries
+	// (and fails) the reconnect path under the write lock.
+	original := connectToBrokers
+
+	t.Cleanup(func() { connectToBrokers = original })
+
+	connectToBrokers = func(context.Context, []string, *kafka.Dialer, pubsub.Logger) ([]Connection, error) {
+		return nil, errFailedToConnectBrokers
+	}
+
+	k := &kafkaClient{
+		dialer: &kafka.Dialer{Timeout: time.Millisecond},
+		config: Config{Brokers: []string{"broker.invalid:0"}},
+		conn: &multiConn{
+			conns: []Connection{stale},
+		},
+		logger: logging.NewMockLogger(logging.DEBUG),
+		mu:     &sync.RWMutex{},
+	}
+
+	// First failure: throttle is zero-value, so this must arm it.
+	assert.False(t, k.ensureConnected(t.Context()))
+	require.False(t, k.reconnectErrLogAt.IsZero(), "first failure should arm the throttle")
+
+	armedAt := k.reconnectErrLogAt
+
+	// Second and third failures within the window: throttle must not
+	// move forward (we did not log Errorf, so we did not advance).
+	assert.False(t, k.ensureConnected(t.Context()))
+	assert.False(t, k.ensureConnected(t.Context()))
+	assert.Equal(t, armedAt, k.reconnectErrLogAt, "throttle must not advance on debug-logged failures")
+}


### PR DESCRIPTION
## Summary

Kafka subscribers currently get permanently stuck in `"kafka client not connected"` after the broker closes an idle TCP connection (default `connections.max.idle.ms = 10 min`). Once stale, every `Subscribe` / `Query` call returns `errClientNotConnected` for the rest of the process lifetime — `retryConnect()` only covers the initial startup failure, not runtime drops.

## Root cause

- `kafkaClient.conn` is a `multiConn` of admin TCP conns dialed **once** in `initialize()`.
- `isConnected()` calls `conn.Controller()` to probe — which keeps failing on a dead socket because nothing re-dials.
- `Subscribe()` and `Query()` return `errClientNotConnected` whenever `isConnected()` is false and never give the client a chance to heal.
- Publishes keep working because `segmentio/kafka-go`'s `kafka.Writer` handles its own reconnects.

## Fix

- New `ensureConnected(ctx)` — replaces the raw `isConnected` probe at the entry of `Subscribe` and `Query`.
- When stale, it acquires the client mutex, double-checks (another subscribe goroutine may have healed it already), and calls a new `reconnectAdmin(ctx)` helper that:
  - re-dials the broker list via the existing `connectToBrokers`,
  - swaps `k.conn` to a fresh `multiConn`,
  - closes the old conn,
  - leaves writer and per-topic readers alone so in-flight work isn't disrupted.

No public API change. Behavior on a genuinely unreachable cluster is unchanged — the reconnect attempt fails and the caller sees the same `errClientNotConnected` plus a 12 s backoff in `Subscribe`.

## Test plan

- [x] `go test ./pkg/gofr/datasource/pubsub/kafka/...` — all green
- [x] Updated `TestKafkaClient_Subscribe_NotConnected` and `TestKafkaClient_Query_Failures/Client_not_connected` to exercise the reconnect attempt; outward error is unchanged
- [x] New `TestEnsureConnected_ReconnectsAfterStaleAdminConn` pins the re-dial-on-stale behavior (the re-dial fails against an unresolvable host, but the attempt is made)
- [x] `go vet ./pkg/gofr/datasource/pubsub/kafka/...` clean

## How this was surfaced

Hit during a long-running demo (`examples/kafka-tracing-demo`): after ~11 min of idle, subscribers started spamming `"kafka client not connected"` every 12 s and never recovered, even though Kafka itself was healthy and publishes continued to succeed. Full trace of the diagnosis is in aryanmehrotra/go-talks#1.