### PR TITLE
feat(ci): auto-tag datasource modules on main module release

### DIFF
--- a/.github/workflows/datasource-tags.yml
+++ b/.github/workflows/datasource-tags.yml
@@ -1,0 +1,99 @@
+---
+name: Tag Datasource Modules
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  tag-datasources:
+    name: Tag Datasource Modules
+    runs-on: ubuntu-latest
+    # Only run on the upstream repo, not forks
+    if: github.repository == 'gofr-dev/gofr'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Tag changed datasource modules
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          set -e
+
+          tagged_any=false
+
+          # Find all datasource modules (directories with go.mod under pkg/gofr/datasource)
+          while IFS= read -r gomod; do
+            module=$(dirname "$gomod")
+
+            # Get the latest tag for this module (path-prefixed format)
+            latest_tag=$(git tag -l "${module}/v*" | sort -V | tail -1)
+
+            if [ -z "$latest_tag" ]; then
+              # Never tagged before — first release
+              new_version="v0.1.0"
+              echo "📦 ${module}: no previous tag found, will tag as ${new_version}"
+            else
+              # Check for commits to this module's directory since the last tag
+              changes=$(git log "${latest_tag}..${RELEASE_SHA}" --oneline -- "${module}/" 2>/dev/null || true)
+
+              if [ -z "$changes" ]; then
+                echo "✅ ${module}: no changes since ${latest_tag}, skipping"
+                continue
+              fi
+
+              # Parse current version
+              current_version=$(echo "$latest_tag" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+$')
+              major=$(echo "$current_version" | cut -d. -f1 | tr -d 'v')
+              minor=$(echo "$current_version" | cut -d. -f2)
+              patch=$(echo "$current_version" | cut -d. -f3)
+
+              # Determine bump type from conventional commit messages
+              # Breaking change → minor bump (pre-1.0 semver: breaking changes bump minor)
+              # feat → minor bump
+              # everything else (fix, chore, build, deps) → patch bump
+              if echo "$changes" | grep -qE ' .+(\(.+\))?!: |BREAKING[- ]CHANGE'; then
+                minor=$((minor + 1))
+                patch=0
+                bump="minor (breaking change)"
+              elif echo "$changes" | grep -qE ' feat(\(.+\))?: '; then
+                minor=$((minor + 1))
+                patch=0
+                bump="minor (new feature)"
+              else
+                patch=$((patch + 1))
+                bump="patch"
+              fi
+
+              new_version="v${major}.${minor}.${patch}"
+              echo "📦 ${module}: ${current_version} → ${new_version} (${bump})"
+              echo "   Recent changes:"
+              echo "$changes" | head -5 | sed 's/^/     /'
+            fi
+
+            new_tag="${module}/${new_version}"
+            git tag -a "${new_tag}" "${RELEASE_SHA}" -m "Release ${new_version}"
+            tagged_any=true
+
+          done < <(find pkg/gofr/datasource -name "go.mod" | sort)
+
+          if [ "$tagged_any" = true ]; then
+            echo ""
+            echo "Pushing datasource tags..."
+            git push origin --tags
+            echo "✅ All datasource tags pushed."
+          else
+            echo "✅ No datasource modules needed tagging."
+          fi


### PR DESCRIPTION
## Problem

Datasource sub-module tags have been created manually and inconsistently — all 25 existing datasources were untagged for multiple release cycles (v1.55.0 through v1.56.7), and the new `cloudsql` module had no tag at all.

## Solution

Add a GitHub Actions workflow that triggers automatically whenever a main module version tag (`vX.Y.Z`) is pushed. It:

1. Finds every datasource sub-module under `pkg/gofr/datasource/` (any directory with a `go.mod`)
2. Checks for commits to that module's directory since its last path-prefixed tag
3. Determines the version bump from conventional commits:
   - `BREAKING CHANGE` or `!` suffix → **minor** bump (pre-1.0 semver convention)
   - `feat` → **minor** bump
   - `fix`, `chore`, `build`, `deps` → **patch** bump
4. Creates an annotated tag matching the existing format (`pkg/gofr/datasource/<name>/vX.Y.Z`)
5. Pushes all new tags in a single `git push --tags`

Modules with no changes since their last tag are skipped.

## Notes

- Requires `contents: write` permission (workflow-level, not default `read`)
- Scoped to `github.repository == 'gofr-dev/gofr'` to skip forks
- As a companion to this PR, all 26 datasource modules were manually tagged for v1.57.0 (the release that was missed):
  - `cloudsql/v0.1.0` (first release)
  - `clickhouse/v0.5.0` (minor — connection-pool + dial config feature)
  - 24 others at patch bumps for deps + Go 1.26 + histogram bucket fix

## Test plan

- [ ] Verify workflow file parses correctly (no YAML syntax errors)
- [ ] After merge, push a test tag to a fork and confirm the workflow logic runs correctly
- [ ] Confirm next release (`v1.58.0`) automatically creates datasource tags