### PR TITLE
ci(website): add workflow_dispatch to prod website pipeline

### DIFF
--- a/.github/workflows/website-prod.yml
+++ b/.github/workflows/website-prod.yml
@@ -6,6 +6,11 @@ on:
   push:
     tags:
       - "v*.*.*"
+  # Manual escape hatch — trigger a prod website rebuild without cutting a
+  # new framework release. Useful when only the website repo changed (new
+  # datasource pages, navigation fixes, etc.) and gofr.dev needs to be
+  # updated independently.
+  workflow_dispatch:
 
 env:
   APP_NAME: gofr-website


### PR DESCRIPTION
## Problem

The production website pipeline (`website-prod.yml`) only triggers on `v*.*.*` tag pushes. When the website repo (`gofr-dev/website`) is updated — new datasource redirect pages, navigation changes, doc fixes — there is no way to redeploy gofr.dev without cutting a new framework release tag.

This became immediately relevant: [gofr-dev/website#222](https://github.com/gofr-dev/website/pull/222) adds the missing `go-import` redirect pages for `cloudsql`, `influxdb`, and `kv-store/dynamodb` (all tagged in v1.57.0), but the prod website cannot be updated until the next tag push.

## Change

Add `workflow_dispatch` to `website-prod.yml` so maintainers can trigger a production website rebuild manually from the GitHub Actions UI — no fake patch release required.

## How to use

Once [gofr-dev/website#222](https://github.com/gofr-dev/website/pull/222) is merged:

1. Go to **Actions → Build and Deploy → Run workflow**
2. Select `development` branch, click **Run workflow**
3. The pipeline checks out `gofr-dev/website:main` (with the new pages) and redeploys to prod

## Test plan

- [ ] Verify workflow shows "Run workflow" button in Actions UI after merge
- [ ] Trigger manually, confirm prod deploy succeeds
- [ ] Confirm `go get gofr.dev/pkg/gofr/datasource/cloudsql@v0.1.0` works after deploy