### PR TITLE
test(eventhub): fix mock expectations for consumer-group + init logs

### DIFF
--- a/pkg/gofr/datasource/pubsub/eventhub/eventhub_test.go
+++ b/pkg/gofr/datasource/pubsub/eventhub/eventhub_test.go
@@ -29,6 +29,8 @@ func TestConnect(t *testing.T) {
 	mockLogger.EXPECT().Debug("Event Hub consumer client setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor running successfully").AnyTimes()
+	mockLogger.EXPECT().Debugf("Using default consumer group: %s", azeventhubs.DefaultConsumerGroup)
+	mockLogger.EXPECT().Debug("Event Hub client initialization complete")
 
 	client.UseLogger(mockLogger)
 	client.UseMetrics(NewMockMetrics(ctrl))
@@ -74,6 +76,7 @@ func TestConnect_ProducerError(t *testing.T) {
 		client.UseMetrics(NewMockMetrics(ctrl))
 
 		mockLogger.EXPECT().Debug(gomock.Any()).AnyTimes()
+		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		mockLogger.EXPECT().Errorf("error occurred while creating producer client %v", gomock.Any())
 
@@ -98,6 +101,7 @@ func TestConnect_ContainerError(t *testing.T) {
 		client.UseMetrics(NewMockMetrics(ctrl))
 
 		mockLogger.EXPECT().Debug(gomock.Any()).AnyTimes()
+		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		mockLogger.EXPECT().Errorf("error occurred while creating container client %v", gomock.Any())
 
@@ -126,6 +130,8 @@ func TestPublish_FailedBatchCreation(t *testing.T) {
 	mockLogger.EXPECT().Debug("Event Hub consumer client setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor running successfully").AnyTimes()
+	mockLogger.EXPECT().Debugf("Using default consumer group: %s", azeventhubs.DefaultConsumerGroup)
+	mockLogger.EXPECT().Debug("Event Hub client initialization complete")
 
 	mockMetrics.EXPECT().IncrementCounter(t.Context(), "app_pubsub_publish_total_count", "topic", client.cfg.EventhubName)
 
@@ -159,6 +165,8 @@ func TestPublish_FailedInvalidTopic(t *testing.T) {
 	mockLogger.EXPECT().Debug("Event Hub consumer client setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor running successfully").AnyTimes()
+	mockLogger.EXPECT().Debugf("Using default consumer group: %s", azeventhubs.DefaultConsumerGroup)
+	mockLogger.EXPECT().Debug("Event Hub client initialization complete")
 
 	client.UseLogger(mockLogger)
 	client.UseMetrics(mockMetrics)
@@ -187,6 +195,8 @@ func Test_CreateTopic(t *testing.T) {
 	mockLogger.EXPECT().Debug("Event Hub consumer client setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor running successfully").AnyTimes()
+	mockLogger.EXPECT().Debugf("Using default consumer group: %s", azeventhubs.DefaultConsumerGroup)
+	mockLogger.EXPECT().Debug("Event Hub client initialization complete")
 	mockLogger.EXPECT().Error("topic creation is not supported in Event Hub")
 
 	client.UseLogger(mockLogger)
@@ -216,6 +226,8 @@ func Test_DeleteTopic(t *testing.T) {
 	mockLogger.EXPECT().Debug("Event Hub consumer client setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor running successfully").AnyTimes()
+	mockLogger.EXPECT().Debugf("Using default consumer group: %s", azeventhubs.DefaultConsumerGroup)
+	mockLogger.EXPECT().Debug("Event Hub client initialization complete")
 	mockLogger.EXPECT().Error("topic deletion is not supported in Event Hub")
 
 	client.UseLogger(mockLogger)
@@ -245,6 +257,8 @@ func Test_HealthCheck(t *testing.T) {
 	mockLogger.EXPECT().Debug("Event Hub consumer client setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor setup success")
 	mockLogger.EXPECT().Debug("Event Hub processor running successfully").AnyTimes()
+	mockLogger.EXPECT().Debugf("Using default consumer group: %s", azeventhubs.DefaultConsumerGroup)
+	mockLogger.EXPECT().Debug("Event Hub client initialization complete")
 	mockLogger.EXPECT().Error("health-check not implemented for Event Hub")
 
 	client.UseLogger(mockLogger)


### PR DESCRIPTION
## Problem

The eventhub unit tests are red on `main` (independent of any dependency bump). The consumer-group interpretation change added two log calls to `Connect()`:
- `Debugf("Using default consumer group: %s", ...)` / `"Using provided consumer group"` (`eventhub.go:141-143`)
- `Debug("Event Hub client initialization complete")` (`eventhub.go:218`)

…but the existing `Connect()`-calling tests (`TestConnect`, `TestPublish_FailedInvalidTopic`, `Test_CreateTopic`, `Test_DeleteTopic`, `Test_HealthCheck`, plus the loose `TestConnect_ProducerError/ContainerError`) were never updated, so they fail on the unexpected mock calls. gomock aborts on the first unexpected call, which masked the second gap.

## Fix

Test-only: add the missing `Debugf`/`Debug` mock expectations to the affected tests, matching the style already used by the newer `TestConnect_ConsumerGroupDefaults/Provided` tests. No production code changed.

## Verification

- `go vet ./...` clean
- `go test ./...` passes
- `go test -race -count=3 ./...` passes (no flakiness)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)