### PR TITLE
fix(examples/grpc): widen histogram buckets to match recorded ms scale

### DIFF
--- a/examples/grpc/grpc-streaming-client/client/health_client.go
+++ b/examples/grpc/grpc-streaming-client/client/health_client.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	metricsOnce sync.Once
-	gRPCBuckets = []float64{0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10}
+	gRPCBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000, 5000, 10000}
 )
 
 type HealthClient interface {

--- a/examples/grpc/grpc-streaming-server/server/health_gofr.go
+++ b/examples/grpc/grpc-streaming-server/server/health_gofr.go
@@ -39,7 +39,7 @@ func registerServerWithGofr(app *gofr.App, srv any, registerFunc func(grpc.Servi
 
 	// Register metrics and health server only once
 	if !healthServerRegistered {
-		gRPCBuckets := []float64{0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10}
+		gRPCBuckets := []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000, 5000, 10000}
 		app.Metrics().NewHistogram("app_gRPC-Server_stats", "Response time of gRPC server in milliseconds.", gRPCBuckets...)
 		app.Metrics().NewHistogram("app_gRPC-Stream_stats", "Duration of gRPC stream in milliseconds.", gRPCBuckets...)
 

--- a/examples/grpc/grpc-unary-client/client/health_client.go
+++ b/examples/grpc/grpc-unary-client/client/health_client.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	metricsOnce sync.Once
-	gRPCBuckets = []float64{0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10}
+	gRPCBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000, 5000, 10000}
 )
 
 type HealthClient interface {

--- a/examples/grpc/grpc-unary-server/server/health_gofr.go
+++ b/examples/grpc/grpc-unary-server/server/health_gofr.go
@@ -39,7 +39,7 @@ func registerServerWithGofr(app *gofr.App, srv any, registerFunc func(grpc.Servi
 
 	// Register metrics and health server only once
 	if !healthServerRegistered {
-		gRPCBuckets := []float64{0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10}
+		gRPCBuckets := []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000, 5000, 10000}
 		app.Metrics().NewHistogram("app_gRPC-Server_stats", "Response time of gRPC server in milliseconds.", gRPCBuckets...)
 		app.Metrics().NewHistogram("app_gRPC-Stream_stats", "Duration of gRPC stream in milliseconds.", gRPCBuckets...)
 


### PR DESCRIPTION
## Description

The gRPC histograms record request duration in **milliseconds** (`recordGRPCMetrics` in
`pkg/gofr/grpc/log.go`), but the example bucket set capped at `10` — i.e. 10ms:

```go
gRPCBuckets := []float64{0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10}
```

Any RPC slower than 10ms lands in the `+Inf` bucket, so
`histogram_quantile(0.95, rate(app_gRPC_Server_stats_bucket[5m]))` reports exactly 10.000ms
for p50/p95/p99 on every method, regardless of actual latency. For comparison, HTTP
histograms go up to 30s and the datasource histograms up to 30,000ms.

## Change

Widen the buckets to a ms-scaled range reaching 10,000ms (10s), in line with the HTTP and
datasource histograms, so quantiles reflect real latency:

```go
gRPCBuckets := []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000, 5000, 10000}
```

Applied to all four gRPC examples (unary/streaming × server/client) so they stay consistent.

> **Note:** these files carry the `DO NOT EDIT` generated header — they are produced by
> `gofr-cli`. This PR fixes the checked-in examples as filed in the issue; the generator
> template lives in the separate `gofr-cli` repo and is out of scope here.

## Testing

- `go build ./examples/grpc/...`
- `go vet ./examples/grpc/...`
- `go test ./examples/grpc/...` — unary server/client tests pass. (The streaming-server
  test binds gRPC port 9000, which was occupied by an unrelated process on my machine; that
  failure is environmental and independent of this change, which only alters bucket values.)

Fixes #3453