### PR TITLE
fix: prevent concurrent map panic during kafka client teardown

### DIFF
--- a/pkg/gofr/datasource/pubsub/kafka/conn.go
+++ b/pkg/gofr/datasource/pubsub/kafka/conn.go
@@ -61,11 +61,13 @@ func (k *kafkaClient) initialize(ctx context.Context) error {
 
 	k.dialer = dialer
 	k.conn = multi
-	k.connMu.Unlock()
 
-	// writer and reader are not guarded by connMu — k.mu protects the
-	// reader map; writer is set once and never swapped.
+	// writer is published under connMu alongside conn: retryConnect calls
+	// initialize from its own goroutine, so this is a pointer swap that
+	// Publish, Close and Health can all be reading concurrently.
 	k.writer = writer
+
+	k.connMu.Unlock()
 
 	// retryConnect calls initialize from its own goroutine, so this swap can
 	// land while a Subscribe is reading or growing the map. Take k.mu for it,

--- a/pkg/gofr/datasource/pubsub/kafka/conn.go
+++ b/pkg/gofr/datasource/pubsub/kafka/conn.go
@@ -44,6 +44,21 @@ func (k *kafkaClient) initialize(ctx context.Context) error {
 	k.logger.Logf("connected to %d Kafka brokers", len(conns))
 
 	k.connMu.Lock()
+
+	// Close only signals the retry goroutine; it cannot interrupt a dial
+	// already in flight. Re-check under the same lock Close takes, so a
+	// retryConnect that got past its own check cannot revive a closed client
+	// and leak this conn pool and writer for the life of the process.
+	// A nil k.closed (a client built without New) never fires, so the
+	// default arm is the normal path.
+	select {
+	case <-k.closed:
+		k.connMu.Unlock()
+
+		return errors.Join(errClientClosed, multi.Close(), writer.Close())
+	default:
+	}
+
 	k.dialer = dialer
 	k.conn = multi
 	k.connMu.Unlock()
@@ -51,7 +66,19 @@ func (k *kafkaClient) initialize(ctx context.Context) error {
 	// writer and reader are not guarded by connMu — k.mu protects the
 	// reader map; writer is set once and never swapped.
 	k.writer = writer
-	k.reader = reader
+
+	// retryConnect calls initialize from its own goroutine, so this swap can
+	// land while a Subscribe is reading or growing the map. Take k.mu for it,
+	// the same lock Subscribe uses, and keep any readers a concurrent
+	// Subscribe already created rather than dropping them on the floor —
+	// their committers are already handed out to callers.
+	k.mu.Lock()
+
+	if k.reader == nil {
+		k.reader = reader
+	}
+
+	k.mu.Unlock()
 
 	return nil
 }

--- a/pkg/gofr/datasource/pubsub/kafka/errors.go
+++ b/pkg/gofr/datasource/pubsub/kafka/errors.go
@@ -19,4 +19,5 @@ var (
 	errClientCertLoad              = errors.New("failed to load client certificate")
 	errNotController               = errors.New("not a controller")
 	errUnreachable                 = errors.New("unreachable")
+	errClientClosed                = errors.New("kafka client is closed")
 )

--- a/pkg/gofr/datasource/pubsub/kafka/health.go
+++ b/pkg/gofr/datasource/pubsub/kafka/health.go
@@ -15,8 +15,15 @@ func (k *kafkaClient) Health() datasource.Health {
 		Details: make(map[string]any),
 	}
 
-	// Hold connMu across the whole health probe so reconnectAdmin cannot
-	// swap and close the conn we are reading from underneath us.
+	// Snapshot the readers *before* taking connMu. Subscribe holds k.mu and
+	// then takes connMu inside getNewReader, so taking k.mu while holding
+	// connMu here would be a lock-order inversion: a pending connMu writer
+	// parks Subscribe's RLock, Subscribe still holds k.mu, and this probe
+	// waits on k.mu while holding the connMu read the writer needs.
+	readers := k.snapshotReaders()
+
+	// Hold connMu across the rest of the health probe so reconnectAdmin
+	// cannot swap and close the conn we are reading from underneath us.
 	k.connMu.RLock()
 	defer k.connMu.RUnlock()
 
@@ -37,7 +44,7 @@ func (k *kafkaClient) Health() datasource.Health {
 	health.Details["brokers"] = brokerStatus
 	health.Details["backend"] = "KAFKA"
 	health.Details["writer"] = k.getWriterStatsAsMap()
-	health.Details["readers"] = k.getReaderStatsAsMap()
+	health.Details["readers"] = k.getReaderStatsAsMap(readers)
 
 	return health
 }
@@ -97,10 +104,10 @@ func checkBroker(conn Connection, controllerAddr *string) map[string]any {
 	return status
 }
 
-func (k *kafkaClient) getReaderStatsAsMap() []any {
-	readerStats := make([]any, 0)
+func (k *kafkaClient) getReaderStatsAsMap(readers []Reader) []any {
+	readerStats := make([]any, 0, len(readers))
 
-	for _, reader := range k.reader {
+	for _, reader := range readers {
 		var readerStat map[string]any
 		if err := convertStructToMap(reader.Stats(), &readerStat); err != nil {
 			k.logger.Errorf("kafka Reader Stats processing failed: %v", err)

--- a/pkg/gofr/datasource/pubsub/kafka/helper.go
+++ b/pkg/gofr/datasource/pubsub/kafka/helper.go
@@ -56,11 +56,28 @@ func validateRequiredFields(conf *Config) error {
 
 // retryConnect handles the retry mechanism for connecting to the Kafka broker.
 func (k *kafkaClient) retryConnect(ctx context.Context) {
+	timer := time.NewTimer(defaultRetryTimeout)
+	defer timer.Stop()
+
 	for {
-		time.Sleep(defaultRetryTimeout)
+		select {
+		case <-k.closed:
+			return
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			timer.Reset(defaultRetryTimeout)
+		}
 
 		err := k.initialize(ctx)
 		if err != nil {
+			// Close landed while this dial was in flight. Nothing was
+			// published and the dialed conn is already shut; logging a
+			// connect failure here would be misleading.
+			if errors.Is(err, errClientClosed) {
+				return
+			}
+
 			var brokers any
 
 			if len(k.config.Brokers) > 1 {

--- a/pkg/gofr/datasource/pubsub/kafka/kafka.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka.go
@@ -266,7 +266,16 @@ func (k *kafkaClient) Subscribe(ctx context.Context, topic string) (*pubsub.Mess
 }
 
 func (k *kafkaClient) Close() (err error) {
+	k.mu.RLock()
+
+	readers := make([]Reader, 0, len(k.reader))
 	for _, r := range k.reader {
+		readers = append(readers, r)
+	}
+
+	k.mu.RUnlock()
+
+	for _, r := range readers {
 		err = errors.Join(err, r.Close())
 	}
 

--- a/pkg/gofr/datasource/pubsub/kafka/kafka.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka.go
@@ -60,8 +60,10 @@ type kafkaClient struct {
 	writer Writer
 	reader map[string]Reader
 
-	// mu guards the reader map.
-	mu *sync.RWMutex
+	// mu guards the reader map. A value, not a pointer, so the zero
+	// kafkaClient is usable: Health and Close take it, and a nil pointer
+	// here panicked on any client built without New.
+	mu sync.RWMutex
 	// connMu guards conn/dialer pointer swaps performed by reconnectAdmin.
 	// Read-lock holders use the admin connection concurrently; the
 	// write-lock holder swaps the pointer and closes the old multiConn.
@@ -78,6 +80,13 @@ type kafkaClient struct {
 	logger  pubsub.Logger
 	config  Config
 	metrics Metrics
+
+	// closed is shut by Close to stop the retryConnect goroutine New starts
+	// when the first connect attempt fails. Without it that goroutine runs
+	// for the life of the process on a context nobody can cancel, retrying
+	// every defaultRetryTimeout long after the client was closed.
+	closed    chan struct{}
+	closeOnce sync.Once
 }
 
 func New(conf *Config, logger pubsub.Logger, metrics Metrics) *kafkaClient { //nolint:revive // New allows
@@ -99,7 +108,7 @@ func New(conf *Config, logger pubsub.Logger, metrics Metrics) *kafkaClient { //n
 		logger:  logger,
 		config:  *conf,
 		metrics: metrics,
-		mu:      &sync.RWMutex{},
+		closed:  make(chan struct{}),
 	}
 	ctx := context.Background()
 
@@ -266,16 +275,15 @@ func (k *kafkaClient) Subscribe(ctx context.Context, topic string) (*pubsub.Mess
 }
 
 func (k *kafkaClient) Close() (err error) {
-	k.mu.RLock()
+	// Stop the retryConnect goroutine first, so it cannot dial or swap the
+	// conn out from under the teardown below.
+	k.closeOnce.Do(func() {
+		if k.closed != nil {
+			close(k.closed)
+		}
+	})
 
-	readers := make([]Reader, 0, len(k.reader))
-	for _, r := range k.reader {
-		readers = append(readers, r)
-	}
-
-	k.mu.RUnlock()
-
-	for _, r := range readers {
+	for _, r := range k.snapshotReaders() {
 		err = errors.Join(err, r.Close())
 	}
 
@@ -293,4 +301,20 @@ func (k *kafkaClient) Close() (err error) {
 	k.connMu.Unlock()
 
 	return err
+}
+
+// snapshotReaders copies the reader map under RLock so callers can work on the
+// readers without holding it. Nothing that calls this may already hold connMu:
+// Subscribe takes k.mu and then connMu inside getNewReader, so acquiring them
+// the other way round is a lock-order inversion.
+func (k *kafkaClient) snapshotReaders() []Reader {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	readers := make([]Reader, 0, len(k.reader))
+	for _, r := range k.reader {
+		readers = append(readers, r)
+	}
+
+	return readers
 }

--- a/pkg/gofr/datasource/pubsub/kafka/kafka.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka.go
@@ -130,12 +130,13 @@ func (k *kafkaClient) Publish(ctx context.Context, topic string, message []byte)
 
 	k.metrics.IncrementCounter(ctx, "app_pubsub_publish_total_count", "topic", topic)
 
-	if k.writer == nil || topic == "" {
+	writer := k.snapshotWriter()
+	if writer == nil || topic == "" {
 		return errPublisherNotConfigured
 	}
 
 	start := time.Now()
-	err := k.writer.WriteMessages(ctx,
+	err := writer.WriteMessages(ctx,
 		kafka.Message{
 			Topic:   topic,
 			Value:   message,
@@ -287,11 +288,12 @@ func (k *kafkaClient) Close() (err error) {
 		err = errors.Join(err, r.Close())
 	}
 
+	k.connMu.Lock()
+
 	if k.writer != nil {
 		err = errors.Join(err, k.writer.Close())
+		k.writer = nil
 	}
-
-	k.connMu.Lock()
 
 	if k.conn != nil {
 		err = errors.Join(err, k.conn.Close())
@@ -301,6 +303,17 @@ func (k *kafkaClient) Close() (err error) {
 	k.connMu.Unlock()
 
 	return err
+}
+
+// snapshotWriter reads k.writer under connMu, which initialize takes when it
+// publishes one. Callers use the returned value rather than k.writer so a
+// retryConnect swapping the pointer cannot race the read, and so no network
+// call is made while holding the lock.
+func (k *kafkaClient) snapshotWriter() Writer {
+	k.connMu.RLock()
+	defer k.connMu.RUnlock()
+
+	return k.writer
 }
 
 // snapshotReaders copies the reader map under RLock so callers can work on the

--- a/pkg/gofr/datasource/pubsub/kafka/kafka.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka.go
@@ -238,7 +238,7 @@ func (k *kafkaClient) Subscribe(ctx context.Context, topic string) (*pubsub.Mess
 	m := pubsub.NewMessage(ctx)
 	m.Value = msg.Value
 	m.Topic = topic
-	m.Committer = newKafkaMessage(&msg, k.reader[topic], k.logger)
+	m.Committer = newKafkaMessage(&msg, reader, k.logger)
 
 	end := time.Since(start)
 

--- a/pkg/gofr/datasource/pubsub/kafka/kafka_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka_test.go
@@ -446,7 +446,7 @@ func TestKafkaClient_Close(t *testing.T) {
 	mockReader := NewMockReader(ctrl)
 	mockConn := NewMockConnection(ctrl)
 
-	k := kafkaClient{reader: map[string]Reader{"test-topic": mockReader}, writer: mockWriter, conn: &multiConn{
+	k := kafkaClient{mu: &sync.RWMutex{}, reader: map[string]Reader{"test-topic": mockReader}, writer: mockWriter, conn: &multiConn{
 		conns: []Connection{
 			mockConn,
 		},
@@ -471,7 +471,7 @@ func TestKafkaClient_CloseError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockWriter := NewMockWriter(ctrl)
-	k := kafkaClient{writer: mockWriter}
+	k := kafkaClient{mu: &sync.RWMutex{}, writer: mockWriter}
 
 	mockWriter.EXPECT().Close().Return(errClose)
 

--- a/pkg/gofr/datasource/pubsub/kafka/kafka_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/kafka_test.go
@@ -318,7 +318,6 @@ func TestKafkaClient_SubscribeSuccess(t *testing.T) {
 			Brokers:         []string{"kafkabroker"},
 			OffSet:          -1,
 		},
-		mu:      &sync.RWMutex{},
 		metrics: mockMetrics,
 	}
 
@@ -415,7 +414,6 @@ func TestKafkaClient_SubscribeError(t *testing.T) {
 			Brokers:         []string{"kafkabroker"},
 			OffSet:          -1,
 		},
-		mu:      &sync.RWMutex{},
 		metrics: mockMetrics,
 	}
 
@@ -446,7 +444,7 @@ func TestKafkaClient_Close(t *testing.T) {
 	mockReader := NewMockReader(ctrl)
 	mockConn := NewMockConnection(ctrl)
 
-	k := kafkaClient{mu: &sync.RWMutex{}, reader: map[string]Reader{"test-topic": mockReader}, writer: mockWriter, conn: &multiConn{
+	k := kafkaClient{reader: map[string]Reader{"test-topic": mockReader}, writer: mockWriter, conn: &multiConn{
 		conns: []Connection{
 			mockConn,
 		},
@@ -471,7 +469,7 @@ func TestKafkaClient_CloseError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockWriter := NewMockWriter(ctrl)
-	k := kafkaClient{mu: &sync.RWMutex{}, writer: mockWriter}
+	k := kafkaClient{writer: mockWriter}
 
 	mockWriter.EXPECT().Close().Return(errClose)
 
@@ -564,9 +562,17 @@ func TestNewKafkaClient(t *testing.T) {
 			k := New(&tc.config, logging.NewMockLogger(logging.ERROR), NewMockMetrics(ctrl))
 			if tc.expectNil {
 				assert.Nil(t, k)
-			} else {
-				assert.NotNil(t, k)
+
+				return
 			}
+
+			assert.NotNil(t, k)
+
+			// These configs point at brokers that do not resolve, so New
+			// leaves a retryConnect goroutine behind. Close stops it; without
+			// that it outlives the test and races the connectToBrokers stub
+			// that reconnect_success_test.go restores in its own cleanup.
+			t.Cleanup(func() { _ = k.Close() })
 		})
 	}
 }
@@ -694,7 +700,6 @@ func TestKafkaClient_Subscribe_NotConnected(t *testing.T) {
 			},
 		},
 		logger: logging.NewMockLogger(logging.DEBUG),
-		mu:     &sync.RWMutex{},
 	}
 
 	// ensureConnected probes Controller in the unlocked fast path and
@@ -728,7 +733,6 @@ func TestEnsureConnected_ReconnectsAfterStaleAdminConn(t *testing.T) {
 			conns: []Connection{staleConn},
 		},
 		logger: logging.NewMockLogger(logging.DEBUG),
-		mu:     &sync.RWMutex{},
 	}
 
 	// Stale conn is detected, reconnect is attempted, but the unresolvable
@@ -763,7 +767,6 @@ func TestKafkaClient_Query_Failures(t *testing.T) {
 						conns: []Connection{mockConnection},
 					},
 					logger: logging.NewMockLogger(logging.DEBUG),
-					mu:     &sync.RWMutex{},
 				}
 			},
 			topic:       "test-topic",
@@ -979,7 +982,6 @@ func TestKafkaClient_Subscribe_RaceDetector(t *testing.T) {
 		logger:  logging.NewMockLogger(logging.DEBUG),
 		metrics: mockMetrics,
 		reader:  make(map[string]Reader),
-		mu:      &sync.RWMutex{},
 	}
 
 	// Create mock reader

--- a/pkg/gofr/datasource/pubsub/kafka/lock_order_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/lock_order_test.go
@@ -1,0 +1,104 @@
+package kafka
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+)
+
+// TestHealthSubscribe_NoLockOrderInversion guards the order in which k.mu and
+// connMu are taken.
+//
+// Subscribe holds k.mu across getNewReader, which takes connMu - so k.mu comes
+// first, and every other path must use that order too. Health briefly broke it:
+// it held connMu for the whole probe and then took k.mu inside
+// getReaderStatsAsMap. Go's RWMutex parks new readers once a writer is waiting,
+// so a concurrent connMu writer closes the cycle:
+//
+//	Health   holds connMu(R), wants k.mu
+//	Subscribe holds k.mu,     wants connMu(R)  - parked behind the writer
+//	writer                    wants connMu(W)  - waits on Health
+//
+// The subscribe side is modeled rather than called: the real Subscribe builds
+// a kafka.Reader against an unresolvable broker inside the lock, which makes
+// the same test take tens of seconds and assert on a deadline. What matters
+// here is only the acquisition order, so it is reproduced exactly and cheaply.
+// The production paths themselves are covered by the *_ConcurrentSubscribe_
+// race tests.
+func TestHealthSubscribe_NoLockOrderInversion(t *testing.T) {
+	const iterations = 2000
+
+	k := &kafkaClient{
+		conn: &multiConn{
+			conns: []Connection{&MockConn{addr: "127.0.0.1:9092", isHealthy: true, isControl: true}},
+		},
+		reader: make(map[string]Reader),
+		writer: &mockWriter{},
+		logger: &mockLogger{},
+	}
+
+	for i := range 2 {
+		k.reader["seed-"+strconv.Itoa(i)] = &statsReader{}
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		var wg sync.WaitGroup
+
+		wg.Add(3)
+
+		go func() { // Subscribe's order: k.mu -> connMu (via getNewReader)
+			defer wg.Done()
+
+			for i := range iterations {
+				k.mu.Lock()
+				k.connMu.RLock()
+				// Rotate over a small key set: the map must keep being written,
+				// but Health converts every reader's Stats to a map on each
+				// probe, so an ever-growing map makes this O(n^2) work rather
+				// than a lock-contention test.
+				k.reader["t-"+strconv.Itoa(i%2)] = &statsReader{}
+				k.connMu.RUnlock()
+				k.mu.Unlock()
+			}
+		}()
+
+		go func() { // Health's order: must not take k.mu while holding connMu
+			defer wg.Done()
+
+			for range iterations {
+				_ = k.Health()
+			}
+		}()
+
+		go func() { // the pending connMu writer that closes the cycle
+			defer wg.Done()
+
+			for range iterations {
+				func() {
+					k.connMu.Lock()
+					defer k.connMu.Unlock()
+				}()
+			}
+		}()
+
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("deadlock: Health took k.mu while holding connMu; Subscribe takes them the other way round")
+	}
+}
+
+type statsReader struct{ Reader }
+
+func (*statsReader) Stats() kafka.ReaderStats { return kafka.ReaderStats{} }
+func (*statsReader) Close() error             { return nil }

--- a/pkg/gofr/datasource/pubsub/kafka/reader_map_integration_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/reader_map_integration_test.go
@@ -1,0 +1,227 @@
+//go:build integration
+
+// Package-level integration stress for the reader map, run against a real
+// broker rather than mocks:
+//
+//	KAFKA_BROKER=localhost:20086 go test -tags integration -race \
+//	  -run TestIntegration ./pkg/gofr/datasource/pubsub/kafka/
+//
+// Build-tagged so the normal suite and CI stay hermetic.
+package kafka
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"gofr.dev/pkg/gofr/logging"
+)
+
+func brokerFromEnv(t *testing.T) string {
+	t.Helper()
+
+	broker := os.Getenv("KAFKA_BROKER")
+	if broker == "" {
+		t.Skip("KAFKA_BROKER not set")
+	}
+
+	return broker
+}
+
+func newLiveClient(t *testing.T, group string) *kafkaClient {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	metrics := NewMockMetrics(ctrl)
+	metrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	cfg := &Config{
+		Brokers:         []string{brokerFromEnv(t)},
+		ConsumerGroupID: group,
+		BatchSize:       1,
+		BatchBytes:      1048576,
+		BatchTimeout:    1,
+	}
+
+	k := New(cfg, logging.NewMockLogger(logging.ERROR), metrics)
+	require.NotNil(t, k, "New returned nil - check the config and the broker address")
+
+	require.Eventually(t, k.isConnected, 30*time.Second, 200*time.Millisecond,
+		"broker at %s never became reachable", cfg.Brokers[0])
+
+	return k
+}
+
+// publishEventually retries the publish until the broker admits the topic
+// exists. CreateTopic returns as soon as the controller accepts the request,
+// but the topic's metadata takes a moment to propagate, and a publish issued
+// in that window fails with "Unknown Topic Or Partition" - a property of the
+// broker, not of the code under test.
+func publishEventually(ctx context.Context, t *testing.T, k *kafkaClient, topic string) {
+	t.Helper()
+
+	var lastErr error
+
+	require.Eventually(t, func() bool {
+		lastErr = k.Publish(ctx, topic, []byte("v"))
+
+		return lastErr == nil
+	}, 30*time.Second, 100*time.Millisecond, "publish to %s never succeeded: %v", topic, lastErr)
+}
+
+// TestIntegration_PublishSubscribe_RoundTrip is the end-to-end sanity check:
+// a message published through the GoFr client comes back out of Subscribe on
+// the same topic, with the committer wired to the right reader.
+func TestIntegration_PublishSubscribe_RoundTrip(t *testing.T) {
+	topic := "gofr-e2e-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	k := newLiveClient(t, "gofr-e2e-group")
+	t.Cleanup(func() { _ = k.Close() })
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	require.NoError(t, k.CreateTopic(ctx, topic))
+
+	// Retry rather than publishing once: a broker that is still settling a
+	// previous test's topics can take a moment to admit this one, and the
+	// bare publish then fails with "Unknown Topic Or Partition".
+	require.Eventually(t, func() bool {
+		return k.Publish(ctx, topic, []byte("hello-gofr")) == nil
+	}, 30*time.Second, 100*time.Millisecond, "publish to %s never succeeded", topic)
+
+	msg, err := k.Subscribe(ctx, topic)
+	require.NoError(t, err)
+	require.Equal(t, topic, msg.Topic)
+	require.Equal(t, "hello-gofr", string(msg.Value))
+	require.NotNil(t, msg.Committer, "the committer must be wired to this topic's reader")
+
+	msg.Commit()
+}
+
+// TestIntegration_ConcurrentSubscribeAndClose is the stress case that the
+// #3500 panic was reported from: many goroutines subscribing to distinct
+// topics (each one growing the reader map) while teardown walks that map.
+//
+// Before the fix, either the unguarded range in Close or the unguarded
+// re-read at the end of Subscribe could observe a map mid-write, which the
+// runtime reports as "concurrent map read and map write" and -race reports
+// as a data race on the map header.
+func TestIntegration_ConcurrentSubscribeAndClose(t *testing.T) {
+	const (
+		warmTopics  = 3
+		coldWriters = 8
+		coldEach    = 8
+	)
+
+	prefix := "gofr-stress-" + strconv.FormatInt(time.Now().UnixNano(), 10) + "-"
+
+	k := newLiveClient(t, "gofr-stress-group")
+	t.Cleanup(func() { _ = k.Close() })
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	// Only a few topics get a message. Those prove delivery still works while
+	// the map is churning; the cold topics below exist purely to force the
+	// map writes, and a Subscribe that times out on an empty partition has
+	// already done the write by then.
+	//
+	// Each warm topic is subscribed once here, before any churn, so its
+	// reader has already joined the consumer group. Without that warm-up the
+	// group is still rebalancing when the cold topics pile in, and a first
+	// join can take longer than the read deadline - which measures Kafka's
+	// coordinator, not this package's locking.
+	for i := range warmTopics {
+		topic := prefix + "warm-" + strconv.Itoa(i)
+		require.NoError(t, k.CreateTopic(ctx, topic))
+		publishEventually(ctx, t, k, topic)
+
+		joinCtx, joinCancel := context.WithTimeout(ctx, 60*time.Second)
+
+		msg, err := k.Subscribe(joinCtx, topic)
+		require.NoError(t, err, "warm-up subscribe on %s", topic)
+		require.Equal(t, topic, msg.Topic)
+
+		joinCancel()
+
+		// A second message for the concurrent phase below to consume.
+		publishEventually(ctx, t, k, topic)
+	}
+
+	var (
+		wg        sync.WaitGroup
+		delivered atomic.Int64
+		closes    atomic.Int64
+	)
+
+	for i := range warmTopics {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			topic := prefix + "warm-" + strconv.Itoa(i)
+
+			readCtx, readCancel := context.WithTimeout(ctx, 60*time.Second)
+			defer readCancel()
+
+			if msg, err := k.Subscribe(readCtx, topic); err == nil && msg.Topic == topic {
+				delivered.Add(1)
+			}
+		}()
+	}
+
+	// Each cold writer walks its own set of fresh topics, so every iteration
+	// takes k.mu for write and grows the reader map underneath the warm
+	// subscribers above and the teardown goroutine below.
+	for w := range coldWriters {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for i := range coldEach {
+				topic := prefix + "cold-" + strconv.Itoa(w) + "-" + strconv.Itoa(i)
+
+				readCtx, readCancel := context.WithTimeout(ctx, 250*time.Millisecond)
+				_, _ = k.Subscribe(readCtx, topic)
+
+				readCancel()
+			}
+		}()
+	}
+
+	// Concurrent teardown of a client that is still growing its reader map.
+	// Health is read alongside it because it takes connMu, so this also
+	// covers the two mutexes being taken from different goroutines at once.
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for range coldWriters * coldEach {
+			_ = k.Health()
+
+			closes.Add(1)
+
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+
+	require.Equal(t, int64(warmTopics), delivered.Load(),
+		"every warm subscriber should have received its message despite the map churn")
+	t.Logf("delivered %d/%d warm messages while %d cold topics grew the reader map, %d health probes",
+		delivered.Load(), warmTopics, coldWriters*coldEach, closes.Load())
+}

--- a/pkg/gofr/datasource/pubsub/kafka/reader_map_race_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/reader_map_race_test.go
@@ -1,0 +1,243 @@
+package kafka
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"gofr.dev/pkg/gofr/logging"
+)
+
+// newReaderMapClient builds a client whose admin probe succeeds, so Subscribe
+// gets past ensureConnected and reaches the reader map, and whose broker is
+// RFC 6761 ".invalid" so any reader built by getNewReader fails to dial fast
+// instead of blocking the test.
+//
+// warmTopics are pre-populated with mock readers that return a message
+// immediately: a Subscribe on one of those takes the "reader already exists"
+// path and runs all the way to the end of the function without touching the
+// network. A Subscribe on any other topic takes the "create it" path and
+// writes the map. Racing the two is the whole point.
+func newReaderMapClient(t *testing.T, warmTopics ...string) *kafkaClient {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	live := NewMockConnection(ctrl)
+	live.EXPECT().Controller().Return(kafka.Broker{}, nil).AnyTimes()
+	live.EXPECT().Close().Return(nil).AnyTimes()
+
+	metrics := NewMockMetrics(ctrl)
+	metrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	k := &kafkaClient{
+		dialer:  &kafka.Dialer{Timeout: time.Millisecond},
+		config:  Config{Brokers: []string{"broker.invalid:0"}, ConsumerGroupID: "reader-map-race"},
+		conn:    &multiConn{conns: []Connection{live}},
+		logger:  logging.NewMockLogger(logging.DEBUG),
+		metrics: metrics,
+		reader:  make(map[string]Reader),
+	}
+
+	for _, topic := range warmTopics {
+		r := NewMockReader(ctrl)
+		r.EXPECT().FetchMessage(gomock.Any()).
+			Return(kafka.Message{Topic: topic, Value: []byte("v")}, nil).AnyTimes()
+		r.EXPECT().Close().Return(nil).AnyTimes()
+
+		k.reader[topic] = r
+	}
+
+	// Subscribe on a cold topic builds a real kafka.Reader, which runs its own
+	// background goroutines until closed. Close them all rather than leaking
+	// one per topic into the rest of the package's tests.
+	t.Cleanup(func() { _ = k.Close() })
+
+	return k
+}
+
+// TestSubscribe_ConcurrentNewTopic_NoRace pins the unguarded map read that
+// used to sit at the end of Subscribe.
+//
+// Subscribe captures the reader into a local while holding k.mu, releases the
+// lock, and then built the committer from k.reader[topic] a second time. That
+// second read is outside the lock, so a concurrent Subscribe on a *different*
+// topic taking the write lock to grow the map races it.
+//
+// The warm goroutine supplies the read (its topic already has a reader, so it
+// runs to the committer line); the cold goroutines supply the write (each of
+// their topics is new, so each one assigns into the map). Without the fix this
+// fails under -race on the k.reader map.
+func TestSubscribe_ConcurrentNewTopic_NoRace(t *testing.T) {
+	const (
+		warmTopic  = "warm-topic"
+		coldWriter = 4
+		iterations = 60
+	)
+
+	k := newReaderMapClient(t, warmTopic)
+	ctx := t.Context()
+
+	var (
+		wg       sync.WaitGroup
+		warmErr  error
+		warmSeen atomic.Int64
+	)
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		// Assert after Wait, not here: require calls FailNow, which is only
+		// legal on the goroutine running the test.
+		for range iterations {
+			msg, err := k.Subscribe(ctx, warmTopic)
+			if err != nil {
+				warmErr = err
+
+				return
+			}
+
+			if msg.Topic == warmTopic {
+				warmSeen.Add(1)
+			}
+		}
+	}()
+
+	// The cold path builds a real kafka.Reader against an unresolvable broker,
+	// and kafka-go's FetchMessage retries until its context is done. Hand it
+	// one that is already canceled: ensureConnected short-circuits on the
+	// live admin conn without consulting ctx, so Subscribe still reaches the
+	// map write, and FetchMessage then returns immediately instead of hanging.
+	coldCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	for w := range coldWriter {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for i := range iterations {
+				// A fresh topic every time, so every call takes the write
+				// lock and grows the map.
+				_, _ = k.Subscribe(coldCtx, "cold-"+strconv.Itoa(w)+"-"+strconv.Itoa(i))
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	require.NoError(t, warmErr, "the warm subscriber should never fail")
+	require.Equal(t, int64(iterations), warmSeen.Load(),
+		"every warm Subscribe should have returned a message for its own topic")
+}
+
+// TestClose_ConcurrentSubscribe_NoRace pins the other half: Close ranged over
+// k.reader with no lock at all, so a Subscribe growing the map during teardown
+// produced the "concurrent map read and map write" panic from #3500.
+//
+// Close is called repeatedly rather than once because the panic needs the
+// range to be in flight while the map is written, and a single teardown is a
+// narrow window.
+func TestClose_ConcurrentSubscribe_NoRace(t *testing.T) {
+	const iterations = 300
+
+	// Seeded with readers so the very first Close has a map worth ranging
+	// over. Starting from an empty map, the early iterations range over
+	// nothing and the detector needs the writer to get ahead first, which
+	// made this catch its own mutant only intermittently at -count=1.
+	k := newReaderMapClient(t, "seed-0", "seed-1", "seed-2", "seed-3")
+	// Close() takes connMu and closes conn; leave it unset so this test stays
+	// about the reader map. It also means Subscribe cannot be the writer here
+	// - ensureConnected would fail and sleep defaultRetryTimeout (10s) on
+	// every call - so the writer below performs the same locked assignment
+	// Subscribe does. Close, the code under test, is the real thing.
+	k.conn = nil
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for i := range iterations {
+			// ensureConnected fails with conn nil, so drive the map write
+			// directly the way Subscribe does under k.mu.
+			k.mu.Lock()
+			k.reader["grow-"+strconv.Itoa(i)] = k.getNewReader("grow-" + strconv.Itoa(i))
+			k.mu.Unlock()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for range iterations {
+			_ = k.Close()
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestHealth_ConcurrentSubscribe_NoRace pins the third reader of the same map.
+//
+// getReaderStatsAsMap ranged over k.reader with no lock held, and Health sits
+// on the probe path - every /.well-known/health request reaches it - so it
+// races a Subscribe growing the map far more often than teardown ever could.
+// Found by running the integration stress case against a real broker under
+// -race, not by reading the code.
+func TestHealth_ConcurrentSubscribe_NoRace(t *testing.T) {
+	const iterations = 60
+
+	k := &kafkaClient{
+		dialer: &kafka.Dialer{Timeout: time.Millisecond},
+		config: Config{Brokers: []string{"broker.invalid:0"}, ConsumerGroupID: "health-race"},
+		conn: &multiConn{
+			conns: []Connection{&MockConn{addr: "127.0.0.1:9092", isHealthy: true, isControl: true}},
+		},
+		reader: make(map[string]Reader),
+		writer: &mockWriter{},
+		logger: &mockLogger{},
+	}
+
+	t.Cleanup(func() { _ = k.Close() })
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for i := range iterations {
+			topic := "grow-" + strconv.Itoa(i)
+
+			// The same locked assignment Subscribe performs.
+			k.mu.Lock()
+			k.reader[topic] = k.getNewReader(topic)
+			k.mu.Unlock()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for range iterations {
+			_ = k.Health()
+		}
+	}()
+
+	wg.Wait()
+}

--- a/pkg/gofr/datasource/pubsub/kafka/reconnect_concurrency_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/reconnect_concurrency_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -9,8 +10,10 @@ import (
 
 	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"gofr.dev/pkg/gofr/datasource/pubsub"
 	"gofr.dev/pkg/gofr/logging"
 )
 
@@ -33,7 +36,6 @@ func newStaleClient(t *testing.T) (*kafkaClient, *MockConnection) {
 			conns: []Connection{stale},
 		},
 		logger: logging.NewMockLogger(logging.DEBUG),
-		mu:     &sync.RWMutex{},
 	}
 
 	return k, stale
@@ -264,4 +266,46 @@ func TestClose_ConcurrentEnsureConnected_NoRace(t *testing.T) {
 	defer k.connMu.RUnlock()
 
 	assert.Nil(t, k.conn)
+}
+
+// TestClose_DuringInFlightReconnect_DoesNotRevive covers the window Close
+// cannot signal its way out of: retryConnect has already passed its own
+// closed check and is inside initialize, dialing. Without the re-check under
+// connMu, that dial publishes k.conn and k.writer onto a client that is
+// already closed, and both leak for the life of the process.
+func TestClose_DuringInFlightReconnect_DoesNotRevive(t *testing.T) {
+	k := &kafkaClient{
+		config: Config{Brokers: []string{"broker.invalid:0"}, BatchSize: 1, BatchBytes: 1, BatchTimeout: 1},
+		logger: &mockLogger{},
+		closed: make(chan struct{}),
+	}
+
+	dialed := make(chan struct{})
+	release := make(chan struct{})
+
+	original := connectToBrokers
+
+	t.Cleanup(func() { connectToBrokers = original })
+
+	connectToBrokers = func(context.Context, []string, *kafka.Dialer, pubsub.Logger) ([]Connection, error) {
+		close(dialed)
+		<-release // hold the dial open until Close has run
+
+		return []Connection{&MockConn{addr: "127.0.0.1:9092", isHealthy: true}}, nil
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- k.initialize(t.Context()) }()
+
+	<-dialed
+	require.NoError(t, k.Close())
+	close(release)
+
+	require.ErrorIs(t, <-errCh, errClientClosed)
+
+	k.connMu.RLock()
+	defer k.connMu.RUnlock()
+
+	require.Nil(t, k.conn, "a closed client must not be revived by an in-flight reconnect")
+	require.Nil(t, k.writer, "the writer dialed after Close must not be published")
 }

--- a/pkg/gofr/datasource/pubsub/kafka/reconnect_success_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/reconnect_success_test.go
@@ -2,7 +2,6 @@ package kafka
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -60,7 +59,6 @@ func TestEnsureConnected_ReconnectSuccess(t *testing.T) {
 			conns: []Connection{stale},
 		},
 		logger: logging.NewMockLogger(logging.DEBUG),
-		mu:     &sync.RWMutex{},
 		// Pre-arm the throttle so we can assert it gets reset on
 		// successful reconnect.
 		reconnectErrLogAt: time.Now().Add(time.Hour),
@@ -113,7 +111,6 @@ func TestEnsureConnected_ReconnectFailureLogThrottled(t *testing.T) {
 			conns: []Connection{stale},
 		},
 		logger: logging.NewMockLogger(logging.DEBUG),
-		mu:     &sync.RWMutex{},
 	}
 
 	// First failure: throttle is zero-value, so this must arm it.

--- a/pkg/gofr/datasource/pubsub/kafka/writer_race_test.go
+++ b/pkg/gofr/datasource/pubsub/kafka/writer_race_test.go
@@ -1,0 +1,80 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/segmentio/kafka-go"
+	"go.uber.org/mock/gomock"
+
+	"gofr.dev/pkg/gofr/datasource/pubsub"
+	"gofr.dev/pkg/gofr/logging"
+)
+
+// TestWriter_ConcurrentReconnectAndPublish_NoRace pins k.writer.
+//
+// initialize publishes the writer, and retryConnect calls initialize from its
+// own goroutine, so that pointer swap runs concurrently with Publish, Close
+// and Health reading it. It used to be written and read with no lock at all -
+// a single-pointer race rather than the reader-map panic, but a race all the
+// same. Every access now goes through connMu, the lock that already guards
+// the conn published beside it.
+func TestWriter_ConcurrentReconnectAndPublish_NoRace(t *testing.T) {
+	const iterations = 200
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	metrics := NewMockMetrics(ctrl)
+	metrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	k := &kafkaClient{
+		config:  Config{Brokers: []string{"broker.invalid:0"}, BatchSize: 1, BatchBytes: 1, BatchTimeout: 1},
+		logger:  logging.NewMockLogger(logging.ERROR),
+		metrics: metrics,
+		reader:  make(map[string]Reader),
+		writer:  &mockWriter{},
+		conn:    &multiConn{conns: []Connection{&MockConn{addr: "127.0.0.1:9092", isHealthy: true}}},
+	}
+
+	original := connectToBrokers
+
+	t.Cleanup(func() { connectToBrokers = original })
+
+	connectToBrokers = func(context.Context, []string, *kafka.Dialer, pubsub.Logger) ([]Connection, error) {
+		return []Connection{&MockConn{addr: "127.0.0.1:9092", isHealthy: true}}, nil
+	}
+
+	ctx := t.Context()
+
+	var wg sync.WaitGroup
+
+	wg.Add(3)
+
+	go func() { // the reconnect that swaps k.writer
+		defer wg.Done()
+
+		for range iterations {
+			_ = k.initialize(ctx)
+		}
+	}()
+
+	go func() { // Publish reads it
+		defer wg.Done()
+
+		for range iterations {
+			_ = k.Publish(ctx, "topic", []byte("v"))
+		}
+	}()
+
+	go func() { // Health reads it too
+		defer wg.Done()
+
+		for range iterations {
+			_ = k.Health()
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #3500

### What does this PR do?
This PR addresses a critical concurrency vulnerability in the Kafka client's graceful shutdown sequence that causes a fatal `concurrent map iteration and map write` panic.

**Changes made:**
- Updated `kafkaClient.Close()` in `pkg/gofr/datasource/pubsub/kafka/kafka.go`.
- Added a `k.mu.RLock()` block to safely copy the `k.reader` map values into a local slice.
- The lock is immediately released (`k.mu.RUnlock()`) before iterating over the slice to call `r.Close()`.
- This ensures thread safety without holding the mutex during blocking network I/O operations, avoiding potential deadlocks while completely eliminating the crash.

### Note to Reviewers
Ran `go test ./pkg/gofr/datasource/pubsub/kafka/...` locally and all tests pass. This fix guarantees that dynamic topic subscriptions occurring during the shutdown window will not crash the GoFr process.