### PR TITLE
ci(website): build source-bundle to --target builder

### DIFF
--- a/.github/workflows/website-prod.yml
+++ b/.github/workflows/website-prod.yml
@@ -90,9 +90,16 @@ jobs:
       # ghcr. The framework's docs/Dockerfile then resolves its
       # FROM ghcr.io/gofr-dev/website:${WEBSITE_TAG=latest} against
       # the local image.
+      #
+      # --target builder stops at the website Dockerfile's first
+      # stage, which contains /app source + node_modules + npm. The
+      # framework's docs/Dockerfile needs that to overlay docs and
+      # run `npm run build`; the default final nginx stage has no
+      # npm and would fail with `npm: not found`.
       - name: Build website source-bundle (with fresh data)
         run: |
           docker build \
+            --target builder \
             -t ghcr.io/gofr-dev/website:latest \
             -f ./website-src/Dockerfile \
             ./website-src/

--- a/.github/workflows/website-stage.yml
+++ b/.github/workflows/website-stage.yml
@@ -94,22 +94,29 @@ jobs:
           echo "TAG=$TAG" >> $GITHUB_ENV
 
       # Build the website source-bundle image locally with the
-      # freshly-refreshed data baked in. Tagged ghcr.io/...:latest
+      # freshly-refreshed data baked in. Tagged ghcr.io/...:stage
       # purely for the *local* docker daemon — we don't push it to
       # ghcr. The framework's docs/Dockerfile then resolves its
-      # FROM ghcr.io/gofr-dev/website:${WEBSITE_TAG=latest} against
+      # FROM ghcr.io/gofr-dev/website:${WEBSITE_TAG=stage} against
       # the local image.
+      #
+      # --target builder stops at the website Dockerfile's first
+      # stage, which contains /app source + node_modules + npm. The
+      # framework's docs/Dockerfile needs that to overlay docs and
+      # run `npm run build`; the default final nginx stage has no
+      # npm and would fail with `npm: not found`.
       - name: Build website source-bundle (with fresh data)
         run: |
           docker build \
-            -t ghcr.io/gofr-dev/website:latest \
+            --target builder \
+            -t ghcr.io/gofr-dev/website:stage \
             -f ./website-src/Dockerfile \
             ./website-src/
 
       - name: Build framework docs image
         run: |
           docker build \
-            --build-arg WEBSITE_TAG=latest \
+            --build-arg WEBSITE_TAG=stage \
             -t us-central1-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REGISTRY }}/${{ env.APP_NAME }}:${{ env.TAG }} \
             -f ./docs/Dockerfile \
             .


### PR DESCRIPTION
## Summary
- Stage and prod CI failed at `Build framework docs image` with `npm: not found` ([run 25388440921](https://github.com/gofr-dev/gofr/actions/runs/25388440921/job/74456045398)) because the website's `Dockerfile` is multi-stage and its final image is `nginx:1.27-alpine` — no npm, no `/app` source.
- The framework's `docs/Dockerfile` FROMs that image expecting a "shell" (npm + node_modules + `/app/src`) so it can overlay docs and run `npm run build`. Adding `--target builder` to the local source-bundle build stops at the website Dockerfile's first stage, which is the shape `docs/Dockerfile` actually needs.
- While here, aligned the stage workflow's local source-bundle tag and `WEBSITE_TAG` with `:stage` (was `:latest`) so the local docker tag matches the workflow's purpose. The tag stays local-only — neither workflow pushes the source-bundle image to ghcr.

## Test plan
- [ ] CI green on this PR (`Build and Deploy Website To Stage` no longer fails on `Build framework docs image`)
- [ ] After merge to `development`, stage deploy succeeds end-to-end
- [ ] On next prod tag, prod deploy succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)