### PR TITLE
fix(http): handle os.Getwd() error in AddStaticFiles

### DIFF
--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -411,7 +411,14 @@ func (a *App) AddStaticFiles(endpoint, filePath string) {
 
 	// update file path based on current directory if it starts with ./
 	if strings.HasPrefix(filePath, "./") {
-		currentWorkingDir, _ := os.Getwd()
+		currentWorkingDir, err := os.Getwd()
+		if err != nil {
+			a.container.Logger.Errorf("error in registering '%s' static endpoint, "+
+				"failed to get current working directory: %v", endpoint, err)
+
+			return
+		}
+
 		filePath = filepath.Join(currentWorkingDir, filePath)
 	}
 

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -405,6 +405,10 @@ func (a *App) AddStaticFiles(endpoint, filePath string) {
 
 	a.httpRegistered = true
 
+	// Normalize the endpoint up front so every error log below reports the same
+	// '/endpoint' form (previously the getwd and os.Stat logs disagreed).
+	endpoint = "/" + strings.TrimPrefix(endpoint, "/")
+
 	if !strings.HasPrefix(filePath, "./") && !filepath.IsAbs(filePath) {
 		filePath = "./" + filePath
 	}
@@ -421,8 +425,6 @@ func (a *App) AddStaticFiles(endpoint, filePath string) {
 
 		filePath = filepath.Join(currentWorkingDir, filePath)
 	}
-
-	endpoint = "/" + strings.TrimPrefix(endpoint, "/")
 
 	if _, err := os.Stat(filePath); err != nil {
 		a.container.Logger.Errorf("error in registering '%s' static endpoint, error: %v", endpoint, err)

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -1299,6 +1299,37 @@ func TestStaticHandlerInvalidFilePath(t *testing.T) {
 	assert.Contains(t, logs, "error in registering '/gofrTest' static endpoint")
 }
 
+func TestStaticHandlerGetwdError(t *testing.T) {
+	testutil.NewServerConfigs(t)
+
+	// Switch into a temporary directory and remove it so that os.Getwd()
+	// inside AddStaticFiles fails when resolving the relative "./" path.
+	// t.Chdir restores the original working directory at test cleanup.
+	tmpDir := t.TempDir()
+
+	t.Chdir(tmpDir)
+
+	require.NoError(t, os.Remove(tmpDir))
+
+	// On some platforms (e.g. macOS) the kernel still resolves the path of an
+	// unlinked working directory, so os.Getwd() does not fail. Skip there since
+	// the error branch cannot be exercised.
+	if _, err := os.Getwd(); err == nil {
+		t.Skip("os.Getwd() does not fail for a removed working directory on this platform")
+	}
+
+	// The app (and its logger) must be created inside StderrOutputForFunc so the
+	// logger writes to the captured stderr rather than the real one.
+	logs := testutil.StderrOutputForFunc(func() {
+		app := New()
+		app.AddStaticFiles("gofrTest", "./somedir")
+	})
+
+	assert.Contains(t, logs, "failed to get current working directory")
+	// The endpoint is logged before its leading "/" is added, so it appears as 'gofrTest'.
+	assert.Contains(t, logs, "error in registering 'gofrTest' static endpoint")
+}
+
 func TestNewSetsHTTPRegisteredWhenStaticDirExists(t *testing.T) {
 	testutil.NewServerConfigs(t)
 

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -1326,8 +1326,7 @@ func TestStaticHandlerGetwdError(t *testing.T) {
 	})
 
 	assert.Contains(t, logs, "failed to get current working directory")
-	// The endpoint is logged before its leading "/" is added, so it appears as 'gofrTest'.
-	assert.Contains(t, logs, "error in registering 'gofrTest' static endpoint")
+	assert.Contains(t, logs, "error in registering '/gofrTest' static endpoint")
 }
 
 func TestNewSetsHTTPRegisteredWhenStaticDirExists(t *testing.T) {


### PR DESCRIPTION
## Description

`AddStaticFiles` in `pkg/gofr/gofr.go` discarded the error returned by `os.Getwd()`:

```go
currentWorkingDir, _ := os.Getwd()
filePath = filepath.Join(currentWorkingDir, filePath)
```

If `os.Getwd()` fails, `currentWorkingDir` becomes empty and the static file path is
silently resolved against the filesystem root, with no log to help the developer diagnose
why the endpoint didn't register correctly.

## Change

Capture the error, log it via the container logger, and return early — mirroring the
existing error handling for the `os.Stat` failure path a few lines below in the same
function.

## Testing

- `go build ./pkg/gofr/`
- `go vet ./pkg/gofr/`
- `go test ./pkg/gofr/ -run 'TestStaticHandler|TestStaticHandlerInvalidFilePath|TestNewSetsHTTPRegisteredWhenStaticDirExists'` — all pass
- `golangci-lint run ./pkg/gofr/` — no new findings in the changed region

Fixes #3322