### PR TITLE
fix: sanitize non-UTF-8 paths in HTTP metrics middleware to prevent Prometheus scrape failures

### DIFF
--- a/pkg/gofr/http/middleware/metrics.go
+++ b/pkg/gofr/http/middleware/metrics.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -120,7 +121,17 @@ func metricsPath(r *http.Request) (path string, templated bool) {
 		path, templated = r.URL.Path, false
 	}
 
-	return strings.TrimSuffix(path, "/"), templated
+	path = strings.TrimSuffix(path, "/")
+
+	// A non-UTF-8 path label fails the whole scrape -- Prometheus and OTLP both
+	// require valid UTF-8 -- so collapse any invalid path (e.g. an over-long
+	// encoding from a probe) to a fixed sentinel. It is not a real route
+	// template, so it must never become a cache key. (#3460)
+	if !utf8.ValidString(path) {
+		return "/<invalid_utf8>", false
+	}
+
+	return path, templated
 }
 
 // histogramName is the request-duration histogram this middleware records.

--- a/pkg/gofr/http/middleware/metrics_test.go
+++ b/pkg/gofr/http/middleware/metrics_test.go
@@ -204,6 +204,31 @@ func TestMetrics_StaticFileWithQueryParam(t *testing.T) {
 		[]string{"path", "/static/example.js", "method", "GET", "status", "200"})
 }
 
+func TestMetrics_NonUTF8Path(t *testing.T) {
+	mockMetrics := &mockMetrics{}
+
+	mockMetrics.On("RecordHistogram", mock.Anything, "app_http_response", mock.Anything,
+		[]string{"path", "/<invalid_utf8>", "method", "GET", "status", "404"}).Return(nil)
+
+	router := mux.NewRouter()
+	// Catch-all so gorilla/mux routes the request and the middleware fires.
+	router.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}).Name("catch-all")
+
+	router.Use(Metrics(mockMetrics))
+
+	// \xc0\x2e is an invalid (over-long) UTF-8 sequence.
+	req := httptest.NewRequest(http.MethodGet, "/\xc0\x2e\xc0\x2e/winnt/win.ini", http.NoBody)
+	rr := httptest.NewRecorder()
+
+	// Must not panic and must record the sentinel label.
+	router.ServeHTTP(rr, req)
+
+	mockMetrics.AssertCalled(t, "RecordHistogram", mock.Anything, "app_http_response", mock.Anything,
+		[]string{"path", "/<invalid_utf8>", "method", "GET", "status", "404"})
+}
+
 // mockOptRecorder implements both optional fast-path interfaces so the
 // measurement-option path is exercised, and records what it was handed.
 type mockOptRecorder struct {


### PR DESCRIPTION
Fixes #3460

### What does this PR do?
This PR addresses a vulnerability where non-UTF-8 HTTP paths (commonly sent by vulnerability scanners like Nessus probing for IIS directory traversals) poison the OTel registry, causing subsequent Prometheus scrapes to fail with a `label value ... is not valid UTF-8` error.

**Changes made:**
- **Middleware Guard:** Imported `unicode/utf8` and added a `utf8.ValidString(path)` check in `pkg/gofr/http/middleware/metrics.go` right before the trailing slash trim.
- **Label Sanitization:** If an invalid UTF-8 string is detected, the path label is sanitized to `/<invalid_utf8>`. This prevents the scrape failure and ensures bounded cardinality so the registry isn't flooded with arbitrary byte sequences.
- **Testing:** Added `TestMetrics_NonUTF8Path` to verify that requests containing invalid bytes (e.g., `/\xc0\x2e\xc0\x2e/winnt/win.ini`) do not panic and correctly record the sanitized label.

### Note to Reviewers:
All middleware tests (`go test ./pkg/gofr/http/middleware/...`) pass successfully locally.