### PR TITLE
perf(http): opt-in O(1) trie router behind GOFR_ROUTER

### DIFF
--- a/docs/advanced-guide/routing-performance/page.md
+++ b/docs/advanced-guide/routing-performance/page.md
@@ -49,7 +49,7 @@ Two further caveats worth setting expectations against:
 
 ## What stays the same
 
-Routing behaviour is unchanged, and that is a property the framework tests for rather than a hope.
+Routing behavior is unchanged, and that is a property the framework tests for rather than a hope.
 The trie only *narrows* the set of routes worth considering; `mux`'s own `Route.Match` still decides
 every request, so method matching, `{id:[0-9]+}` constraints, header and query matchers, route
 ordering and path cleaning all behave exactly as they do by default. Anything the trie cannot index

--- a/docs/advanced-guide/routing-performance/page.md
+++ b/docs/advanced-guide/routing-performance/page.md
@@ -1,0 +1,103 @@
+---
+description: "Speed up route matching in GoFr with the opt-in trie router. Set GOFR_ROUTER=trie to make matching cost O(path length) instead of scaling with your route count."
+nextjs:
+  metadata:
+    title: "Routing Performance in GoFr — The Opt-In Trie Router"
+    description: "Speed up route matching in GoFr with the opt-in trie router. Set GOFR_ROUTER=trie to make matching cost O(path length) instead of scaling with your route count."
+---
+
+# Routing Performance
+
+GoFr routes on `gorilla/mux`, which finds a handler by walking the registered routes in order and
+testing each one against the request path. That is O(n) in the number of routes, so a service pays a
+little more per request for every route it adds.
+
+Setting `GOFR_ROUTER=trie` swaps the matching step for a segment trie, making it O(path length) —
+flat as the route table grows. Everything else is unchanged: `mux` is still the route registry, and
+`mux` still makes the final decision about which route matches.
+
+```bash
+# configs/.env
+GOFR_ROUTER=trie
+```
+
+It is **off by default**. Leave it unset and your service behaves exactly as it always has.
+
+## Whether it will help you
+
+The win scales with the size of your route table, so it is worth being concrete about where the line
+is. Measured on an Apple M4, with the request hitting the middle of the table:
+
+| Routes | Default (mux) | `GOFR_ROUTER=trie` | Speedup |
+| -----: | ------------: | -----------------: | ------: |
+|      1 |        431 ns |             447 ns |   0.96x |
+|     10 |        506 ns |             461 ns |    1.1x |
+|     50 |       1007 ns |             550 ns |    1.8x |
+|    100 |       1642 ns |             548 ns |    3.0x |
+|    200 |       2918 ns |             515 ns |    5.7x |
+
+The crossover is around 5–10 routes. Below that the trie is marginally slower, so a small service
+gains nothing by turning it on.
+
+Two further caveats worth setting expectations against:
+
+- **Matching is a minority of a request.** The middleware chain — tracing, logging, metrics, CORS —
+  dominates. So end-to-end throughput moves by less than the table above, approaching it only as the
+  route count grows.
+- **The trie allocates slightly more.** Two extra allocations per matched request, for restoring the
+  path params and route template. This is a CPU and scaling win, not an allocation win.
+
+## What stays the same
+
+Routing behaviour is unchanged, and that is a property the framework tests for rather than a hope.
+The trie only *narrows* the set of routes worth considering; `mux`'s own `Route.Match` still decides
+every request, so method matching, `{id:[0-9]+}` constraints, header and query matchers, route
+ordering and path cleaning all behave exactly as they do by default. Anything the trie cannot index
+— `PathPrefix` routes, static file handlers, slash-spanning parameters like `{path:.*}` — is handled
+by `mux` directly. Requests that match nothing are handed to `mux` in full.
+
+Path parameters are unaffected: `ctx.PathParam("id")` and `mux.Vars(r)` work identically.
+
+## The one thing to check in your own code
+
+The trie serves matched requests without going through `mux`'s own `ServeHTTP`, which is what
+populates `mux.CurrentRoute`. If any of your handlers or middleware calls it:
+
+```go
+// Returns nil when GOFR_ROUTER=trie.
+route := mux.CurrentRoute(r)
+tmpl, _ := route.GetPathTemplate()
+```
+
+use GoFr's accessor instead. It resolves the template under both routers, so it is safe to adopt
+before you flip the flag:
+
+```go
+import gofrHTTP "gofr.dev/pkg/gofr/http"
+
+tmpl := gofrHTTP.RouteTemplate(r) // "/users/{id}", or "" if nothing matched
+```
+
+`mux.Vars(r)` is **not** affected and needs no change.
+
+## Confirming which matcher is active
+
+GoFr logs the matcher at startup whenever `GOFR_ROUTER` is set:
+
+```
+INFO  HTTP route matcher: trie
+```
+
+A value it does not recognize falls back to `mux` and says so, so a typo does not cost you the opt-in
+silently:
+
+```
+WARN  unrecognized GOFR_ROUTER value "tri", using the "mux" router; valid values are "mux" and "trie"
+```
+
+## A note on registering routes late
+
+The index is built once, from the routes present when the first request arrives. GoFr registers every
+route during startup, before the server begins accepting requests, so this holds for all framework
+code paths. A route added after the server is already serving would not be indexed — it would still
+be served correctly, via `mux`, just without the speedup.

--- a/docs/navigation.js
+++ b/docs/navigation.js
@@ -80,6 +80,11 @@ export const navigation = [
                 desc: "Get familiar with making HTTP requests and handling responses within your GoFr application to facilitate seamless communication."
             },
             {
+                title: 'Routing Performance',
+                href: '/docs/advanced-guide/routing-performance',
+                desc: "Opt into the trie router with GOFR_ROUTER=trie to keep route matching flat as your route table grows, instead of scaling with the number of routes."
+            },
+            {
                 title: 'Authentication',
                 href: '/docs/advanced-guide/authentication',
                 desc: "Implement various authentication methods to secure your GoFR application and protect sensitive endpoints across HTTP and gRPC."

--- a/docs/references/configs/page.md
+++ b/docs/references/configs/page.md
@@ -171,6 +171,12 @@ This document lists all the configuration options supported by the GoFr framewor
 
 ---
 
+-  GOFR_ROUTER
+-  Route matcher for the HTTP server. Set to `trie` to opt into the O(path length) trie index instead of the default linear scan — see [Routing Performance](/docs/advanced-guide/routing-performance). Any other value falls back to `mux`.
+-  mux
+
+---
+
 -  LOG_DISABLE_PROBES
 -  Disable log probes for health checks
 -  false

--- a/pkg/gofr/http/middleware/metrics.go
+++ b/pkg/gofr/http/middleware/metrics.go
@@ -10,8 +10,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel/attribute"
+
+	gofrhttp "gofr.dev/pkg/gofr/http"
 )
 
 type metrics interface {
@@ -89,16 +90,13 @@ func Metrics(metrics metrics) func(inner http.Handler) http.Handler {
 				srw = &StatusResponseWriter{ResponseWriter: w}
 			}
 
-			// mux.CurrentRoute is nil for unmatched routes (404), and even
-			// when matched, GetPathTemplate can return "" for routes built
-			// without an explicit Path() (e.g. PathPrefix-only handlers).
-			// Fall back to r.URL.Path in both cases so the metric carries a
-			// usable path label instead of caching an empty key.
-			var path string
-			if cr := mux.CurrentRoute(r); cr != nil {
-				path, _ = cr.GetPathTemplate()
-			}
-
+			// Resolve the route template for the metric label via the
+			// router-agnostic accessor (it reads the trie router's context key
+			// or mux.CurrentRoute, whichever applies). It is "" for unmatched
+			// routes and for routes built without an explicit Path() (e.g.
+			// PathPrefix-only handlers), so fall back to r.URL.Path there to
+			// keep a usable path label rather than an empty key.
+			path := gofrhttp.RouteTemplate(r)
 			if path == "" {
 				path = r.URL.Path
 			}

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -5,12 +5,12 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
+	gofrhttp "gofr.dev/pkg/gofr/http"
 	"gofr.dev/pkg/gofr/version"
 )
 
@@ -31,14 +31,13 @@ func methodKV(method string) attribute.KeyValue {
 }
 
 // routeTemplate returns the matched route template (e.g. "/users/{id}") for
-// the request when gorilla/mux has resolved one, otherwise the raw URL path.
-// Used for the span name and http.route attribute so tracing cardinality
-// stays bounded by route count, not request count.
+// the request, otherwise the raw URL path. Used for the span name and
+// http.route attribute so tracing cardinality stays bounded by route count,
+// not request count. gofrhttp.RouteTemplate resolves the template under both
+// the trie and the default mux router.
 func routeTemplate(r *http.Request) string {
-	if route := mux.CurrentRoute(r); route != nil {
-		if t, err := route.GetPathTemplate(); err == nil && t != "" {
-			return t
-		}
+	if t := gofrhttp.RouteTemplate(r); t != "" {
+		return t
 	}
 
 	return r.URL.Path

--- a/pkg/gofr/http/route_context.go
+++ b/pkg/gofr/http/route_context.go
@@ -1,0 +1,45 @@
+package http
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// routeTemplateCtxKey is the private context key under which the trie router
+// stores the matched route template (e.g. "/users/{id}"). It exists because,
+// once the trie router bypasses mux's ServeHTTP, mux.CurrentRoute(r) is no
+// longer populated, so the template must be carried some other way.
+type routeTemplateCtxKey struct{}
+
+// withRouteTemplate returns r carrying tmpl as the matched route template. An
+// empty template is a no-op so unmatched requests do not pay for a context copy.
+func withRouteTemplate(r *http.Request, tmpl string) *http.Request {
+	if tmpl == "" {
+		return r
+	}
+
+	return r.WithContext(context.WithValue(r.Context(), routeTemplateCtxKey{}, tmpl))
+}
+
+// RouteTemplate returns the matched route template for r (e.g. "/users/{id}"),
+// or "" if none is available. It is the router-agnostic replacement for
+// mux.CurrentRoute(r).GetPathTemplate() and works under both routers: the trie
+// router records the template in the request context (it bypasses mux's
+// ServeHTTP, so mux.CurrentRoute is nil), while the default mux path exposes it
+// via mux.CurrentRoute. Callers get consistent behavior without knowing which
+// router is active.
+func RouteTemplate(r *http.Request) string {
+	if tmpl, _ := r.Context().Value(routeTemplateCtxKey{}).(string); tmpl != "" {
+		return tmpl
+	}
+
+	if route := mux.CurrentRoute(r); route != nil {
+		if tmpl, err := route.GetPathTemplate(); err == nil {
+			return tmpl
+		}
+	}
+
+	return ""
+}

--- a/pkg/gofr/http/route_context_test.go
+++ b/pkg/gofr/http/route_context_test.go
@@ -1,0 +1,68 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouteTemplate_ResolvesUnderBothRouters is the guard for the accessor the
+// tracer and metrics middleware depend on for their route label. It must return
+// the route template — not the raw request path — under BOTH routers: the trie
+// router records it in the request context (it bypasses mux's ServeHTTP, so
+// mux.CurrentRoute is nil there), while the default mux router exposes it via
+// mux.CurrentRoute. A silent regression here would degrade the metric label to
+// an unbounded raw path without failing any other test.
+func TestRouteTemplate_ResolvesUnderBothRouters(t *testing.T) {
+	const tmpl = "/users/{id}"
+
+	for _, tc := range []struct {
+		name    string
+		useTrie bool
+	}{
+		{"mux", false},
+		{"trie", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+
+			r := NewRouter()
+			r.useTrie = tc.useTrie
+			r.Add(http.MethodGet, tmpl, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				got = RouteTemplate(req)
+
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/users/42", http.NoBody)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code, "handler must have run")
+			assert.Equal(t, tmpl, got, "route template must resolve under the %s router", tc.name)
+		})
+	}
+}
+
+// TestRouteTemplate_EmptyWhenUnmatched asserts the accessor reports no template
+// for a request that matched no route, so callers fall back to the raw path
+// rather than reading a stale or bogus label.
+func TestRouteTemplate_EmptyWhenUnmatched(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/nothing", http.NoBody)
+
+	assert.Empty(t, RouteTemplate(req), "no template should be reported for an unrouted request")
+}
+
+// TestWithRouteTemplate_EmptyIsNoOp verifies that recording an empty template
+// does not copy the request — unmatched requests must not pay for a context
+// allocation.
+func TestWithRouteTemplate_EmptyIsNoOp(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody)
+
+	assert.Same(t, req, withRouteTemplate(req, ""), "empty template must not copy the request")
+	assert.NotSame(t, req, withRouteTemplate(req, "/x/{id}"), "a real template must be recorded")
+}

--- a/pkg/gofr/http/router.go
+++ b/pkg/gofr/http/router.go
@@ -20,6 +20,16 @@ const (
 	DefaultSwaggerFileName       = "openapi.json"
 	staticServerNotFoundFileName = "404.html"
 	staticServerIndexFileName    = "index.html"
+
+	// RouterEnvVar selects the route matcher. Unset (or any unrecognized value)
+	// means MatcherMux, so the default behavior is unchanged.
+	RouterEnvVar = "GOFR_ROUTER"
+
+	// MatcherMux is gorilla/mux's linear scan — the default.
+	MatcherMux = "mux"
+	// MatcherTrie is the opt-in segment-trie index, O(path length) in the number
+	// of registered routes.
+	MatcherTrie = "trie"
 )
 
 // errReadPermissionDenied wraps fs.ErrPermission so that a file whose mode carries no read bit is
@@ -67,7 +77,7 @@ func NewRouter() *Router {
 	r := &Router{
 		Router:           *muxRouter,
 		RegisteredRoutes: &routes,
-		useTrie:          strings.EqualFold(os.Getenv("GOFR_ROUTER"), "trie"),
+		useTrie:          strings.EqualFold(os.Getenv(RouterEnvVar), MatcherTrie),
 	}
 
 	return r
@@ -130,6 +140,9 @@ func normalizePath(r *http.Request) {
 // Tracer/Logging/CORS/Metrics chain running. serveTrie mirrors that exactly, so
 // unmatched requests are not logged, measured, or CORS-answered (and the metrics
 // path label is never populated from a raw, unbounded request path).
+//
+// Anything the trie does not match is handed to mux's own ServeHTTP rather than
+// resolved here — see the comment on that call for why.
 func (rou *Router) serveTrie(w http.ResponseWriter, r *http.Request) {
 	rou.buildIdx.Do(func() {
 		idx := newRouteIndex()
@@ -158,16 +171,31 @@ func (rou *Router) serveTrie(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Unmatched: serve mux's NotFound/MethodNotAllowed handler directly, WITHOUT
-	// the middleware chain — matching mux, which applies middleware only on a
-	// successful match.
-	if errors.Is(match.MatchErr, mux.ErrMethodMismatch) {
-		rou.methodNotAllowed().ServeHTTP(w, r)
-
-		return
-	}
-
-	rou.notFound().ServeHTTP(w, r)
+	// Unmatched by the trie: hand the request to mux's own ServeHTTP instead of
+	// deciding 404-vs-405 here. This is the cold path — the response is already
+	// an error — so mux's linear scan costs nothing that matters, and it buys two
+	// things that reimplementing the decision cannot.
+	//
+	// Exactness. mux's 405 depends on state that routes which do NOT match the
+	// request path still mutate: a later route whose method matcher succeeds
+	// clears an ErrMethodMismatch left by an earlier one (gorilla/mux route.go),
+	// and GoFr registers routes as Methods(m).Path(p), so the method matcher runs
+	// first. Reproducing that outcome therefore requires visiting routes the trie
+	// exists to skip. Delegating gets it exactly right instead of approximately.
+	// The custom NotFoundHandler / MethodNotAllowedHandler and subrouter
+	// semantics come along for free, and mux applies no middleware on this path,
+	// so the parity the chain relies on is mux's own by construction.
+	//
+	// Safety. It also makes the index self-healing: if isIndexablePathRegexp ever
+	// admitted a shape it should not have and the trie dropped a route that does
+	// match, mux's full scan finds it here and serves it correctly. That turns the
+	// one catastrophic failure mode of this design — a live route silently
+	// 404ing — into a request that is merely slower, leaving the trie strictly an
+	// accelerator.
+	//
+	// Inside a GoFr app this is unreachable: the PathPrefix("/") catch-all matches
+	// every path and method, so the trie always has a candidate that matches.
+	rou.Router.ServeHTTP(w, r)
 }
 
 // Use registers mux middlewares. It records them in GoFr's own chain — so the
@@ -179,26 +207,20 @@ func (rou *Router) Use(mwf ...mux.MiddlewareFunc) {
 	rou.Router.Use(mwf...)
 }
 
-// notFound returns the handler mux would use for an unmatched route, honoring a
-// custom NotFoundHandler if one was set.
-func (rou *Router) notFound() http.Handler {
-	if rou.NotFoundHandler != nil {
-		return rou.NotFoundHandler
+// Matcher reports which route matcher this router uses: MatcherTrie for the
+// opt-in index, MatcherMux for the default linear scan.
+//
+// It is exported so the server can state the active matcher at startup. The
+// choice is made from the environment inside NewRouter, and an unrecognized
+// GOFR_ROUTER value falls back to mux — which is indistinguishable, from the
+// outside, from not setting the variable at all. Reporting the resolved matcher
+// is what lets the caller tell a typo from a default.
+func (rou *Router) Matcher() string {
+	if rou.useTrie {
+		return MatcherTrie
 	}
 
-	return http.NotFoundHandler()
-}
-
-// methodNotAllowed returns the handler mux would use when the path matches but
-// the method does not, honoring a custom MethodNotAllowedHandler if set.
-func (rou *Router) methodNotAllowed() http.Handler {
-	if rou.MethodNotAllowedHandler != nil {
-		return rou.MethodNotAllowedHandler
-	}
-
-	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusMethodNotAllowed)
-	})
+	return MatcherMux
 }
 
 // composeMiddleware wraps h with mws so that mws[0] is the outermost layer,

--- a/pkg/gofr/http/router.go
+++ b/pkg/gofr/http/router.go
@@ -153,20 +153,7 @@ func (rou *Router) serveTrie(w http.ResponseWriter, r *http.Request) {
 	var match mux.RouteMatch
 
 	if rou.idx.match(r, &match) && match.Handler != nil {
-		// Reinstate what mux.Router.ServeHTTP would have populated so that
-		// mux.Vars(r) (used by request.go and user handlers) and the route
-		// template (used by the tracer/metrics middleware) keep working.
-		if match.Vars != nil {
-			r = mux.SetURLVars(r, match.Vars)
-		}
-
-		if match.Route != nil {
-			if tmpl, err := match.Route.GetPathTemplate(); err == nil {
-				r = withRouteTemplate(r, tmpl)
-			}
-		}
-
-		composeMiddleware(rou.mws, match.Handler).ServeHTTP(w, r)
+		rou.serveMatched(w, r, &match)
 
 		return
 	}
@@ -196,6 +183,37 @@ func (rou *Router) serveTrie(w http.ResponseWriter, r *http.Request) {
 	// Inside a GoFr app this is unreachable: the PathPrefix("/") catch-all matches
 	// every path and method, so the trie always has a candidate that matches.
 	rou.Router.ServeHTTP(w, r)
+}
+
+// serveMatched runs a handler the trie matched, after restoring the request state that mux's own
+// ServeHTTP would have populated.
+func (rou *Router) serveMatched(w http.ResponseWriter, r *http.Request, match *mux.RouteMatch) {
+	// Reinstate what mux.Router.ServeHTTP would have populated so that mux.Vars(r) (used by
+	// request.go and user handlers) and the route template (used by the tracer/metrics middleware)
+	// keep working.
+	if match.Vars != nil {
+		r = mux.SetURLVars(r, match.Vars)
+	}
+
+	if match.Route != nil {
+		if tmpl, err := match.Route.GetPathTemplate(); err == nil {
+			r = withRouteTemplate(r, tmpl)
+		}
+	}
+
+	// mux builds its middleware chain inside Match, guarded by MatchErr == nil, so a route that
+	// matches while REPORTING an error is served WITHOUT the chain. A subrouter carrying its own
+	// NotFoundHandler is exactly that case: it reports a successful match with ErrNotFound. Running
+	// the chain here would log, trace, meter and CORS-answer a request mux does not — and with no
+	// path template on a PathPrefix route, the metrics label would fall back to the raw request
+	// path, the unbounded-cardinality outcome this router is otherwise careful to avoid.
+	if match.MatchErr != nil {
+		match.Handler.ServeHTTP(w, r)
+
+		return
+	}
+
+	composeMiddleware(rou.mws, match.Handler).ServeHTTP(w, r)
 }
 
 // Use registers mux middlewares. It records them in GoFr's own chain — so the

--- a/pkg/gofr/http/router.go
+++ b/pkg/gofr/http/router.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/gorilla/mux"
 
@@ -30,6 +31,31 @@ var errReadPermissionDenied = fmt.Errorf("file does not have read permission: %w
 type Router struct {
 	mux.Router
 	RegisteredRoutes *[]string
+
+	// useTrie selects the O(path) trie matcher (GOFR_ROUTER=trie) over mux's
+	// default O(n) linear scan. When false, ServeHTTP delegates to mux exactly
+	// as before, so the default behavior is byte-for-byte unchanged.
+	useTrie bool
+	// idx is the trie index. It is built once, lazily, on the first request,
+	// from the routes registered up to that point. This is correct for GoFr's
+	// lifecycle: every route is registered during startup (app.GET/POST/...,
+	// the GraphQL route, the static/catch-all handlers) before the server
+	// accepts its first request, and GoFr does not add routes afterwards. A
+	// route registered after the first request would not be reflected in the
+	// trie index — a deliberate trade for a lock-free steady state, matching
+	// GoFr's static-routing model. buildIdx guards that one-time build.
+	idx      *routeIndex
+	buildIdx sync.Once
+	// mws mirrors the middleware chain registered via Use, so the trie matcher
+	// can apply it itself when it bypasses mux's ServeHTTP. In mux mode it is
+	// unused (mux owns the chain) but kept in sync, costing nothing.
+	//
+	// Invariant: every middleware MUST be registered through (*Router).Use (or
+	// UseMiddleware, which calls it). A direct call to the embedded
+	// mux.Router.Use would bypass this slice and be silently dropped in trie
+	// mode. All framework registration paths go through (*Router).Use, and the
+	// MiddlewareParity differential test guards the resulting behavior.
+	mws []mux.MiddlewareFunc
 }
 
 type Middleware func(handler http.Handler) http.Handler
@@ -41,43 +67,148 @@ func NewRouter() *Router {
 	r := &Router{
 		Router:           *muxRouter,
 		RegisteredRoutes: &routes,
+		useTrie:          strings.EqualFold(os.Getenv("GOFR_ROUTER"), "trie"),
 	}
-
-	r.Router = *muxRouter
 
 	return r
 }
 
 // ServeHTTP implements [http.Handler] interface with path normalization.
 func (rou *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Normalize the path before routing to handle double slashes
+	normalizePath(r)
+
+	if rou.useTrie {
+		rou.serveTrie(w, r)
+
+		return
+	}
+
+	// Delegate to the underlying Gorilla Mux router.
+	rou.Router.ServeHTTP(w, r)
+}
+
+// normalizePath canonicalizes r.URL.Path in place so routing sees a clean path
+// (no "//", "/.", "/.." or non-root trailing slash), matching the behavior both
+// the mux and trie matchers rely on.
+func normalizePath(r *http.Request) {
 	originalPath := r.URL.Path
 
 	// Fast path: the vast majority of incoming paths are already canonical
 	// ("/users/42", "/api/v1/things"). Skip the path.Clean + string ops in
 	// that case so they only run for inputs that actually need normalizing.
-	if !isCleanPath(originalPath) {
-		normalizedPath := path.Clean(originalPath)
-
-		// path.Clean returns "." for empty paths, convert to "/" for HTTP routing
-		if normalizedPath == "." {
-			normalizedPath = "/"
-		}
-
-		// Ensure path starts with "/" for HTTP routing
-		normalizedPath = "/" + strings.TrimLeft(normalizedPath, "/")
-
-		// Only modify if path changed
-		if originalPath != normalizedPath {
-			r.URL.Path = normalizedPath
-			if r.URL.RawPath != "" {
-				r.URL.RawPath = normalizedPath
-			}
-		}
+	if isCleanPath(originalPath) {
+		return
 	}
 
-	// Delegate to the underlying Gorilla Mux router
-	rou.Router.ServeHTTP(w, r)
+	normalizedPath := path.Clean(originalPath)
+
+	// path.Clean returns "." for empty paths, convert to "/" for HTTP routing
+	if normalizedPath == "." {
+		normalizedPath = "/"
+	}
+
+	// Ensure path starts with "/" for HTTP routing
+	normalizedPath = "/" + strings.TrimLeft(normalizedPath, "/")
+
+	// Only modify if path changed
+	if originalPath != normalizedPath {
+		r.URL.Path = normalizedPath
+		if r.URL.RawPath != "" {
+			r.URL.RawPath = normalizedPath
+		}
+	}
+}
+
+// serveTrie handles a request using the trie matcher: it matches (delegating the
+// real decision to mux's Route.Match), restores the path params and route
+// template that mux's own ServeHTTP would have set, then runs the matched
+// handler through GoFr's middleware chain.
+//
+// The middleware chain wraps the matched handler ONLY. mux builds its chain
+// inside Match, guarded by MatchErr == nil, so it never wraps the NotFound or
+// MethodNotAllowed handlers — a 404/405 request is served by mux without the
+// Tracer/Logging/CORS/Metrics chain running. serveTrie mirrors that exactly, so
+// unmatched requests are not logged, measured, or CORS-answered (and the metrics
+// path label is never populated from a raw, unbounded request path).
+func (rou *Router) serveTrie(w http.ResponseWriter, r *http.Request) {
+	rou.buildIdx.Do(func() {
+		idx := newRouteIndex()
+		idx.build(&rou.Router)
+		rou.idx = idx
+	})
+
+	var match mux.RouteMatch
+
+	if rou.idx.match(r, &match) && match.Handler != nil {
+		// Reinstate what mux.Router.ServeHTTP would have populated so that
+		// mux.Vars(r) (used by request.go and user handlers) and the route
+		// template (used by the tracer/metrics middleware) keep working.
+		if match.Vars != nil {
+			r = mux.SetURLVars(r, match.Vars)
+		}
+
+		if match.Route != nil {
+			if tmpl, err := match.Route.GetPathTemplate(); err == nil {
+				r = withRouteTemplate(r, tmpl)
+			}
+		}
+
+		composeMiddleware(rou.mws, match.Handler).ServeHTTP(w, r)
+
+		return
+	}
+
+	// Unmatched: serve mux's NotFound/MethodNotAllowed handler directly, WITHOUT
+	// the middleware chain — matching mux, which applies middleware only on a
+	// successful match.
+	if errors.Is(match.MatchErr, mux.ErrMethodMismatch) {
+		rou.methodNotAllowed().ServeHTTP(w, r)
+
+		return
+	}
+
+	rou.notFound().ServeHTTP(w, r)
+}
+
+// Use registers mux middlewares. It records them in GoFr's own chain — so the
+// trie matcher can apply them when it bypasses mux's ServeHTTP — and delegates
+// to the embedded mux router, leaving the default (mux) path unchanged. It
+// shadows mux.Router.Use for calls made on *Router.
+func (rou *Router) Use(mwf ...mux.MiddlewareFunc) {
+	rou.mws = append(rou.mws, mwf...)
+	rou.Router.Use(mwf...)
+}
+
+// notFound returns the handler mux would use for an unmatched route, honoring a
+// custom NotFoundHandler if one was set.
+func (rou *Router) notFound() http.Handler {
+	if rou.NotFoundHandler != nil {
+		return rou.NotFoundHandler
+	}
+
+	return http.NotFoundHandler()
+}
+
+// methodNotAllowed returns the handler mux would use when the path matches but
+// the method does not, honoring a custom MethodNotAllowedHandler if set.
+func (rou *Router) methodNotAllowed() http.Handler {
+	if rou.MethodNotAllowedHandler != nil {
+		return rou.MethodNotAllowedHandler
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+}
+
+// composeMiddleware wraps h with mws so that mws[0] is the outermost layer,
+// matching the order in which mux applies its middleware chain.
+func composeMiddleware(mws []mux.MiddlewareFunc, h http.Handler) http.Handler {
+	for i := len(mws) - 1; i >= 0; i-- {
+		h = mws[i](h)
+	}
+
+	return h
 }
 
 // isCleanPath reports whether p is already canonical — starts with "/", no

--- a/pkg/gofr/http/router.go
+++ b/pkg/gofr/http/router.go
@@ -203,10 +203,14 @@ func (rou *Router) serveMatched(w http.ResponseWriter, r *http.Request, match *m
 
 	// mux builds its middleware chain inside Match, guarded by MatchErr == nil, so a route that
 	// matches while REPORTING an error is served WITHOUT the chain. A subrouter carrying its own
-	// NotFoundHandler is exactly that case: it reports a successful match with ErrNotFound. Running
-	// the chain here would log, trace, meter and CORS-answer a request mux does not — and with no
-	// path template on a PathPrefix route, the metrics label would fall back to the raw request
-	// path, the unbounded-cardinality outcome this router is otherwise careful to avoid.
+	// NotFoundHandler is that case: it reports a successful match with ErrNotFound. Running the chain
+	// here would log, trace, meter and CORS-answer a request mux leaves uninstrumented — a silent
+	// difference, since the status and body are identical either way.
+	//
+	// The mirror only needs this one guard. A subrouter's MethodNotAllowedHandler also matches
+	// successfully, but mux clears ErrMethodMismatch as soon as one of the route's matchers succeeds
+	// (the else arm of the matcher loop in gorilla/mux route.go), so that case arrives here with a nil
+	// MatchErr and correctly DOES get the chain.
 	if match.MatchErr != nil {
 		match.Handler.ServeHTTP(w, r)
 

--- a/pkg/gofr/http/trie_router.go
+++ b/pkg/gofr/http/trie_router.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"errors"
 	"net/http"
 	"regexp/syntax"
 	"strings"
@@ -296,7 +295,7 @@ func (idx *routeIndex) insert(tpl string, e *routeEntry) {
 	cur.routes = append(cur.routes, e)
 }
 
-// candidates gathers every route whose template structurally lines up with path
+// collect gathers every route whose template structurally lines up with path
 // by exploring both the literal and the parameter branch at each segment
 // (backtracking). This is O(path length × small branching), never O(route
 // count). A route the trie omits here could not have matched path anyway, so
@@ -329,16 +328,12 @@ func (n *trieNode) collect(rest string, out *[]*routeEntry) {
 // candidate that fully matches — identical to what stock mux would pick, only
 // without scanning every registered route.
 //
-// It reports true and fills rm on a full match. On no match it returns false;
-// if some candidate matched the path but not the method, rm.MatchErr is set to
-// mux.ErrMethodMismatch so the caller can render 405 rather than 404.
-//
-// Note: inside a running GoFr app this 405 path is effectively unreachable. GoFr
-// registers a PathPrefix("/") catch-all (see gofr.go) that matches any method,
-// so a wrong-method request to an existing path is a FULL match on the catch-all
-// and returns before methodMismatch is consulted — yielding the same 404 as mux.
-// The 405 result only surfaces on a bare Router with no catch-all (e.g. unit
-// tests), which is why the documented 404->405 divergence is framework-moot.
+// It reports true and fills rm on a full match, and false otherwise — nothing
+// more. It deliberately does NOT classify a non-match as 404 or 405: that
+// distinction depends on state which routes that do not match the request path
+// still mutate (see serveTrie), so it cannot be derived from the narrowed
+// candidate set. serveTrie hands every non-match to mux's own ServeHTTP, which
+// decides it by the full scan, exactly as it would without the index.
 func (idx *routeIndex) match(req *http.Request, rm *mux.RouteMatch) bool {
 	var buf [12]*routeEntry
 
@@ -360,8 +355,6 @@ func (idx *routeIndex) match(req *http.Request, rm *mux.RouteMatch) bool {
 
 	sortByRegistrationOrder(cands)
 
-	methodMismatch := false
-
 	for _, e := range cands {
 		// Match writes into rm directly; reset it between candidates so a
 		// failed attempt cannot leak state into the next one. This avoids a
@@ -377,17 +370,11 @@ func (idx *routeIndex) match(req *http.Request, rm *mux.RouteMatch) bool {
 		if e.route.Match(req, rm) {
 			return true
 		}
-
-		if errors.Is(rm.MatchErr, mux.ErrMethodMismatch) {
-			methodMismatch = true
-		}
 	}
 
+	// Leave nothing behind for the caller to misread as a partial verdict: the
+	// request is going to mux, which starts from a clean RouteMatch of its own.
 	*rm = mux.RouteMatch{}
-
-	if methodMismatch {
-		rm.MatchErr = mux.ErrMethodMismatch
-	}
 
 	return false
 }

--- a/pkg/gofr/http/trie_router.go
+++ b/pkg/gofr/http/trie_router.go
@@ -1,0 +1,326 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+	"regexp/syntax"
+	"sort"
+	"strings"
+
+	"github.com/gorilla/mux"
+)
+
+// routeEntry pairs a registered mux route with its registration order. The
+// order lets the index reproduce mux's "first registered wins" semantics after
+// the trie has narrowed the candidate set.
+type routeEntry struct {
+	route *mux.Route
+	order int
+}
+
+// trieNode indexes routes by path segment. A literal segment ("users") is keyed
+// in children; a parameter segment ("{id}" or "{id:[0-9]+}") uses paramChild.
+// Routes whose template ends at this node are collected in routes.
+type trieNode struct {
+	children   map[string]*trieNode
+	paramChild *trieNode
+	routes     []*routeEntry
+}
+
+func newTrieNode() *trieNode { return &trieNode{children: make(map[string]*trieNode)} }
+
+// routeIndex accelerates route matching to O(path length) — independent of the
+// number of registered routes — by narrowing the candidate set with a segment
+// trie and then delegating the ACTUAL match to mux's own Route.Match. Because
+// the final decision is still mux's, every mux semantic (method matching,
+// {id:regex} constraints, header/query/host matchers, path cleaning) is
+// preserved exactly; the trie only avoids mux's O(n) linear scan.
+//
+// The O(path length) property applies to trie-indexable routes (plain exact
+// paths). Routes that cannot be indexed (PathPrefix/static, slash-spanning
+// params) live in the fallback list, which is scanned on every request — so an
+// app that registers many such routes stays linear in the size of that set. In
+// practice the fallback set is small (a handful of static/catch-all routes), so
+// the "flat as route count grows" result holds for realistic route tables.
+type routeIndex struct {
+	root     *trieNode
+	fallback []*routeEntry // routes with no indexable path template (PathPrefix, host-only, ...)
+}
+
+func newRouteIndex() *routeIndex { return &routeIndex{root: newTrieNode()} }
+
+// build indexes every route the given mux router knows about, in registration
+// order. Routes with a plain segmented path go into the trie; anything else
+// (PathPrefix, host-only, matcher-only) goes into the order-preserving fallback
+// list so it is still considered on every request.
+func (idx *routeIndex) build(router *mux.Router) {
+	order := 0
+
+	// Walk visits routes in registration order. The walk func never returns an
+	// error, so the walk always completes and every route is classified.
+	_ = router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		e := &routeEntry{route: route, order: order}
+		order++
+
+		tpl, ok := exactPathTemplate(route)
+		if !ok {
+			idx.fallback = append(idx.fallback, e)
+
+			return nil
+		}
+
+		idx.insert(tpl, e)
+
+		return nil
+	})
+}
+
+// exactPathTemplate returns the path template of route and true only when the
+// route can be safely trie-indexed: a full, exact path whose every segment maps
+// to exactly one request-path segment. It returns false — deferring the route
+// to the always-evaluated fallback list, where mux's own Route.Match decides it
+// — for:
+//
+//   - PathPrefix/static handlers (un-anchored path regexp);
+//   - routes whose path template does not start with "/" or has no path at all;
+//   - routes with a parameter whose regex can match "/" (e.g. "{path:.*}"), which
+//     can span multiple request-path segments and therefore cannot be located by
+//     the trie's segment-by-segment walk;
+//   - routes with a mixed literal+parameter segment (e.g. "/{name}.txt" or
+//     "/user-{id}"), which the whole-segment trie keys cannot represent.
+//
+// Trie membership is purely an acceleration decision: correctness never depends
+// on it, because match() runs mux's real Route.Match on whichever candidate is
+// selected regardless of which list it came from. Host/header/query matchers on
+// an otherwise-exact path are thus safe to index — Route.Match still enforces
+// them — so they are intentionally not excluded here.
+//
+// The exact-vs-prefix discriminator is the path regexp: mux end-anchors an exact
+// path ("^/users/([^/]+)$") but leaves a PathPrefix un-anchored ("^/static/").
+func exactPathTemplate(route *mux.Route) (string, bool) {
+	tpl, err := route.GetPathTemplate()
+	if err != nil || !strings.HasPrefix(tpl, "/") {
+		return "", false
+	}
+
+	rx, err := route.GetPathRegexp()
+	if err != nil || !strings.HasSuffix(rx, "$") {
+		return "", false
+	}
+
+	// A parameter whose regex can match "/" (e.g. "{path:.*}") spans multiple
+	// request-path segments and cannot be located by the segment-by-segment
+	// trie walk, so such a route must go to the fallback list. The literal "/"
+	// separators live at the top level of the path regexp; only the capture
+	// groups (the params) are inspected here.
+	if pathRegexpHasSlashInCapture(rx) {
+		return "", false
+	}
+
+	// The trie keys each segment as a whole — either a literal ("users") or a
+	// single parameter ("{id}"). A segment that mixes a literal with a parameter
+	// ("{name}.txt", "user-{id}", "v{ver}") is neither, so it cannot be indexed
+	// by a whole-segment key; defer such routes to the fallback list.
+	for _, seg := range pathSegments(tpl) {
+		if strings.Contains(seg, "{") && !isParamSegment(seg) {
+			return "", false
+		}
+	}
+
+	return tpl, true
+}
+
+// pathRegexpHasSlashInCapture reports whether any capturing group in the mux
+// path regexp rx can match a "/". It over-approximates: a regexp it cannot parse
+// is treated as slash-capable, so a route is trie-indexed only when its params
+// are provably slash-free (no false negatives — a spanning route is never wrongly
+// indexed and silently lost).
+func pathRegexpHasSlashInCapture(rx string) bool {
+	re, err := syntax.Parse(rx, syntax.Perl)
+	if err != nil {
+		return true
+	}
+
+	return anyCaptureMatchesSlash(re)
+}
+
+// anyCaptureMatchesSlash walks re and reports whether any OpCapture subtree can
+// match a "/".
+func anyCaptureMatchesSlash(re *syntax.Regexp) bool {
+	if re.Op == syntax.OpCapture && reNodeMayMatchSlash(re) {
+		return true
+	}
+
+	for _, sub := range re.Sub {
+		if anyCaptureMatchesSlash(sub) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// reNodeMayMatchSlash reports whether the regexp subtree re can match a "/".
+func reNodeMayMatchSlash(re *syntax.Regexp) bool {
+	if opEmitsSlash(re) {
+		return true
+	}
+
+	for _, sub := range re.Sub {
+		if reNodeMayMatchSlash(sub) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// opEmitsSlash reports whether this single regexp node (ignoring its children)
+// can itself contribute a "/". Only literal/char-class/any-char ops can; every
+// other op is purely structural and defers to its children.
+//
+//nolint:exhaustive // only the char-producing ops can introduce a "/"; the rest are structural.
+func opEmitsSlash(re *syntax.Regexp) bool {
+	switch re.Op {
+	case syntax.OpAnyChar, syntax.OpAnyCharNotNL:
+		// "." matches "/" in Go's regexp (only newline is excluded).
+		return true
+	case syntax.OpLiteral:
+		for _, r := range re.Rune {
+			if r == '/' {
+				return true
+			}
+		}
+	case syntax.OpCharClass:
+		// Rune holds inclusive [lo, hi] range pairs.
+		for i := 0; i+1 < len(re.Rune); i += 2 {
+			if re.Rune[i] <= '/' && '/' <= re.Rune[i+1] {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (idx *routeIndex) insert(tpl string, e *routeEntry) {
+	cur := idx.root
+
+	for _, seg := range pathSegments(tpl) {
+		if isParamSegment(seg) {
+			if cur.paramChild == nil {
+				cur.paramChild = newTrieNode()
+			}
+
+			cur = cur.paramChild
+
+			continue
+		}
+
+		next, ok := cur.children[seg]
+		if !ok {
+			next = newTrieNode()
+			cur.children[seg] = next
+		}
+
+		cur = next
+	}
+
+	cur.routes = append(cur.routes, e)
+}
+
+// candidates gathers every route whose template structurally lines up with path
+// by exploring both the literal and the parameter branch at each segment
+// (backtracking). This is O(path length × small branching), never O(route
+// count). A route the trie omits here could not have matched path anyway, so
+// omitting it does not change the final result.
+func (idx *routeIndex) candidates(path string) []*routeEntry {
+	var out []*routeEntry
+
+	var walk func(n *trieNode, segs []string)
+
+	walk = func(n *trieNode, segs []string) {
+		if len(segs) == 0 {
+			out = append(out, n.routes...)
+
+			return
+		}
+
+		seg, rest := segs[0], segs[1:]
+
+		if child, ok := n.children[seg]; ok {
+			walk(child, rest)
+		}
+
+		if n.paramChild != nil {
+			walk(n.paramChild, rest)
+		}
+	}
+
+	walk(idx.root, pathSegments(path))
+
+	return out
+}
+
+// match narrows candidates via the trie, adds the fallback routes, orders the
+// whole set by registration order, and returns mux's own match for the first
+// candidate that fully matches — identical to what stock mux would pick, only
+// without scanning every registered route.
+//
+// It reports true and fills rm on a full match. On no match it returns false;
+// if some candidate matched the path but not the method, rm.MatchErr is set to
+// mux.ErrMethodMismatch so the caller can render 405 rather than 404.
+//
+// Note: inside a running GoFr app this 405 path is effectively unreachable. GoFr
+// registers a PathPrefix("/") catch-all (see gofr.go) that matches any method,
+// so a wrong-method request to an existing path is a FULL match on the catch-all
+// and returns before methodMismatch is consulted — yielding the same 404 as mux.
+// The 405 result only surfaces on a bare Router with no catch-all (e.g. unit
+// tests), which is why the documented 404->405 divergence is framework-moot.
+func (idx *routeIndex) match(req *http.Request, rm *mux.RouteMatch) bool {
+	cands := idx.candidates(req.URL.Path)
+	cands = append(cands, idx.fallback...)
+
+	if len(cands) > 1 {
+		sort.Slice(cands, func(i, j int) bool { return cands[i].order < cands[j].order })
+	}
+
+	methodMismatch := false
+
+	for _, e := range cands {
+		var m mux.RouteMatch
+
+		if e.route.Match(req, &m) && m.MatchErr == nil {
+			*rm = m
+
+			return true
+		}
+
+		if errors.Is(m.MatchErr, mux.ErrMethodMismatch) {
+			methodMismatch = true
+		}
+	}
+
+	if methodMismatch {
+		rm.MatchErr = mux.ErrMethodMismatch
+	}
+
+	return false
+}
+
+// pathSegments splits a path into its non-empty segments. "/" yields no
+// segments; "/users/{id}" yields ["users", "{id}"].
+func pathSegments(p string) []string {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return nil
+	}
+
+	return strings.Split(p, "/")
+}
+
+// isParamSegment reports whether a template segment is a mux parameter, i.e.
+// "{name}" or "{name:regex}".
+func isParamSegment(seg string) bool {
+	return strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}")
+}

--- a/pkg/gofr/http/trie_router.go
+++ b/pkg/gofr/http/trie_router.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 	"regexp/syntax"
-	"sort"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -75,28 +74,22 @@ func (idx *routeIndex) build(router *mux.Router) {
 	})
 }
 
-// exactPathTemplate returns the path template of route and true only when the
-// route can be safely trie-indexed: a full, exact path whose every segment maps
-// to exactly one request-path segment. It returns false — deferring the route
-// to the always-evaluated fallback list, where mux's own Route.Match decides it
-// — for:
+// exactPathTemplate returns the path template of route, and true only when the
+// route's shape can be proven trie-indexable by isIndexablePathRegexp — a fully
+// anchored path whose every segment maps to exactly one request-path segment.
+// Everything else goes to the always-evaluated fallback list, where mux's own
+// Route.Match decides it.
 //
-//   - PathPrefix/static handlers (un-anchored path regexp);
-//   - routes whose path template does not start with "/" or has no path at all;
-//   - routes with a parameter whose regex can match "/" (e.g. "{path:.*}"), which
-//     can span multiple request-path segments and therefore cannot be located by
-//     the trie's segment-by-segment walk;
-//   - routes with a mixed literal+parameter segment (e.g. "/{name}.txt" or
-//     "/user-{id}"), which the whole-segment trie keys cannot represent.
+// A segment that mixes a literal with a parameter ("{name}.txt", "user-{id}") is
+// still indexable: it matches exactly one path segment, so it is inserted as a
+// parameter slot (see segmentHasParam) and mux validates the intra-segment
+// pattern.
 //
 // Trie membership is purely an acceleration decision: correctness never depends
 // on it, because match() runs mux's real Route.Match on whichever candidate is
 // selected regardless of which list it came from. Host/header/query matchers on
 // an otherwise-exact path are thus safe to index — Route.Match still enforces
 // them — so they are intentionally not excluded here.
-//
-// The exact-vs-prefix discriminator is the path regexp: mux end-anchors an exact
-// path ("^/users/([^/]+)$") but leaves a PathPrefix un-anchored ("^/static/").
 func exactPathTemplate(route *mux.Route) (string, bool) {
 	tpl, err := route.GetPathTemplate()
 	if err != nil || !strings.HasPrefix(tpl, "/") {
@@ -104,55 +97,129 @@ func exactPathTemplate(route *mux.Route) (string, bool) {
 	}
 
 	rx, err := route.GetPathRegexp()
-	if err != nil || !strings.HasSuffix(rx, "$") {
+	if err != nil {
 		return "", false
 	}
 
-	// A parameter whose regex can match "/" (e.g. "{path:.*}") spans multiple
-	// request-path segments and cannot be located by the segment-by-segment
-	// trie walk, so such a route must go to the fallback list. The literal "/"
-	// separators live at the top level of the path regexp; only the capture
-	// groups (the params) are inspected here.
-	if pathRegexpHasSlashInCapture(rx) {
+	if !isIndexablePathRegexp(rx) {
 		return "", false
-	}
-
-	// The trie keys each segment as a whole — either a literal ("users") or a
-	// single parameter ("{id}"). A segment that mixes a literal with a parameter
-	// ("{name}.txt", "user-{id}", "v{ver}") is neither, so it cannot be indexed
-	// by a whole-segment key; defer such routes to the fallback list.
-	for _, seg := range pathSegments(tpl) {
-		if strings.Contains(seg, "{") && !isParamSegment(seg) {
-			return "", false
-		}
 	}
 
 	return tpl, true
 }
 
-// pathRegexpHasSlashInCapture reports whether any capturing group in the mux
-// path regexp rx can match a "/". It over-approximates: a regexp it cannot parse
-// is treated as slash-capable, so a route is trie-indexed only when its params
-// are provably slash-free (no false negatives — a spanning route is never wrongly
-// indexed and silently lost).
-func pathRegexpHasSlashInCapture(rx string) bool {
+// isIndexablePathRegexp decides, from mux's compiled path regexp, whether a
+// route's shape is one the segment trie can locate. It is an ALLOWLIST: it
+// returns true only for a pattern it can positively prove is
+//
+//   - anchored at both ends (an exact path, not a PathPrefix), and
+//   - built from captures that each match a non-empty, slash-free fragment,
+//
+// so the template's segment count always equals the request's segment count.
+// Anything it cannot prove — a regexp it cannot parse, a prefix pattern, a capture
+// that may span "/" ("{p:.*}") or match "" ("{p:[a-z]*}") — returns false and
+// the route goes to the fallback list, where mux's own Route.Match decides it.
+//
+// An allowlist is deliberate. Trie membership is only an acceleration decision
+// (match() always runs mux's real Route.Match on the candidates it produces), so
+// a route wrongly EXCLUDED merely loses speed, while a route wrongly INCLUDED is
+// a correctness bug — it can be dropped from the candidate set entirely and
+// silently 404 or fall through to another handler. Proving the shape is safe,
+// rather than enumerating unsafe shapes, keeps that failure mode impossible.
+//
+// Anchoring is checked on the parsed syntax tree, not by a "$" string suffix: a
+// template containing a literal "$" is QuoteMeta-escaped by mux, so a PathPrefix
+// such as "/p$" compiles to the unanchored "^/p\\$" — which ends in the byte "$"
+// yet must NOT be treated as an exact path.
+func isIndexablePathRegexp(rx string) bool {
 	re, err := syntax.Parse(rx, syntax.Perl)
 	if err != nil {
-		return true
+		return false
 	}
 
-	return anyCaptureMatchesSlash(re)
+	return isAnchoredBothEnds(re) && capturesAreSingleSegment(re)
 }
 
-// anyCaptureMatchesSlash walks re and reports whether any OpCapture subtree can
-// match a "/".
-func anyCaptureMatchesSlash(re *syntax.Regexp) bool {
-	if re.Op == syntax.OpCapture && reNodeMayMatchSlash(re) {
-		return true
+// isAnchoredBothEnds reports whether re begins with a begin-text anchor and ends
+// with an end-text anchor — mux's shape for an exact path ("^/users/([^/]+)$")
+// as opposed to a prefix ("^/static/").
+func isAnchoredBothEnds(re *syntax.Regexp) bool {
+	if re.Op != syntax.OpConcat || len(re.Sub) < 2 {
+		return false
+	}
+
+	first, last := re.Sub[0], re.Sub[len(re.Sub)-1]
+
+	beginOK := first.Op == syntax.OpBeginText || first.Op == syntax.OpBeginLine
+	endOK := last.Op == syntax.OpEndText || last.Op == syntax.OpEndLine
+
+	return beginOK && endOK
+}
+
+// capturesAreSingleSegment reports whether every capturing group in re matches a
+// non-empty, slash-free fragment — i.e. each parameter consumes text within
+// exactly one path segment, never spanning "/" and never vanishing.
+func capturesAreSingleSegment(re *syntax.Regexp) bool {
+	if re.Op == syntax.OpCapture && (reNodeMayMatchSlash(re) || canMatchEmpty(re)) {
+		return false
 	}
 
 	for _, sub := range re.Sub {
-		if anyCaptureMatchesSlash(sub) {
+		if !capturesAreSingleSegment(sub) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// canMatchEmpty reports whether the regexp subtree re can match the empty
+// string. Such a capture would let a template segment vanish, so the template's
+// segment count would no longer equal the request's and the trie walk would miss
+// the route (e.g. "/{s:[a-z]*}" must match the request "/"). Unrecognized ops
+// are reported as empty-matching, keeping the decision conservative.
+//
+//nolint:exhaustive // the default arm deliberately covers every remaining op conservatively.
+func canMatchEmpty(re *syntax.Regexp) bool {
+	switch re.Op {
+	case syntax.OpLiteral:
+		return len(re.Rune) == 0
+	case syntax.OpCharClass, syntax.OpAnyChar, syntax.OpAnyCharNotNL, syntax.OpNoMatch:
+		// Each of these consumes exactly one rune.
+		return false
+	case syntax.OpCapture, syntax.OpPlus:
+		// x+ matches empty only if x does; a capture defers to its body.
+		return canMatchEmpty(re.Sub[0])
+	case syntax.OpRepeat:
+		return re.Min == 0 || canMatchEmpty(re.Sub[0])
+	case syntax.OpConcat:
+		return allCanMatchEmpty(re.Sub)
+	case syntax.OpAlternate:
+		return anyCanMatchEmpty(re.Sub)
+	default:
+		// OpEmptyMatch, OpStar, OpQuest, anchors, word boundaries, and anything
+		// added to the syntax package later: assume it can match empty.
+		return true
+	}
+}
+
+// allCanMatchEmpty reports whether every branch can match empty — a concatenation
+// matches empty only if all of its parts do.
+func allCanMatchEmpty(subs []*syntax.Regexp) bool {
+	for _, sub := range subs {
+		if !canMatchEmpty(sub) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// anyCanMatchEmpty reports whether any branch can match empty — an alternation
+// matches empty if at least one of its arms does.
+func anyCanMatchEmpty(subs []*syntax.Regexp) bool {
+	for _, sub := range subs {
+		if canMatchEmpty(sub) {
 			return true
 		}
 	}
@@ -207,7 +274,7 @@ func (idx *routeIndex) insert(tpl string, e *routeEntry) {
 	cur := idx.root
 
 	for _, seg := range pathSegments(tpl) {
-		if isParamSegment(seg) {
+		if segmentHasParam(seg) {
 			if cur.paramChild == nil {
 				cur.paramChild = newTrieNode()
 			}
@@ -234,32 +301,27 @@ func (idx *routeIndex) insert(tpl string, e *routeEntry) {
 // (backtracking). This is O(path length × small branching), never O(route
 // count). A route the trie omits here could not have matched path anyway, so
 // omitting it does not change the final result.
-func (idx *routeIndex) candidates(path string) []*routeEntry {
-	var out []*routeEntry
+func (n *trieNode) collect(rest string, out *[]*routeEntry) {
+	if rest == "" {
+		*out = append(*out, n.routes...)
 
-	var walk func(n *trieNode, segs []string)
-
-	walk = func(n *trieNode, segs []string) {
-		if len(segs) == 0 {
-			out = append(out, n.routes...)
-
-			return
-		}
-
-		seg, rest := segs[0], segs[1:]
-
-		if child, ok := n.children[seg]; ok {
-			walk(child, rest)
-		}
-
-		if n.paramChild != nil {
-			walk(n.paramChild, rest)
-		}
+		return
 	}
 
-	walk(idx.root, pathSegments(path))
+	var seg, tail string
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		seg, tail = rest[:i], rest[i+1:]
+	} else {
+		seg, tail = rest, ""
+	}
 
-	return out
+	if child, ok := n.children[seg]; ok {
+		child.collect(tail, out)
+	}
+
+	if n.paramChild != nil {
+		n.paramChild.collect(tail, out)
+	}
 }
 
 // match narrows candidates via the trie, adds the fallback routes, orders the
@@ -278,34 +340,70 @@ func (idx *routeIndex) candidates(path string) []*routeEntry {
 // The 405 result only surfaces on a bare Router with no catch-all (e.g. unit
 // tests), which is why the documented 404->405 divergence is framework-moot.
 func (idx *routeIndex) match(req *http.Request, rm *mux.RouteMatch) bool {
-	cands := idx.candidates(req.URL.Path)
-	cands = append(cands, idx.fallback...)
+	var buf [12]*routeEntry
 
-	if len(cands) > 1 {
-		sort.Slice(cands, func(i, j int) bool { return cands[i].order < cands[j].order })
+	cands := buf[:0]
+	idx.root.collect(strings.Trim(req.URL.Path, "/"), &cands)
+
+	// mux matches the escaped path when the router is in UseEncodedPath mode,
+	// where the escaped and decoded forms can split into different segments.
+	// That flag is not readable from here, so when the two forms differ, walk
+	// both and take the union. Over-producing candidates is always safe (mux
+	// filters them); missing one would not be.
+	if esc := req.URL.EscapedPath(); esc != req.URL.Path {
+		idx.root.collect(strings.Trim(esc, "/"), &cands)
 	}
+
+	if len(idx.fallback) > 0 {
+		cands = append(cands, idx.fallback...)
+	}
+
+	sortByRegistrationOrder(cands)
 
 	methodMismatch := false
 
 	for _, e := range cands {
-		var m mux.RouteMatch
+		// Match writes into rm directly; reset it between candidates so a
+		// failed attempt cannot leak state into the next one. This avoids a
+		// per-candidate RouteMatch allocation.
+		*rm = mux.RouteMatch{}
 
-		if e.route.Match(req, &m) && m.MatchErr == nil {
-			*rm = m
-
+		// Mirror mux.Router.ServeHTTP: the first route whose Match succeeds
+		// wins, whatever MatchErr says. A subrouter with its own
+		// NotFoundHandler reports a successful match with MatchErr set to
+		// ErrNotFound and its handler in rm.Handler, and mux serves exactly
+		// that; requiring MatchErr == nil here would skip it and fall through
+		// to an unrelated route.
+		if e.route.Match(req, rm) {
 			return true
 		}
 
-		if errors.Is(m.MatchErr, mux.ErrMethodMismatch) {
+		if errors.Is(rm.MatchErr, mux.ErrMethodMismatch) {
 			methodMismatch = true
 		}
 	}
+
+	*rm = mux.RouteMatch{}
 
 	if methodMismatch {
 		rm.MatchErr = mux.ErrMethodMismatch
 	}
 
 	return false
+}
+
+// sortByRegistrationOrder orders candidates by their registration index so the
+// scan reproduces mux's first-registered-wins semantics. Insertion sort: the
+// candidate set is tiny (a handful at most) and, unlike sort.Slice, this
+// allocates nothing — sort.Slice's reflect-based swapper would otherwise cost an
+// allocation on every single request, since GoFr's PathPrefix("/") catch-all
+// means the set is essentially never of length one.
+func sortByRegistrationOrder(cands []*routeEntry) {
+	for i := 1; i < len(cands); i++ {
+		for j := i; j > 0 && cands[j].order < cands[j-1].order; j-- {
+			cands[j], cands[j-1] = cands[j-1], cands[j]
+		}
+	}
 }
 
 // pathSegments splits a path into its non-empty segments. "/" yields no
@@ -319,8 +417,14 @@ func pathSegments(p string) []string {
 	return strings.Split(p, "/")
 }
 
-// isParamSegment reports whether a template segment is a mux parameter, i.e.
-// "{name}" or "{name:regex}".
-func isParamSegment(seg string) bool {
-	return strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}")
+// segmentHasParam reports whether a template segment contains a mux parameter —
+// a whole-segment param ("{id}", "{id:[0-9]+}") or a param embedded with literal
+// text ("{name}.txt", "user-{id}", "{a}.{b}"). Any such segment matches exactly
+// one path segment, because slash-spanning params are excluded upstream (see
+// exactPathTemplate) and routed to the fallback list. It is therefore indexed as
+// a single parameter slot in the trie, and mux's Route.Match enforces the exact
+// intra-segment pattern — the trie only needs to produce the route as a
+// candidate, never to decide it.
+func segmentHasParam(seg string) bool {
+	return strings.Contains(seg, "{")
 }

--- a/pkg/gofr/http/trie_router_test.go
+++ b/pkg/gofr/http/trie_router_test.go
@@ -1,0 +1,374 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file is the differential ("characterization") gate for the trie router.
+// The discipline: register an identical route set on the default mux router and
+// on the trie router, replay the same requests through both, and require the
+// observable outcome — status code, body, and extracted path params — to be
+// byte-for-byte identical. mux is the oracle; any divergence is either a bug to
+// fix or a consciously documented intentional change.
+
+// routeDef is one route registration used by both routers.
+type routeDef struct {
+	method  string
+	pattern string
+}
+
+// echoHandler reports, as JSON, exactly what the router resolved for a request:
+// the path params (via mux.Vars, which must work under both routers) and the
+// route template. Comparing these across routers proves they matched the same
+// route with the same variables.
+func echoHandler(tag string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+		keys := make([]string, 0, len(vars))
+		for k := range vars {
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
+		ordered := make([][2]string, 0, len(keys))
+		for _, k := range keys {
+			ordered = append(ordered, [2]string{k, vars[k]})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"tag": tag, "vars": ordered})
+	})
+}
+
+// buildRouter constructs a Router in the requested mode with the given routes.
+func buildRouter(routes []routeDef, useTrie bool) *Router {
+	r := NewRouter()
+	r.useTrie = useTrie
+
+	for _, rd := range routes {
+		r.Add(rd.method, rd.pattern, echoHandler(rd.method+" "+rd.pattern))
+	}
+
+	return r
+}
+
+// serve runs one request and returns the response status and body.
+func serve(router *Router, method, target string) (status int, body string) {
+	req := httptest.NewRequestWithContext(context.Background(), method, target, http.NoBody)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	return rec.Code, rec.Body.String()
+}
+
+type reqCase struct {
+	method string
+	target string
+}
+
+// runDifferential registers routes on both a mux and a trie router and asserts
+// every request yields an identical (status, body) from both.
+func runDifferential(t *testing.T, name string, routes []routeDef, cases []reqCase) {
+	t.Helper()
+
+	muxR := buildRouter(routes, false)
+	trieR := buildRouter(routes, true)
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%s/%s_%s", name, c.method, c.target), func(t *testing.T) {
+			muxStatus, muxBody := serve(muxR, c.method, c.target)
+			trieStatus, trieBody := serve(trieR, c.method, c.target)
+
+			require.Equalf(t, muxStatus, trieStatus,
+				"status differs for %s %s (mux=%d trie=%d)", c.method, c.target, muxStatus, trieStatus)
+			assert.Equalf(t, muxBody, trieBody,
+				"body differs for %s %s", c.method, c.target)
+		})
+	}
+}
+
+func TestTrieDifferential_StaticAndParams(t *testing.T) {
+	routes := []routeDef{
+		{http.MethodGet, "/users"},
+		{http.MethodGet, "/users/me"},         // static beats param when registered first
+		{http.MethodGet, "/users/{id}"},       // single param
+		{http.MethodGet, "/users/{id}/posts"}, // nested static after param
+		{http.MethodGet, "/orgs/{org}/repos/{repo}"},
+		{http.MethodPost, "/users/{id}"}, // same path, different method
+		{http.MethodGet, "/items/{id:[0-9]+}"},
+	}
+
+	cases := []reqCase{
+		{http.MethodGet, "/users"},
+		{http.MethodGet, "/users/me"},       // must hit the static route
+		{http.MethodGet, "/users/42"},       // must hit {id}
+		{http.MethodGet, "/users/42/posts"}, // nested
+		{http.MethodGet, "/orgs/gofr/repos/x"},
+		{http.MethodPost, "/users/42"},        // POST variant
+		{http.MethodGet, "/items/123"},        // regex passes
+		{http.MethodGet, "/items/abc"},        // regex fails -> 404
+		{http.MethodDelete, "/users/42"},      // no DELETE -> 405
+		{http.MethodGet, "/nonexistent"},      // unknown -> 404
+		{http.MethodGet, "/users/42/unknown"}, // partial depth -> 404
+	}
+
+	runDifferential(t, "static_params", routes, cases)
+}
+
+func TestTrieDifferential_OverlapOrder(t *testing.T) {
+	// Param registered BEFORE the static — mux tries in registration order, so
+	// /cfg/all is served by {key}. The trie must reproduce that exactly.
+	routes := []routeDef{
+		{http.MethodGet, "/cfg/{key}"},
+		{http.MethodGet, "/cfg/all"},
+	}
+
+	cases := []reqCase{
+		{http.MethodGet, "/cfg/all"}, // {key} wins because registered first
+		{http.MethodGet, "/cfg/x"},
+	}
+
+	runDifferential(t, "overlap_order", routes, cases)
+}
+
+func TestTrieDifferential_TrailingSlashAndNormalization(t *testing.T) {
+	routes := []routeDef{
+		{http.MethodGet, "/a/b"},
+		{http.MethodGet, "/"},
+		{http.MethodGet, "/x/{id}"},
+	}
+
+	cases := []reqCase{
+		{http.MethodGet, "/a/b"},
+		{http.MethodGet, "/a/b/"},     // trailing slash normalized
+		{http.MethodGet, "//a//b"},    // double slashes normalized
+		{http.MethodGet, "/a/./b"},    // dot segment
+		{http.MethodGet, "/a/c/../b"}, // dot-dot segment
+		{http.MethodGet, "/"},
+		{http.MethodGet, "/x/7?a=1&b=2"}, // query ignored, vars intact
+	}
+
+	runDifferential(t, "normalization", routes, cases)
+}
+
+// TestTrieDifferential_SlashSpanningParams covers routes whose param regex can
+// match "/" and therefore span multiple request-path segments — catch-all file
+// paths and proxy passthroughs, a standard mux idiom. These must go to the
+// fallback list so mux's own matcher resolves them; the trie must not silently
+// drop them.
+func TestTrieDifferential_SlashSpanningParams(t *testing.T) {
+	routes := []routeDef{
+		{http.MethodGet, "/files/{path:.*}"},     // classic catch-all
+		{http.MethodGet, "/proxy/{rest:.+}"},     // non-empty catch-all
+		{http.MethodGet, "/mix/{a}/{b:[a-z/]+}"}, // slash allowed in a class
+		{http.MethodGet, "/items/{id:[0-9]+}"},   // slash-free regex: stays fast in trie
+		{http.MethodGet, "/plain/{name}"},        // plain param: single segment
+	}
+
+	cases := []reqCase{
+		{http.MethodGet, "/files/a/b/c.txt"}, // spans 3 segments -> vars{path:a/b/c.txt}
+		{http.MethodGet, "/files/single"},
+		{http.MethodGet, "/files/"}, // empty catch-all (.* matches "")
+		{http.MethodGet, "/proxy/x/y"},
+		{http.MethodGet, "/proxy/"},        // .+ needs >=1 char -> 404 in both
+		{http.MethodGet, "/mix/one/a/b/c"}, // {b} spans a/b/c
+		{http.MethodGet, "/items/42"},      // regex passes
+		{http.MethodGet, "/items/4/2"},     // extra segment -> 404 in both
+		{http.MethodGet, "/plain/bob"},
+		{http.MethodGet, "/plain/bob/extra"}, // extra segment -> 404 in both
+	}
+
+	runDifferential(t, "slash_spanning", routes, cases)
+}
+
+// TestTrieDifferential_MixedLiteralParamSegments covers segments that mix a
+// literal with a parameter ("/{name}.txt", "/user-{id}", "/v{ver}/x"). The trie
+// keys whole segments, so these can't be indexed and must fall through to mux
+// via the fallback list — the router must not drop them.
+func TestTrieDifferential_MixedLiteralParamSegments(t *testing.T) {
+	routes := []routeDef{
+		{http.MethodGet, "/files/{name}.txt"}, // param with a literal suffix
+		{http.MethodGet, "/user-{id}"},        // literal prefix + param
+		{http.MethodGet, "/v{ver}/x"},         // literal+param, then a static segment
+		{http.MethodGet, "/{lang}-{region}"},  // two params + a literal separator
+		{http.MethodGet, "/pure/{id}"},        // control: pure param stays trie-indexed
+	}
+
+	cases := []reqCase{
+		{http.MethodGet, "/files/report.txt"}, // vars{name:report}
+		{http.MethodGet, "/files/report.csv"}, // wrong suffix -> 404 in both
+		{http.MethodGet, "/user-42"},          // vars{id:42}
+		{http.MethodGet, "/v2/x"},             // vars{ver:2}
+		{http.MethodGet, "/en-US"},            // vars{lang:en,region:US}
+		{http.MethodGet, "/pure/9"},
+	}
+
+	runDifferential(t, "mixed_seg", routes, cases)
+}
+
+// TestTrieDifferential_KnownMethodMismatchDivergence pins the ONE intentional,
+// documented behavior difference between the two routers (see trie_router.go and
+// the plan's characterization notes).
+//
+// When a request's method is wrong for a path that DOES exist, mux's status is
+// registration-order dependent: a later route whose path does not match resets
+// mux's internal ErrMethodMismatch, so mux can report 404 instead of 405. The
+// trie decides method-mismatch over the narrowed candidate set and therefore
+// reports the more correct 405. This affects only the status code (404 vs 405)
+// of wrong-method requests to existing paths; it never changes which handler a
+// valid request reaches, nor its params or body. It is inert by default because
+// the trie router is opt-in (GOFR_ROUTER=trie).
+func TestTrieDifferential_KnownMethodMismatchDivergence(t *testing.T) {
+	routes := []routeDef{
+		{http.MethodPost, "/a/{id}"}, // only POST on this path
+		{http.MethodGet, "/a/b"},     // a later, non-overlapping path
+	}
+
+	muxR := buildRouter(routes, false)
+	trieR := buildRouter(routes, true)
+
+	// GET /a/xyz: path matches /a/{id} (wrong method). mux resets its
+	// method-mismatch via the later /a/b route -> 404; trie -> 405.
+	muxStatus, _ := serve(muxR, http.MethodGet, "/a/xyz")
+	trieStatus, _ := serve(trieR, http.MethodGet, "/a/xyz")
+
+	assert.Equal(t, http.StatusNotFound, muxStatus, "mux baseline: registration-order 404")
+	assert.Equal(t, http.StatusMethodNotAllowed, trieStatus, "trie: more-correct 405 for existing path, wrong method")
+}
+
+// TestTrieDifferential_MiddlewareParity asserts the middleware chain runs the
+// same number of times under both routers for matched, 404, and 405 requests.
+// mux applies its chain only on a successful match (never around NotFound /
+// MethodNotAllowed), so the trie must not run middleware on unmatched requests
+// either — otherwise 404s would be logged/measured and CORS-answered, and the
+// metrics path label would be populated from a raw unbounded path.
+func TestTrieDifferential_MiddlewareParity(t *testing.T) {
+	build := func(useTrie bool, counter *int) *Router {
+		rt := NewRouter()
+		rt.useTrie = useTrie
+		rt.Add(http.MethodGet, "/hit", echoHandler("hit"))
+		rt.Add(http.MethodPost, "/only-post", echoHandler("op"))
+		rt.UseMiddleware(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				*counter++
+
+				next.ServeHTTP(w, r)
+			})
+		})
+
+		return rt
+	}
+
+	cases := []struct {
+		name           string
+		method, target string
+	}{
+		{"matched", http.MethodGet, "/hit"},
+		{"not_found", http.MethodGet, "/missing"},
+		{"method_not_allowed", http.MethodGet, "/only-post"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var muxN, trieN int
+
+			serve(build(false, &muxN), c.method, c.target)
+			serve(build(true, &trieN), c.method, c.target)
+
+			assert.Equalf(t, muxN, trieN,
+				"middleware invocation count differs for %s %s (mux=%d trie=%d)",
+				c.method, c.target, muxN, trieN)
+		})
+	}
+}
+
+func TestTrieDifferential_MethodsAndFallback(t *testing.T) {
+	// A header-constrained route (fallback) plus a plain route on the same path
+	// exercises registration-order fidelity across the trie/fallback boundary.
+	r := func(useTrie bool) *Router {
+		rt := NewRouter()
+		rt.useTrie = useTrie
+		rt.Router.NewRoute().Methods(http.MethodGet).Path("/gated").
+			Headers("X-Key", "secret").Handler(echoHandler("gated-hdr"))
+		rt.Add(http.MethodGet, "/gated", echoHandler("gated-plain"))
+
+		return rt
+	}
+
+	muxR, trieR := r(false), r(true)
+
+	do := func(router *Router, hdr string) (int, string) {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/gated", http.NoBody)
+		if hdr != "" {
+			req.Header.Set("X-Key", hdr)
+		}
+
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		return rec.Code, rec.Body.String()
+	}
+
+	for _, hdr := range []string{"secret", "wrong", ""} {
+		ms, mb := do(muxR, hdr)
+		ts, tb := do(trieR, hdr)
+		require.Equalf(t, ms, ts, "status differs for header %q", hdr)
+		assert.Equalf(t, mb, tb, "body differs for header %q", hdr)
+	}
+}
+
+// benchmarkRouterMatch measures per-request route matching as the number of
+// registered routes grows, for one router mode. mux scans routes linearly
+// (O(n)); the trie narrows to O(path length), so its cost should stay roughly
+// flat as n rises.
+func benchmarkRouterMatch(b *testing.B, useTrie bool) {
+	b.Helper()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("routes=%d", n), func(b *testing.B) {
+			r := NewRouter()
+			r.useTrie = useTrie
+
+			for i := 0; i < n; i++ {
+				r.Add(http.MethodGet, fmt.Sprintf("/resource-%d/{id}", i), handler)
+			}
+
+			// Match the LAST-registered route: worst case for a linear scan,
+			// unaffected by position for a trie.
+			target := fmt.Sprintf("/resource-%d/42", n-1)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, target, http.NoBody)
+			w := httptest.NewRecorder()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				r.ServeHTTP(w, req)
+			}
+		})
+	}
+}
+
+// BenchmarkRouterMatchMux is the O(n) baseline (default router).
+func BenchmarkRouterMatchMux(b *testing.B) { benchmarkRouterMatch(b, false) }
+
+// BenchmarkRouterMatchTrie is the trie matcher (GOFR_ROUTER=trie); its cost
+// should stay flat as the route count grows.
+func BenchmarkRouterMatchTrie(b *testing.B) { benchmarkRouterMatch(b, true) }

--- a/pkg/gofr/http/trie_router_test.go
+++ b/pkg/gofr/http/trie_router_test.go
@@ -194,29 +194,69 @@ func TestTrieDifferential_SlashSpanningParams(t *testing.T) {
 	runDifferential(t, "slash_spanning", routes, cases)
 }
 
-// TestTrieDifferential_MixedLiteralParamSegments covers segments that mix a
-// literal with a parameter ("/{name}.txt", "/user-{id}", "/v{ver}/x"). The trie
-// keys whole segments, so these can't be indexed and must fall through to mux
-// via the fallback list — the router must not drop them.
-func TestTrieDifferential_MixedLiteralParamSegments(t *testing.T) {
-	routes := []routeDef{
-		{http.MethodGet, "/files/{name}.txt"}, // param with a literal suffix
-		{http.MethodGet, "/user-{id}"},        // literal prefix + param
-		{http.MethodGet, "/v{ver}/x"},         // literal+param, then a static segment
-		{http.MethodGet, "/{lang}-{region}"},  // two params + a literal separator
-		{http.MethodGet, "/pure/{id}"},        // control: pure param stays trie-indexed
+// mixedSegmentRoutes exercises every single-segment pattern shape mux supports:
+// a param with a literal suffix, prefix, or both; regex params with an affix;
+// adjacent and multi params; and a pure literal sharing a position with a mixed
+// one. All match exactly one path segment, so the trie indexes each as a param
+// slot and mux validates the intra-segment pattern.
+func mixedSegmentRoutes() []routeDef {
+	return []routeDef{
+		{http.MethodGet, "/files/{name}.txt"},         // literal suffix
+		{http.MethodGet, "/files/pinned.txt"},         // pure literal at the SAME position
+		{http.MethodGet, "/user-{id}"},                // literal prefix
+		{http.MethodGet, "/pre-{x}-post"},             // literal on both sides
+		{http.MethodGet, "/v{ver}/x"},                 // mixed, then a static segment
+		{http.MethodGet, "/{a}.{b}"},                  // two params + a literal separator
+		{http.MethodGet, "/{lang}-{region}"},          // two params, whole-segment braces
+		{http.MethodGet, "/img/{id:[0-9]+}.png"},      // regex param + literal suffix
+		{http.MethodGet, "/mix/{y:[a-z]+}.json/tail"}, // regex+suffix, then static
+		{http.MethodGet, "/plain/{id}"},               // control: pure param
 	}
+}
 
+// TestTrieDifferential_MixedLiteralParamSegments covers segments that mix a
+// literal with a parameter. These match exactly one path segment, so the trie
+// indexes them as a parameter slot (mux validates the exact pattern) — they are
+// NOT deferred to the fallback list. Verified byte-identical to mux across a
+// battery of affix / regex / adjacency / overlap / negative cases.
+func TestTrieDifferential_MixedLiteralParamSegments(t *testing.T) {
 	cases := []reqCase{
 		{http.MethodGet, "/files/report.txt"}, // vars{name:report}
-		{http.MethodGet, "/files/report.csv"}, // wrong suffix -> 404 in both
+		{http.MethodGet, "/files/report.csv"}, // wrong suffix -> 404 both
+		{http.MethodGet, "/files/pinned.txt"}, // literal wins by registration order
+		{http.MethodGet, "/files/a.b.txt"},    // dots inside the param value
 		{http.MethodGet, "/user-42"},          // vars{id:42}
+		{http.MethodGet, "/user-"},            // empty param -> 404 both
+		{http.MethodGet, "/admin-42"},         // wrong prefix -> 404 both
+		{http.MethodGet, "/pre-mid-post"},     // vars{x:mid}
 		{http.MethodGet, "/v2/x"},             // vars{ver:2}
+		{http.MethodGet, "/v/x"},              // empty param -> 404 both
+		{http.MethodGet, "/x.y"},              // vars{a:x,b:y}
 		{http.MethodGet, "/en-US"},            // vars{lang:en,region:US}
-		{http.MethodGet, "/pure/9"},
+		{http.MethodGet, "/img/123.png"},      // regex passes
+		{http.MethodGet, "/img/12a.png"},      // regex fails -> 404 both
+		{http.MethodGet, "/mix/abc.json/tail"},
+		{http.MethodGet, "/mix/ab1.json/tail"}, // regex fails -> 404 both
+		{http.MethodGet, "/plain/9"},
+		{http.MethodGet, "/plain/9/extra"}, // extra segment -> 404 both
 	}
 
-	runDifferential(t, "mixed_seg", routes, cases)
+	runDifferential(t, "mixed_seg", mixedSegmentRoutes(), cases)
+}
+
+// TestTrieRouter_MixedSegmentsAreIndexed asserts the mixed/param routes are
+// actually trie-indexed (not sitting in the linearly-scanned fallback list), so
+// the O(path) property holds for them too.
+func TestTrieRouter_MixedSegmentsAreIndexed(t *testing.T) {
+	r := buildRouter(mixedSegmentRoutes(), true)
+
+	r.buildIdx.Do(func() {
+		idx := newRouteIndex()
+		idx.build(&r.Router)
+		r.idx = idx
+	})
+
+	assert.Empty(t, r.idx.fallback, "all slash-free mixed/param routes must be trie-indexed, not in fallback")
 }
 
 // TestTrieDifferential_KnownMethodMismatchDivergence pins the ONE intentional,
@@ -341,7 +381,7 @@ func benchmarkRouterMatch(b *testing.B, useTrie bool) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	for _, n := range []int{10, 100, 1000} {
+	for _, n := range []int{1, 10, 20, 50, 100, 200} {
 		b.Run(fmt.Sprintf("routes=%d", n), func(b *testing.B) {
 			r := NewRouter()
 			r.useTrie = useTrie
@@ -350,9 +390,16 @@ func benchmarkRouterMatch(b *testing.B, useTrie bool) {
 				r.Add(http.MethodGet, fmt.Sprintf("/resource-%d/{id}", i), handler)
 			}
 
-			// Match the LAST-registered route: worst case for a linear scan,
-			// unaffected by position for a trie.
-			target := fmt.Sprintf("/resource-%d/42", n-1)
+			// Every GoFr app registers a PathPrefix("/") catch-all, which lands
+			// in the fallback list and is therefore scanned on every request.
+			// Include it so the numbers reflect a real route table.
+			r.Router.NewRoute().PathPrefix("/").Handler(handler)
+
+			// Match the MIDDLE route. mux's scan cost is linear in registration
+			// position, so hitting the last route measures its worst case rather
+			// than what real traffic sees; the middle route is the average case.
+			// The trie is unaffected by position either way.
+			target := fmt.Sprintf("/resource-%d/42", n/2)
 			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, target, http.NoBody)
 			w := httptest.NewRecorder()
 
@@ -372,3 +419,239 @@ func BenchmarkRouterMatchMux(b *testing.B) { benchmarkRouterMatch(b, false) }
 // BenchmarkRouterMatchTrie is the trie matcher (GOFR_ROUTER=trie); its cost
 // should stay flat as the route count grows.
 func BenchmarkRouterMatchTrie(b *testing.B) { benchmarkRouterMatch(b, true) }
+
+// This file pins the router edge cases found by adversarial review. Each test
+// names the shape that previously diverged from mux, so a regression is
+// self-describing.
+
+// TestTrieDifferential_EmptyMatchingParams covers params whose regex can match
+// the empty string ("{s:[a-z]*}"). Such a template segment can vanish, so the
+// template's segment count no longer equals the request's and a segment-by-
+// segment walk cannot locate it — the route must go to the fallback list.
+//
+// This previously produced a SILENT WRONG ROUTE in the real GoFr shape: with the
+// PathPrefix("/") catch-all also registered, a request for "/" returned 200 from
+// both routers but ran the catch-all under the trie instead of the user handler.
+func TestTrieDifferential_EmptyMatchingParams(t *testing.T) {
+	routes := []routeDef{
+		{http.MethodGet, "/{s:[a-z]*}"},   // may match ""
+		{http.MethodGet, "/n/{n:[0-9]*}"}, // may match ""
+		{http.MethodGet, "/o/{a:(?:x)?}"}, // optional group
+		{http.MethodGet, "/r/{l:[a-z]{0,2}}"},
+		{http.MethodGet, "/ok/{id}"}, // control: cannot match ""
+	}
+
+	cases := []reqCase{
+		{http.MethodGet, "/"},      // the empty-match case
+		{http.MethodGet, "/abc"},   // non-empty
+		{http.MethodGet, "/n/"},    // trailing empty after normalization
+		{http.MethodGet, "/n/123"}, //
+		{http.MethodGet, "/o/"},    //
+		{http.MethodGet, "/o/x"},   //
+		{http.MethodGet, "/r/ab"},  //
+		{http.MethodGet, "/ok/7"},  // control
+	}
+
+	runDifferential(t, "empty_param", routes, cases)
+}
+
+// TestTrieDifferential_EmptyParamWithCatchAll reproduces the silent-wrong-route
+// shape directly: the user route and GoFr's default PathPrefix("/") catch-all
+// both match "/", so the status is 200 either way and only the BODY reveals
+// which handler ran.
+func TestTrieDifferential_EmptyParamWithCatchAll(t *testing.T) {
+	build := func(useTrie bool) *Router {
+		r := NewRouter()
+		r.useTrie = useTrie
+		r.Add(http.MethodGet, "/{s:[a-z]*}", echoHandler("user-handler"))
+		r.Router.NewRoute().PathPrefix("/").Handler(echoHandler("catch-all"))
+
+		return r
+	}
+
+	_, muxBody := serve(build(false), http.MethodGet, "/")
+	_, trieBody := serve(build(true), http.MethodGet, "/")
+
+	assert.Equal(t, muxBody, trieBody, "the same handler must run under both routers")
+}
+
+// TestTrieRouter_PrefixEndingInLiteralDollar covers a PathPrefix whose template
+// ends in a literal "$". mux QuoteMeta-escapes it, so the UNANCHORED prefix
+// regexp still ends in the byte "$" — a naive HasSuffix(rx, "$") check would
+// wrongly treat it as an exact path and index it.
+func TestTrieRouter_PrefixEndingInLiteralDollar(t *testing.T) {
+	build := func(useTrie bool) *Router {
+		r := NewRouter()
+		r.useTrie = useTrie
+		r.Router.NewRoute().PathPrefix("/p$").Handler(echoHandler("prefix"))
+
+		return r
+	}
+
+	muxStatus, muxBody := serve(build(false), http.MethodGet, "/p$/q")
+	trieStatus, trieBody := serve(build(true), http.MethodGet, "/p$/q")
+
+	require.Equal(t, muxStatus, trieStatus, "prefix route ending in a literal $ must still match")
+	assert.Equal(t, muxBody, trieBody)
+}
+
+// TestTrieRouter_SubrouterMiddlewareRuns guards the security-relevant case: a
+// subrouter's own middleware must run under the trie router too. It previously
+// did not when the parent prefix was misclassified as an exact path, so auth or
+// CORS registered via Subrouter().Use() was silently skipped.
+func TestTrieRouter_SubrouterMiddlewareRuns(t *testing.T) {
+	build := func(useTrie bool) *Router {
+		r := NewRouter()
+		r.useTrie = useTrie
+
+		sub := r.Router.PathPrefix("/api$").Subrouter()
+		sub.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("X-Sub", "yes")
+				next.ServeHTTP(w, req)
+			})
+		})
+		sub.Path("/users").Handler(echoHandler("sub-users"))
+
+		return r
+	}
+
+	do := func(router *Router) (int, string) {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api$/users", http.NoBody)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		return rec.Code, rec.Header().Get("X-Sub")
+	}
+
+	muxCode, muxHdr := do(build(false))
+	trieCode, trieHdr := do(build(true))
+
+	require.Equal(t, muxCode, trieCode)
+	assert.Equal(t, muxHdr, trieHdr, "subrouter middleware must run under both routers")
+}
+
+// TestTrieRouter_SubrouterNotFoundHandler covers a subrouter carrying its own
+// NotFoundHandler. mux reports a SUCCESSFUL match with MatchErr == ErrNotFound
+// and the subrouter's handler in the match; requiring MatchErr == nil would skip
+// it and fall through to an unrelated route.
+func TestTrieRouter_SubrouterNotFoundHandler(t *testing.T) {
+	build := func(useTrie bool) *Router {
+		r := NewRouter()
+		r.useTrie = useTrie
+
+		sub := r.Router.PathPrefix("/api").Subrouter()
+		sub.NotFoundHandler = echoHandler("SUB404")
+		sub.Path("/users").Handler(echoHandler("sub-users"))
+
+		r.Add(http.MethodGet, "/api/other", echoHandler("top-other"))
+
+		return r
+	}
+
+	muxR, trieR := build(false), build(true)
+
+	for _, target := range []string{"/api/other", "/api/zzz", "/api/users"} {
+		muxStatus, muxBody := serve(muxR, http.MethodGet, target)
+		trieStatus, trieBody := serve(trieR, http.MethodGet, target)
+
+		require.Equalf(t, muxStatus, trieStatus, "status differs for %s", target)
+		assert.Equalf(t, muxBody, trieBody, "handler differs for %s", target)
+	}
+}
+
+// TestTrieRouter_UseEncodedPath covers a router in UseEncodedPath mode, where
+// mux matches the ESCAPED path. The decoded and escaped forms can split into
+// different segment counts, so the trie walks both and unions the candidates.
+func TestTrieRouter_UseEncodedPath(t *testing.T) {
+	build := func(useTrie bool) *Router {
+		r := NewRouter()
+		r.useTrie = useTrie
+		r.Router.UseEncodedPath()
+		r.Router.NewRoute().Methods(http.MethodGet).Path("/a/{v}").Handler(echoHandler("one"))
+		r.Router.NewRoute().Methods(http.MethodGet).Path("/a/{x}/{y}").Handler(echoHandler("two"))
+
+		return r
+	}
+
+	muxR, trieR := build(false), build(true)
+
+	for _, target := range []string{"/a/x%2Fy", "/a/plain", "/a/p/q"} {
+		muxStatus, muxBody := serve(muxR, http.MethodGet, target)
+		trieStatus, trieBody := serve(trieR, http.MethodGet, target)
+
+		require.Equalf(t, muxStatus, trieStatus, "status differs for %s", target)
+		assert.Equalf(t, muxBody, trieBody, "handler/vars differ for %s", target)
+	}
+}
+
+// TestTrieRouter_IndexInvariant is the structural gate behind every other test:
+// for every request, no route that mux would match may be absent from the
+// candidate set the trie produces. Over-producing candidates is safe (mux
+// filters them); dropping one is the failure mode that causes silent 404s and
+// wrong handlers. This asserts the invariant directly rather than relying on a
+// particular request happening to expose a gap.
+func TestTrieRouter_IndexInvariant(t *testing.T) {
+	templates := []string{
+		"/", "/users", "/users/{id}", "/users/{id}/posts", "/{a}/{b}",
+		"/files/{name}.txt", "/user-{id}", "/{a}.{b}", "/img/{id:[0-9]+}.png",
+		"/files/{path:.*}", "/proxy/{rest:.+}", "/opt/{s:[a-z]*}", "/n/{n:[0-9]*}",
+		"/static/x", "/deep/a/b/c/d",
+	}
+
+	r := NewRouter()
+	r.useTrie = true
+
+	for i, tpl := range templates {
+		r.Add(http.MethodGet, tpl, echoHandler(fmt.Sprintf("h%d", i)))
+	}
+
+	r.Router.NewRoute().PathPrefix("/").Handler(echoHandler("catch-all"))
+
+	idx := newRouteIndex()
+	idx.build(&r.Router)
+
+	paths := []string{
+		"/", "/users", "/users/42", "/users/42/posts", "/a/b", "/files/x.txt",
+		"/user-9", "/x.y", "/img/12.png", "/files/a/b/c", "/proxy/z", "/opt/",
+		"/opt/abc", "/n/", "/n/5", "/static/x", "/deep/a/b/c/d", "/unknown/path",
+	}
+
+	for _, p := range paths {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, p, http.NoBody)
+		normalizePath(req)
+
+		// Every route mux itself would match must be among the candidates.
+		cands := make([]*routeEntry, 0, len(idx.fallback))
+
+		idx.root.collect(pathTrimForTest(req.URL.Path), &cands)
+		cands = append(cands, idx.fallback...)
+
+		inCandidates := make(map[*mux.Route]bool, len(cands))
+		for _, c := range cands {
+			inCandidates[c.route] = true
+		}
+
+		_ = r.Router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+			var m mux.RouteMatch
+			if route.Match(req, &m) {
+				assert.Truef(t, inCandidates[route],
+					"path %q: mux matches a route the trie never offered as a candidate", p)
+			}
+
+			return nil
+		})
+	}
+}
+
+func pathTrimForTest(p string) string {
+	for p != "" && p[0] == '/' {
+		p = p[1:]
+	}
+
+	for p != "" && p[len(p)-1] == '/' {
+		p = p[:len(p)-1]
+	}
+
+	return p
+}

--- a/pkg/gofr/http/trie_router_test.go
+++ b/pkg/gofr/http/trie_router_test.go
@@ -259,19 +259,23 @@ func TestTrieRouter_MixedSegmentsAreIndexed(t *testing.T) {
 	assert.Empty(t, r.idx.fallback, "all slash-free mixed/param routes must be trie-indexed, not in fallback")
 }
 
-// TestTrieDifferential_KnownMethodMismatchDivergence pins the ONE intentional,
-// documented behavior difference between the two routers (see trie_router.go and
-// the plan's characterization notes).
+// TestTrieDifferential_MethodMismatchParity pins the case that used to be the
+// one documented divergence between the routers, and now is not.
 //
-// When a request's method is wrong for a path that DOES exist, mux's status is
-// registration-order dependent: a later route whose path does not match resets
-// mux's internal ErrMethodMismatch, so mux can report 404 instead of 405. The
-// trie decides method-mismatch over the narrowed candidate set and therefore
-// reports the more correct 405. This affects only the status code (404 vs 405)
-// of wrong-method requests to existing paths; it never changes which handler a
-// valid request reaches, nor its params or body. It is inert by default because
-// the trie router is opt-in (GOFR_ROUTER=trie).
-func TestTrieDifferential_KnownMethodMismatchDivergence(t *testing.T) {
+// mux's 404-vs-405 for a wrong-method request is registration-order dependent.
+// In gorilla/mux's Route.Match, a matcher that SUCCEEDS clears any
+// ErrMethodMismatch a previous route left behind, and GoFr registers routes as
+// Methods(m).Path(p) — method matcher first. So below, the later GET /a/b clears
+// the mismatch recorded by POST /a/{id} purely because its method matches, even
+// though its path does not, and mux answers 404.
+//
+// That makes the 405 decision depend on routes whose path does not match the
+// request — precisely the routes the trie exists to skip — so no amount of
+// bookkeeping over the narrowed candidate set can reproduce it. serveTrie
+// therefore does not try: it hands every non-match to mux's own ServeHTTP, which
+// resolves it by the full scan. The two routers agree here by construction, not
+// by coincidence.
+func TestTrieDifferential_MethodMismatchParity(t *testing.T) {
 	routes := []routeDef{
 		{http.MethodPost, "/a/{id}"}, // only POST on this path
 		{http.MethodGet, "/a/b"},     // a later, non-overlapping path
@@ -280,13 +284,37 @@ func TestTrieDifferential_KnownMethodMismatchDivergence(t *testing.T) {
 	muxR := buildRouter(routes, false)
 	trieR := buildRouter(routes, true)
 
-	// GET /a/xyz: path matches /a/{id} (wrong method). mux resets its
-	// method-mismatch via the later /a/b route -> 404; trie -> 405.
+	// GET /a/xyz: the path matches /a/{id}, the method does not.
 	muxStatus, _ := serve(muxR, http.MethodGet, "/a/xyz")
 	trieStatus, _ := serve(trieR, http.MethodGet, "/a/xyz")
 
 	assert.Equal(t, http.StatusNotFound, muxStatus, "mux baseline: registration-order 404")
-	assert.Equal(t, http.StatusMethodNotAllowed, trieStatus, "trie: more-correct 405 for existing path, wrong method")
+	assert.Equal(t, muxStatus, trieStatus, "trie must reproduce mux's order-dependent status, not a 405")
+}
+
+// TestTrieRouter_UnmatchedFallsBackToMux asserts the safety property that the
+// delegation buys: a route missing from the trie index is still served.
+//
+// The index is normally built by serveTrie from the router's own routes, so this
+// installs a deliberately blind one — every route diverted to neither the trie
+// nor the fallback list — to simulate the worst outcome a classifier bug could
+// produce. Without the delegation this request 404s even though the route is
+// registered and matches; with it, mux's full scan finds the route and serves it,
+// so a classifier bug costs speed rather than correctness.
+func TestTrieRouter_UnmatchedFallsBackToMux(t *testing.T) {
+	r := NewRouter()
+	r.useTrie = true
+	r.Add(http.MethodGet, "/users/{id}", echoHandler("real-handler"))
+
+	// Pre-seed an empty index so the lazy build in serveTrie is skipped and the
+	// trie can match nothing at all.
+	r.buildIdx.Do(func() { r.idx = newRouteIndex() })
+
+	status, body := serve(r, http.MethodGet, "/users/42")
+
+	require.Equal(t, http.StatusOK, status, "an unindexed but registered route must still be served by mux")
+	assert.Contains(t, body, "real-handler")
+	assert.Contains(t, body, `"42"`, "mux must populate the path params it always would")
 }
 
 // TestTrieDifferential_MiddlewareParity asserts the middleware chain runs the

--- a/pkg/gofr/http/trie_router_test.go
+++ b/pkg/gofr/http/trie_router_test.go
@@ -564,7 +564,7 @@ func TestTrieRouter_SubrouterMiddlewareRuns(t *testing.T) {
 // and the subrouter's handler in the match; requiring MatchErr == nil would skip
 // it and fall through to an unrelated route.
 func TestTrieRouter_SubrouterNotFoundHandler(t *testing.T) {
-	build := func(useTrie bool) *Router {
+	build := func(useTrie bool, mwRuns *int) *Router {
 		r := NewRouter()
 		r.useTrie = useTrie
 
@@ -574,17 +574,33 @@ func TestTrieRouter_SubrouterNotFoundHandler(t *testing.T) {
 
 		r.Add(http.MethodGet, "/api/other", echoHandler("top-other"))
 
+		r.UseMiddleware(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				*mwRuns++
+
+				next.ServeHTTP(w, req)
+			})
+		})
+
 		return r
 	}
 
-	muxR, trieR := build(false), build(true)
-
+	// The middleware count is asserted, not just the status and body. This case is why: a subrouter
+	// NotFoundHandler answers 200 through mux and through the trie alike, so status and body agree
+	// while the chain does not. mux builds its chain only when MatchErr == nil, and this match carries
+	// ErrNotFound, so mux runs NO middleware here. The trie ran it, which meant such a request was
+	// logged, traced, metered and CORS-answered when mux would not have -- and with no path template
+	// on a PathPrefix route, the metrics label fell back to the raw request path.
 	for _, target := range []string{"/api/other", "/api/zzz", "/api/users"} {
-		muxStatus, muxBody := serve(muxR, http.MethodGet, target)
-		trieStatus, trieBody := serve(trieR, http.MethodGet, target)
+		var muxN, trieN int
+
+		muxStatus, muxBody := serve(build(false, &muxN), http.MethodGet, target)
+		trieStatus, trieBody := serve(build(true, &trieN), http.MethodGet, target)
 
 		require.Equalf(t, muxStatus, trieStatus, "status differs for %s", target)
 		assert.Equalf(t, muxBody, trieBody, "handler differs for %s", target)
+		assert.Equalf(t, muxN, trieN, "middleware invocation count differs for %s (mux=%d trie=%d)",
+			target, muxN, trieN)
 	}
 }
 

--- a/pkg/gofr/http/trie_router_test.go
+++ b/pkg/gofr/http/trie_router_test.go
@@ -317,6 +317,54 @@ func TestTrieRouter_UnmatchedFallsBackToMux(t *testing.T) {
 	assert.Contains(t, body, `"42"`, "mux must populate the path params it always would")
 }
 
+// TestTrieRouter_SubrouterMethodNotAllowedHandler is the other half of the match-with-error family,
+// and it is deliberately the OPPOSITE expectation from the NotFoundHandler case above: here the
+// middleware chain MUST run.
+//
+// A subrouter's MethodNotAllowedHandler also reports a successful match, but mux clears
+// ErrMethodMismatch the moment one of the route's matchers succeeds (the else arm of the matcher loop
+// in gorilla/mux route.go), so the match arrives with a nil MatchErr and mux builds its chain. A
+// blanket "skip the chain whenever the handler came from an error path" would be wrong here, which is
+// why the guard keys on MatchErr rather than on the kind of handler.
+func TestTrieRouter_SubrouterMethodNotAllowedHandler(t *testing.T) {
+	build := func(useTrie bool, mwRuns *int) *Router {
+		r := NewRouter()
+		r.useTrie = useTrie
+
+		sub := r.Router.PathPrefix("/mna").Subrouter()
+		sub.MethodNotAllowedHandler = echoHandler("SUB405")
+		sub.Path("/only-post").Methods(http.MethodPost).Handler(echoHandler("mna-post"))
+
+		r.UseMiddleware(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				*mwRuns++
+
+				next.ServeHTTP(w, req)
+			})
+		})
+
+		return r
+	}
+
+	for _, c := range []struct {
+		method, target string
+	}{
+		{http.MethodPost, "/mna/only-post"},   // the real route
+		{http.MethodDelete, "/mna/only-post"}, // wrong method -> the subrouter's 405 handler
+		{http.MethodGet, "/mna/absent"},       // no inner route at all
+	} {
+		var muxN, trieN int
+
+		muxStatus, muxBody := serve(build(false, &muxN), c.method, c.target)
+		trieStatus, trieBody := serve(build(true, &trieN), c.method, c.target)
+
+		require.Equalf(t, muxStatus, trieStatus, "status differs for %s %s", c.method, c.target)
+		assert.Equalf(t, muxBody, trieBody, "handler differs for %s %s", c.method, c.target)
+		assert.Equalf(t, muxN, trieN, "middleware count differs for %s %s (mux=%d trie=%d)",
+			c.method, c.target, muxN, trieN)
+	}
+}
+
 // TestTrieDifferential_MiddlewareParity asserts the middleware chain runs the
 // same number of times under both routers for matched, 404, and 405 requests.
 // mux applies its chain only on a successful match (never around NotFound /

--- a/pkg/gofr/http_server.go
+++ b/pkg/gofr/http_server.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
 	"gofr.dev/pkg/gofr/container"
 	gofrHTTP "gofr.dev/pkg/gofr/http"
 	"gofr.dev/pkg/gofr/http/middleware"
+	"gofr.dev/pkg/gofr/logging"
 	"gofr.dev/pkg/gofr/websocket"
 )
 
@@ -31,8 +33,34 @@ var (
 	errInvalidKeyFile         = errors.New("invalid key file")
 )
 
+// logRouterChoice reports the route matcher the router resolved to.
+//
+// It stays quiet for the default, which every service gets and nobody needs told
+// about. It speaks up for the two cases that are worth a line: the opt-in matcher
+// being active, and a GOFR_ROUTER value that was not understood — the latter
+// falls back to mux, which looks exactly like never having set the variable, so a
+// typo would otherwise cost the opt-in with nothing said.
+func logRouterChoice(logger logging.Logger, r *gofrHTTP.Router) {
+	requested := os.Getenv(gofrHTTP.RouterEnvVar)
+	if requested == "" {
+		return
+	}
+
+	if !strings.EqualFold(requested, r.Matcher()) {
+		logger.Warnf("unrecognized %s value %q, using the %q router; valid values are %q and %q",
+			gofrHTTP.RouterEnvVar, requested, r.Matcher(), gofrHTTP.MatcherMux, gofrHTTP.MatcherTrie)
+
+		return
+	}
+
+	logger.Infof("HTTP route matcher: %s", r.Matcher())
+}
+
 func newHTTPServer(c *container.Container, port int, middlewareConfigs middleware.Config) *httpServer {
 	r := gofrHTTP.NewRouter()
+
+	logRouterChoice(c.Logger, r)
+
 	wsManager := websocket.New()
 
 	r.Use(

--- a/pkg/gofr/http_server_test.go
+++ b/pkg/gofr/http_server_test.go
@@ -456,3 +456,65 @@ func BenchmarkRequest_FullChain_SDK(b *testing.B) {
 		h.ServeHTTP(w, req)
 	}
 }
+
+// TestLogRouterChoice covers the three shapes GOFR_ROUTER can take at startup.
+// The unrecognized case is the one that earns the log: it falls back to mux,
+// which is indistinguishable from leaving the variable unset, so without a
+// warning a typo costs the opt-in silently.
+func TestLogRouterChoice(t *testing.T) {
+	// The logger emits JSON, so quotes inside a message come back escaped — want
+	// is a fragment chosen to survive that.
+	cases := []struct {
+		name      string
+		env       string
+		want      string
+		wantLevel string
+	}{
+		{"unset stays quiet", "", "", ""},
+		{"trie is announced", gofrHTTP.MatcherTrie, "HTTP route matcher: trie", "INFO"},
+		{"typo is warned about", "tri", "unrecognized GOFR_ROUTER value", "WARN"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Always set it, empty included: the suite itself may be run with
+			// GOFR_ROUTER exported, and the "unset" case has to mean unset.
+			t.Setenv(gofrHTTP.RouterEnvVar, tc.env)
+
+			logs := testutil.StdoutOutputForFunc(func() {
+				c := container.NewContainer(config.NewMockConfig(map[string]string{"LOG_LEVEL": "INFO"}))
+				logRouterChoice(c.Logger, gofrHTTP.NewRouter())
+			})
+
+			if tc.wantLevel == "" {
+				assert.NotContains(t, logs, "route matcher")
+				assert.NotContains(t, logs, gofrHTTP.RouterEnvVar)
+
+				return
+			}
+
+			assert.Contains(t, logs, tc.want)
+			assert.Contains(t, logs, `"level":"`+tc.wantLevel+`"`)
+		})
+	}
+}
+
+// TestRouter_Matcher pins the accessor the startup log reads: it must report
+// what NewRouter actually resolved from the environment, including the fallback
+// to mux for a value that is not understood.
+func TestRouter_Matcher(t *testing.T) {
+	cases := map[string]string{
+		"":     gofrHTTP.MatcherMux,
+		"mux":  gofrHTTP.MatcherMux,
+		"trie": gofrHTTP.MatcherTrie,
+		"TRIE": gofrHTTP.MatcherTrie, // the lookup is case-insensitive
+		"tri":  gofrHTTP.MatcherMux,  // unrecognized falls back
+	}
+
+	for env, want := range cases {
+		t.Run("GOFR_ROUTER="+env, func(t *testing.T) {
+			t.Setenv(gofrHTTP.RouterEnvVar, env)
+			assert.Equal(t, want, gofrHTTP.NewRouter().Matcher())
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

GoFr routes on `gorilla/mux`, which matches with an **O(n) linear scan + per-route regexp**, so per-request routing cost climbs with the number of registered routes. Services with large route tables pay for this on every request — measured below, a 200-route service spends ~2.9 µs per request just locating the handler, and it keeps growing with the table.

This is **not** about dropping `gorilla/mux` — mux stays the route registry, keeps `mux.Vars`, route templates, and the whole registration API. It's purely about the matching cost. mux's `ServeHTTP` is exported/overridable, so this PR overrides just the matching step with a **radix trie** to make it O(path length), and then hands the actual match decision back to mux's own `Route.Match` — so mux's semantics are still what decide every request.

It is **strictly opt-in** (`GOFR_ROUTER=trie`). Default behaviour is byte-for-byte unchanged. Kept opt-in on purpose: route matching has a long tail of edge cases, so this ships as a switch you turn on, with the option to flip the default in a later release once it has mileage.

Documented in [Routing Performance](docs/advanced-guide/routing-performance/page.md) and in the configuration reference. The server states the matcher at startup when the trie is active, and warns on a value it does not recognize — that case falls back to mux, which is otherwise indistinguishable from never setting the variable, so a typo would cost the opt-in silently.

## Performance

`BenchmarkRouterMatch`, Apple M4. The request hits the **middle** route — mux's cost is linear in registration position, so measuring the last route would report its worst case rather than what real traffic sees. GoFr's default `PathPrefix("/")` catch-all is registered too, so the numbers reflect a real route table.

| routes | mux | trie | speedup |
|-------:|--------:|--------:|--------:|
|      1 |  431 ns |  447 ns | 0.96x |
|     10 |  506 ns |  461 ns | 1.1x |
|     20 |  647 ns |  531 ns | 1.2x |
|     50 | 1007 ns |  550 ns | 1.8x |
|    100 | 1642 ns |  548 ns | 3.0x |
|    200 | 2918 ns |  515 ns | **5.7x** |

mux grows linearly; the trie is flat. **Be clear about where this helps:** the crossover is at roughly 5–10 routes, so a small service sees nothing, and at a single route the trie is marginally slower. The win scales with the route table, which is where large services live. The trie also costs **+2 allocations per request** (10 vs 8) for the candidate set.

Scope note: this optimises route matching only. Matching is a minority of total request cost — the middleware chain (tracing, logging, metrics, CORS) dominates a GoFr request — so the end-to-end RPS change is smaller than the table above and approaches it only as the route count grows.

## Design

- **mux stays the registry.** The trie is an index built once (lazily, on the first request) by `Walk`-ing the routes mux already has, so registration (`Add` / `NewRoute` / `PathPrefix` / `AddStaticFiles`) is untouched.
- **matching** — narrow via the trie, append the fallback list, order by registration, return the first candidate mux's `Route.Match` accepts. A route the trie omits could not have matched the path anyway, so the result is the same route mux's full scan would pick.
- **The classifier is an allowlist.** A route is trie-indexed only when its compiled path regexp can be *proven* safe: anchored at both ends on the parsed syntax tree, with every capture matching a non-empty, slash-free fragment. Anything unproven — `PathPrefix`/static, slash-spanning `{p:.*}`, empty-matching `{p:[a-z]*}` — goes to the fallback list where mux decides it. The asymmetry drives the direction: a route wrongly *excluded* only loses speed, while a route wrongly *included* could be dropped from the candidate set and silently 404.
- **`mux.Vars` / route template** — since the trie bypasses mux's `ServeHTTP`, `mux.CurrentRoute` is no longer populated. Params are restored with `mux.SetURLVars` (so `mux.Vars` is unchanged) and the template is carried in a context key, read through `RouteTemplate(r)`, which resolves under both routers.
- **middleware** — applied by the router itself, in the same order mux applies it, and only around a matched handler (mux never wraps its NotFound/MethodNotAllowed handlers, so neither does this).
- **anything unmatched goes back to mux.** `serveTrie` does not decide 404-vs-405 itself; it hands every non-match to mux's own `ServeHTTP`. That branch is the cold path — the response is already an error — so the linear scan costs nothing that matters, and it makes the index *self-healing*: if the classifier ever admitted a shape it should not have and the trie dropped a route that does match, mux's full scan finds and serves it. The one catastrophic failure mode of this design — a live route silently 404ing — becomes a request that is merely slower, leaving the trie strictly an accelerator.

## Behaviour audit

With `GOFR_ROUTER` unset there is no behaviour change — same code path as today.

With `GOFR_ROUTER=trie`, a differential suite registers an identical route set on both routers and requires byte-identical `{status, body, vars}` across static / param / `{id:regex}` / mixed literal+param (`{name}.txt`, `user-{id}`) / overlap ordering / normalisation / slash-spanning / subrouter / encoded-path / middleware-invocation scenarios. On top of that, an invariant test asserts the property the design rests on: **no route mux matches is ever absent from the trie's candidate set.**

**There is now no divergence at all** — the routers agree on every request, in a running app and on a bare `Router` alike.

An earlier revision had one: for a wrong-method request to an existing path the trie returned 405 where mux returns 404. That turned out not to be a bookkeeping bug but a structural one. In gorilla/mux's `Route.Match`, a matcher that *succeeds* clears any `ErrMethodMismatch` an earlier route left behind, and GoFr registers routes as `Methods(m).Path(p)` — method matcher first. So a later route whose path does **not** match the request can still erase the mismatch purely because its method does, which is why mux's 404-vs-405 is registration-order dependent. Reproducing that outcome requires visiting exactly the routes the trie exists to skip, so no amount of bookkeeping over the narrowed candidate set can get there.

Delegating the unmatched branch to mux resolves it exactly rather than approximately, and brings the custom `NotFoundHandler` / `MethodNotAllowedHandler` and subrouter semantics along for free. The differential test that used to pin the divergence now pins the parity.

The index is built once from the routes present at the first request. GoFr registers every route during startup, before the server accepts requests, so this holds for all framework code paths; a route added after the first request would not be indexed (documented on the field).

## Tests

`go test -race ./pkg/gofr/http/...` green in **both** modes; full framework suite green in both modes; `golangci-lint` clean under `only-new-issues`. Each edge-case test was mutation-checked — it fails against the previous implementation and passes against this one.

