### PR TITLE
fix(subscriber): emit error on handler panic recover to prevent commit of not processed messages

### DIFF
--- a/pkg/gofr/subscriber.go
+++ b/pkg/gofr/subscriber.go
@@ -68,6 +68,7 @@ func (s *SubscriptionManager) handleSubscription(ctx context.Context, topic stri
 		defer func() {
 			if r := recover(); r != nil {
 				panicRecovery(r, ctx.Logger)
+
 				err = errSubscriberHandlerPanic
 			}
 		}()

--- a/pkg/gofr/subscriber.go
+++ b/pkg/gofr/subscriber.go
@@ -2,12 +2,17 @@ package gofr
 
 import (
 	"context"
+	"errors"
 	"runtime/debug"
 	"time"
 
 	"gofr.dev/pkg/gofr/container"
 	"gofr.dev/pkg/gofr/logging"
 )
+
+// errSubscriberHandlerPanic marks a recovered panic in a subscription handler.
+// panicRecovery already logs the panic, so this must not be Errorf-logged again.
+var errSubscriberHandlerPanic = errors.New("subscriber handler panicked")
 
 type SubscribeFunc func(c *Context) error
 
@@ -58,17 +63,22 @@ func (s *SubscriptionManager) handleSubscription(ctx context.Context, topic stri
 	// newContext creates a new context from the msg.Context()
 	msgCtx := newContext(nil, msg, s.container)
 
-	err = func(ctx *Context) error {
+	err = func(ctx *Context) (err error) {
 		// TODO : Move panic recovery at central location which will manage for all the different cases.
 		defer func() {
-			panicRecovery(recover(), ctx.Logger)
+			if r := recover(); r != nil {
+				panicRecovery(r, ctx.Logger)
+				err = errSubscriberHandlerPanic
+			}
 		}()
 
 		return handler(ctx)
 	}(msgCtx)
+	if errors.Is(err, errSubscriberHandlerPanic) {
+		return nil
+	}
 	if err != nil {
 		s.container.Logger.Errorf("error in handler for topic %s: %v", topic, err)
-
 		return nil
 	}
 

--- a/pkg/gofr/subscriber_test.go
+++ b/pkg/gofr/subscriber_test.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"gofr.dev/pkg/gofr/container"
 	"gofr.dev/pkg/gofr/datasource"
 	"gofr.dev/pkg/gofr/datasource/pubsub"
 	"gofr.dev/pkg/gofr/datasource/pubsub/kafka"
+	"gofr.dev/pkg/gofr/logging"
 )
 
 var errSubscription = errors.New("subscription error")
@@ -55,4 +60,93 @@ func (mockSubscriber) Subscribe(ctx context.Context, topic string) (*pubsub.Mess
 
 func (mockSubscriber) Close() error {
 	return nil
+}
+
+const (
+	topicHandleSubPanic = "handle-sub-panic"
+	topicHandleSubOK    = "handle-sub-ok"
+	topicHandleSubErr   = "handle-sub-err"
+)
+
+// countingCommitter records Commit calls for tests.
+type countingCommitter struct {
+	n int
+}
+
+func (c *countingCommitter) Commit() {
+	c.n++
+}
+
+// handleSubscriptionTestPubSub returns messages with a counting committer for selected topics.
+// lastCommitter is the spy for the most recent Subscribe matching those topics.
+type handleSubscriptionTestPubSub struct {
+	mockSubscriber
+	lastCommitter *countingCommitter
+}
+
+func (h *handleSubscriptionTestPubSub) Subscribe(ctx context.Context, topic string) (*pubsub.Message, error) {
+	msg := pubsub.NewMessage(ctx)
+	msg.Topic = topic
+	msg.Value = []byte(`{}`)
+
+	switch topic {
+	case topicHandleSubPanic, topicHandleSubOK, topicHandleSubErr:
+		h.lastCommitter = &countingCommitter{}
+		msg.Committer = h.lastCommitter
+
+		return msg, nil
+	default:
+		return (&mockSubscriber{}).Subscribe(ctx, topic)
+	}
+}
+
+func TestSubscriptionManager_handleSubscription_SuccessCommits(t *testing.T) {
+	t.Parallel()
+
+	ps := &handleSubscriptionTestPubSub{}
+	c := &container.Container{
+		Logger: logging.NewMockLogger(logging.ERROR),
+		PubSub: ps,
+	}
+	s := SubscriptionManager{container: c}
+
+	err := s.handleSubscription(t.Context(), topicHandleSubOK, func(*Context) error { return nil })
+	require.NoError(t, err)
+	require.NotNil(t, ps.lastCommitter)
+	require.Equal(t, 1, ps.lastCommitter.n, "successful handler must commit once")
+}
+
+func TestSubscriptionManager_handleSubscription_PanicDoesNotCommit(t *testing.T) {
+	t.Parallel()
+
+	ps := &handleSubscriptionTestPubSub{}
+	c := &container.Container{
+		Logger: logging.NewMockLogger(logging.ERROR),
+		PubSub: ps,
+	}
+	s := SubscriptionManager{container: c}
+
+	err := s.handleSubscription(t.Context(), topicHandleSubPanic, func(*Context) error {
+		panic("boom")
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ps.lastCommitter)
+	require.Zero(t, ps.lastCommitter.n, "panic must not commit the message")
+}
+
+func TestSubscriptionManager_handleSubscription_HandlerErrorDoesNotCommit(t *testing.T) {
+	t.Parallel()
+
+	ps := &handleSubscriptionTestPubSub{}
+	c := &container.Container{
+		Logger: logging.NewMockLogger(logging.ERROR),
+		PubSub: ps,
+	}
+	s := SubscriptionManager{container: c}
+
+	handlerErr := errors.New("handler failed")
+	err := s.handleSubscription(t.Context(), topicHandleSubErr, func(*Context) error { return handlerErr })
+	require.NoError(t, err)
+	require.NotNil(t, ps.lastCommitter)
+	require.Zero(t, ps.lastCommitter.n, "handler error must not commit")
 }

--- a/pkg/gofr/subscriber_test.go
+++ b/pkg/gofr/subscriber_test.go
@@ -15,7 +15,10 @@ import (
 	"gofr.dev/pkg/gofr/logging"
 )
 
-var errSubscription = errors.New("subscription error")
+var (
+	errSubscription = errors.New("subscription error")
+	errHandlerFail  = errors.New("handler failed")
+)
 
 func subscriptionError(err string) error {
 	return fmt.Errorf("%w: %s", errSubscription, err)
@@ -144,8 +147,7 @@ func TestSubscriptionManager_handleSubscription_HandlerErrorDoesNotCommit(t *tes
 	}
 	s := SubscriptionManager{container: c}
 
-	handlerErr := errors.New("handler failed")
-	err := s.handleSubscription(t.Context(), topicHandleSubErr, func(*Context) error { return handlerErr })
+	err := s.handleSubscription(t.Context(), topicHandleSubErr, func(*Context) error { return errHandlerFail })
 	require.NoError(t, err)
 	require.NotNil(t, ps.lastCommitter)
 	require.Zero(t, ps.lastCommitter.n, "handler error must not commit")


### PR DESCRIPTION

**Description:**

- Fixes #3425.

When a subscription handler **panicked**, `recover()` in the deferred function stopped the panic, but the anonymous function still completed with the **zero value** for its `error` result (`nil`). From the outside that looked like a successful handler run, so `handleSubscription` went on to **`Commit()`** the message even though the handler had not finished successfully. 


To fix:
- Used a sentinel error with errors.Is to identify the specific panic error and skip commit and avoid duplicate Errorf logging after panicRecovery.
- Added tests for handler panic, success, and  error paths.

**Breaking Changes (if applicable):**

-  Messages processed by handlers now ae retried if the handler panics

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

