### PR TITLE
fix: handle os.Getwd() error silently ignored in AddStaticFiles

### DIFF
--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -403,7 +403,12 @@ func (a *App) AddStaticFiles(endpoint, filePath string) {
 
 	// update file path based on current directory if it starts with ./
 	if strings.HasPrefix(filePath, "./") {
-		currentWorkingDir, _ := os.Getwd()
+		currentWorkingDir, err := os.Getwd()
+		if err != nil {
+			a.container.Logger.Errorf("error resolving current working directory: %v", err)
+			return
+		}
+
 		filePath = filepath.Join(currentWorkingDir, filePath)
 	}
 

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -1232,6 +1233,28 @@ func TestStaticHandlerInvalidFilePath(t *testing.T) {
 
 	assert.Contains(t, logs, "no such file or directory")
 	assert.Contains(t, logs, "error in registering '/gofrTest' static endpoint")
+}
+
+func TestAddStaticFilesGetwdError(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("removing the current working directory only breaks os.Getwd on linux")
+	}
+
+	testutil.NewServerConfigs(t)
+
+	deletedDir := t.TempDir()
+
+	t.Chdir(deletedDir)
+
+	require.NoError(t, os.RemoveAll(deletedDir))
+
+	logs := testutil.StderrOutputForFunc(func() {
+		app := New()
+
+		app.AddStaticFiles("gofrTest", "testdir")
+	})
+
+	assert.Contains(t, logs, "error resolving current working directory")
 }
 
 func TestNewSetsHTTPRegisteredWhenStaticDirExists(t *testing.T) {


### PR DESCRIPTION
**Description:**

Fixes #3322.

In `AddStaticFiles` (`pkg/gofr/gofr.go`), the error returned by `os.Getwd()` was discarded:

```go
currentWorkingDir, _ := os.Getwd()
filePath = filepath.Join(currentWorkingDir, filePath)
```

If `os.Getwd()` fails, `currentWorkingDir` is `""`, so `filePath` silently resolves against the filesystem root instead of the intended relative path, with no indication to the developer of what went wrong.

This PR logs the error and aborts registration of the static endpoint when the working directory cannot be resolved, matching the existing error-handling pattern later in the same function (the `os.Stat` check).

**Breaking Changes:**

None. Behavior is unchanged on the happy path; only the previously-silent failure path now logs and returns early instead of registering a static endpoint at an incorrect path.

**Additional Information:**

Added `TestAddStaticFilesGetwdError`, which makes `os.Getwd()` fail by chdir-ing into a directory and then removing it, and asserts the new log line is emitted. The test is skipped on non-Linux runners since removing the current working directory only breaks `os.Getwd()` on Linux (verified locally; macOS/BSD `getcwd` does not fail in this scenario). CI runs on `ubuntu-latest`, so the assertion is exercised there.

Verified locally (Go 1.26, linux/arm64 container):
- `go build ./...`
- `go test ./pkg/gofr/...` — all pass, coverage unchanged (86.7%)
- `gofmt -l` — clean on changed files
- `golangci-lint run` (v2.12.2) — no new issues on changed files

**Checklist:**

- [x] I have formatted my code using `goimport` and `golangci-lint`.
- [x] All new code is covered by unit tests.
- [x] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.