### PR TITLE
test: regression guard for non-blocking circuit-breaker recovery

### DIFF
--- a/pkg/gofr/service/circuit_breaker_test.go
+++ b/pkg/gofr/service/circuit_breaker_test.go
@@ -1179,6 +1179,7 @@ func TestCircuitBreaker_SlowHealthCheckDoesNotBlock(t *testing.T) {
 	go func() {
 		open := cb.isOpen()
 		recovered := cb.tryCircuitRecovery()
+
 		bDone <- bResult{isOpen: open, recovered: recovered}
 	}()
 

--- a/pkg/gofr/service/circuit_breaker_test.go
+++ b/pkg/gofr/service/circuit_breaker_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1113,4 +1114,94 @@ func TestCircuitBreaker_MixedHTTPMethods(t *testing.T) {
 
 	// All 5 methods should complete in ~1s (parallel)
 	assert.Less(t, totalTime, 2*time.Second, "Different HTTP methods should execute in parallel")
+}
+
+// TestCircuitBreaker_SlowHealthCheckDoesNotBlock asserts that while tryCircuitRecovery's
+// health probe is in-flight, other circuit-breaker operations are not blocked by the
+// exclusive lock. Regression guard for the fix in tryCircuitRecovery that releases
+// cb.mu before calling healthCheck.
+//
+// Built directly on the unexported circuitBreaker struct (without NewCircuitBreaker)
+// so the background health-check ticker doesn't introduce timing races.
+func TestCircuitBreaker_SlowHealthCheckDoesNotBlock(t *testing.T) {
+	healthEntered := make(chan struct{}, 1)
+	releaseHealth := make(chan struct{})
+
+	ctrl := gomock.NewController(t)
+	mockHTTP := NewMockHTTP(ctrl)
+
+	mockHTTP.EXPECT().
+		HealthCheck(gomock.Any()).
+		DoAndReturn(func(_ context.Context) *Health {
+			select {
+			case healthEntered <- struct{}{}:
+			default:
+			}
+
+			<-releaseHealth
+
+			return &Health{Status: serviceUp}
+		}).
+		AnyTimes()
+
+	cb := &circuitBreaker{
+		state:       OpenState,
+		threshold:   1,
+		interval:    50 * time.Millisecond,
+		lastChecked: time.Now().Add(-1 * time.Hour), // stale, so time.Since > interval
+		HTTP:        mockHTTP,
+	}
+
+	// Goroutine A triggers recovery; its HealthCheck will block until releaseHealth is closed.
+	aDone := make(chan bool, 1)
+
+	go func() {
+		aDone <- cb.tryCircuitRecovery()
+	}()
+
+	// Wait until the health check is actually in-flight (lock has been released by A).
+	select {
+	case <-healthEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HealthCheck never invoked")
+	}
+
+	// Goroutine B issues independent operations. With the fix, none should be blocked
+	// by A's in-flight health check. Without the fix, isOpen()/tryCircuitRecovery would
+	// wait on cb.mu held by A across the slow HealthCheck call.
+	type bResult struct {
+		isOpen    bool
+		recovered bool
+	}
+
+	bDone := make(chan bResult, 1)
+
+	go func() {
+		open := cb.isOpen()
+		recovered := cb.tryCircuitRecovery()
+		bDone <- bResult{isOpen: open, recovered: recovered}
+	}()
+
+	select {
+	case r := <-bDone:
+		assert.True(t, r.isOpen, "circuit should still report open while health check is in-flight")
+		assert.False(t, r.recovered, "second tryCircuitRecovery must short-circuit, not block")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("concurrent operations were blocked by the in-flight health check")
+	}
+
+	// Unblock A and verify recovery completed successfully.
+	close(releaseHealth)
+
+	select {
+	case ok := <-aDone:
+		require.True(t, ok, "tryCircuitRecovery should succeed after healthy probe")
+	case <-time.After(2 * time.Second):
+		t.Fatal("tryCircuitRecovery never returned")
+	}
+
+	cb.mu.RLock()
+	state := cb.state
+	cb.mu.RUnlock()
+	assert.Equal(t, ClosedState, state, "circuit should be closed after successful recovery")
 }


### PR DESCRIPTION
## Summary

Adds `TestCircuitBreaker_SlowHealthCheckDoesNotBlock` — a regression guard for the fix in #3255 that releases `cb.mu` before calling `cb.healthCheck()` in `tryCircuitRecovery()`.

The test drives the unexported `circuitBreaker` struct directly with a `MockHTTP` whose `HealthCheck` blocks on a channel, so the assertion is deterministic and doesn't depend on the background `startHealthChecks` ticker timing.

What it asserts:
- While goroutine A's recovery health-probe is in-flight, goroutine B's `isOpen()` and second `tryCircuitRecovery()` must return promptly (not block on `cb.mu`).
- After unblocking, the circuit transitions to `ClosedState`.

Verified:
- Passes 10/10 with `-race` against the fix in #3255.
- Fails cleanly in ~0.5s (assertion, not hang) when `tryCircuitRecovery` is reverted to the old write-lock-held-across-healthCheck behavior.

## Dependency

**This PR depends on #3255.** On `development` alone (without #3255), this test fails because `isOpen()` still uses an exclusive lock and `tryCircuitRecovery` holds it across `healthCheck`. Merge order: #3255 → this PR.

## Test plan

- [x] `go test -race -count=10 -run TestCircuitBreaker_SlowHealthCheckDoesNotBlock ./pkg/gofr/service/...` (passes after #3255)
- [x] Same test fails cleanly on pre-fix code (confirms it's a real regression guard)
- [x] `go vet ./pkg/gofr/service/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)