### PR TITLE
test(middleware): characterize the request-path middleware contract

### DIFF
--- a/pkg/gofr/http/middleware/cors_test.go
+++ b/pkg/gofr/http/middleware/cors_test.go
@@ -3,10 +3,13 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type MockHandlerForCORS struct {
@@ -134,7 +137,7 @@ func setMiddlewareHeadersTestCases() []struct {
 			allowedOrigins:    map[string]bool{"*": true},
 			expectedHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "*",
-				"Access-Control-Allow-Headers": allowedHeaders,
+				"Access-Control-Allow-Headers": corsCharDefaultAllowHeaders,
 				"Access-Control-Allow-Methods": "GET, OPTIONS",
 			},
 		},
@@ -145,7 +148,7 @@ func setMiddlewareHeadersTestCases() []struct {
 			allowedOrigins:    map[string]bool{"*": true},
 			expectedHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "*",
-				"Access-Control-Allow-Headers": allowedHeaders + ", clientid",
+				"Access-Control-Allow-Headers": corsCharDefaultAllowHeaders + ", clientid",
 				"Access-Control-Allow-Methods": "POST, PUT, OPTIONS",
 			},
 		},
@@ -161,7 +164,7 @@ func setMiddlewareHeadersTestCases() []struct {
 			expectedHeaders: map[string]string{
 				"Access-Control-Max-Age":       strconv.Itoa(600),
 				"Access-Control-Allow-Origin":  "https://example.com",
-				"Access-Control-Allow-Headers": allowedHeaders,
+				"Access-Control-Allow-Headers": corsCharDefaultAllowHeaders,
 				"Access-Control-Allow-Methods": "OPTIONS",
 				"Vary":                         "Origin",
 			},
@@ -175,7 +178,7 @@ func setMiddlewareHeadersTestCases() []struct {
 			allowedOrigins:   map[string]bool{"*": true},
 			expectedHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "*",
-				"Access-Control-Allow-Headers": allowedHeaders,
+				"Access-Control-Allow-Headers": corsCharDefaultAllowHeaders,
 				"Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
 			},
 		},
@@ -189,7 +192,7 @@ func setMiddlewareHeadersTestCases() []struct {
 			allowedOrigins:   map[string]bool{"https://a.com": true, "https://b.com": true},
 			expectedHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "https://b.com",
-				"Access-Control-Allow-Headers": allowedHeaders,
+				"Access-Control-Allow-Headers": corsCharDefaultAllowHeaders,
 				"Access-Control-Allow-Methods": "GET, OPTIONS",
 				"Vary":                         "Origin",
 			},
@@ -204,7 +207,7 @@ func setMiddlewareHeadersTestCases() []struct {
 			allowedOrigins:   map[string]bool{"https://a.com": true},
 			expectedHeaders: map[string]string{
 				"Access-Control-Allow-Origin":  "",
-				"Access-Control-Allow-Headers": allowedHeaders,
+				"Access-Control-Allow-Headers": corsCharDefaultAllowHeaders,
 				"Access-Control-Allow-Methods": "GET, OPTIONS",
 			},
 		},
@@ -260,6 +263,796 @@ func TestParseOrigins(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := parseOrigins(tc.input)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Characterization suite: pins the EXACT observable output of the CORS
+// middleware. Every helper/type/const below is prefixed with `corsChar` and
+// every test with `Test_CORSContract` to stay collision-free.
+//
+// These tests describe CURRENT behavior, including behavior that looks like a
+// latent bug. They must be updated only when a behavior change is intentional.
+// ---------------------------------------------------------------------------
+
+// corsCharDefaultAllowHeaders is the literal Access-Control-Allow-Headers
+// value GoFr puts on the wire. It is spelled out here on purpose rather than
+// referencing the production `allowedHeaders` constant: a characterization
+// test that reuses the constant under test would silently follow any edit to
+// it. Test_CORSContract_DefaultAllowHeadersLiteral asserts the two agree, so
+// changing the production spelling (including its casing or its comma-space
+// separators) fails loudly here.
+const corsCharDefaultAllowHeaders = "Authorization, Content-Type, x-requested-with, " +
+	"origin, true-client-ip, X-Correlation-ID"
+
+// Test_CORSContract_DefaultAllowHeadersLiteral pins the exact bytes of the
+// default Access-Control-Allow-Headers value.
+func Test_CORSContract_DefaultAllowHeadersLiteral(t *testing.T) {
+	assert.Equal(t, corsCharDefaultAllowHeaders, allowedHeaders)
+}
+
+const (
+	corsCharBody             = "Sample Response"
+	corsCharOriginA          = "https://a.com"
+	corsCharOriginB          = "https://b.com"
+	corsCharOriginEvil       = "https://evil.com"
+	corsCharKeyOrigin        = "Access-Control-Allow-Origin"
+	corsCharKeyMethods       = "Access-Control-Allow-Methods"
+	corsCharKeyHeaders       = "Access-Control-Allow-Headers"
+	corsCharAllowHeadersLine = corsCharKeyHeaders + ": " + corsCharDefaultAllowHeaders
+	corsCharVaryLine         = "Vary: Origin"
+)
+
+// corsCharSpyHandler records whether the inner handler was reached.
+type corsCharSpyHandler struct {
+	called int
+}
+
+func (h *corsCharSpyHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	h.called++
+
+	w.WriteHeader(http.StatusFound)
+	_, _ = w.Write([]byte(corsCharBody))
+}
+
+// corsCharHeaderLines renders a whole http.Header into a deterministic, sorted
+// slice of "Key: v1, v2" lines so a full snapshot can be compared exactly.
+func corsCharHeaderLines(h http.Header) []string {
+	lines := make([]string, 0, len(h))
+	for k, v := range h {
+		lines = append(lines, k+": "+strings.Join(v, ", "))
+	}
+
+	sort.Strings(lines)
+
+	return lines
+}
+
+func corsCharSorted(in []string) []string {
+	out := make([]string, len(in))
+	copy(out, in)
+	sort.Strings(out)
+
+	return out
+}
+
+func corsCharMethodsLine(v string) string { return corsCharKeyMethods + ": " + v }
+
+func corsCharOriginLine(v string) string { return corsCharKeyOrigin + ": " + v }
+
+// corsCharRun drives the middleware once and returns the recorder plus the spy.
+func corsCharRun(t *testing.T, cfg map[string]string, routes *[]string,
+	method, origin string,
+) (*httptest.ResponseRecorder, *corsCharSpyHandler) {
+	t.Helper()
+
+	spy := &corsCharSpyHandler{}
+	handler := CORS(cfg, routes)(spy)
+
+	req := httptest.NewRequestWithContext(t.Context(), method, "/hello", http.NoBody)
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	return w, spy
+}
+
+type corsCharCase struct {
+	name     string
+	config   map[string]string
+	method   string
+	origin   string
+	routes   []string
+	expLines []string
+	expCode  int
+	expBody  string
+	expInner int
+}
+
+func corsCharBaselineCases() []corsCharCase {
+	twoRoutes := []string{http.MethodGet, http.MethodPost}
+	baseMethods := corsCharMethodsLine("GET, POST, OPTIONS")
+
+	return []corsCharCase{
+		{
+			name: "nil config GET no origin", config: nil, method: http.MethodGet,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name: "empty config POST no origin", config: map[string]string{}, method: http.MethodPost,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name: "empty config OPTIONS short circuits", config: map[string]string{}, method: http.MethodOptions,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusOK, expBody: "", expInner: 0,
+		},
+		{
+			name:   "empty origin config value falls back to wildcard",
+			config: map[string]string{corsCharKeyOrigin: ""}, method: http.MethodGet, origin: corsCharOriginA,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "explicit wildcard never adds Vary",
+			config: map[string]string{corsCharKeyOrigin: "*"}, method: http.MethodGet, origin: corsCharOriginA,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "wildcard OPTIONS with origin",
+			config: map[string]string{corsCharKeyOrigin: "*"}, method: http.MethodOptions, origin: corsCharOriginA,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusOK, expBody: "", expInner: 0,
+		},
+	}
+}
+
+func corsCharOriginMatchingCases() []corsCharCase {
+	twoRoutes := []string{http.MethodGet, http.MethodPost}
+	baseMethods := corsCharMethodsLine("GET, POST, OPTIONS")
+
+	return []corsCharCase{
+		{
+			name:   "single origin matched adds Vary",
+			config: map[string]string{corsCharKeyOrigin: corsCharOriginA}, method: http.MethodGet, origin: corsCharOriginA,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine(corsCharOriginA), corsCharVaryLine},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "single origin not matched drops origin and Vary",
+			config: map[string]string{corsCharKeyOrigin: corsCharOriginA}, method: http.MethodGet, origin: corsCharOriginEvil,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "single origin with no Origin request header drops origin",
+			config: map[string]string{corsCharKeyOrigin: corsCharOriginA}, method: http.MethodGet,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "single origin OPTIONS not matched still short circuits",
+			config: map[string]string{corsCharKeyOrigin: corsCharOriginA}, method: http.MethodOptions, origin: corsCharOriginEvil,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods},
+			expCode:  http.StatusOK, expBody: "", expInner: 0,
+		},
+		{
+			name:   "comma list without spaces",
+			config: map[string]string{corsCharKeyOrigin: corsCharOriginA + "," + corsCharOriginB},
+			method: http.MethodGet, origin: corsCharOriginB, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine(corsCharOriginB), corsCharVaryLine},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "comma list with spaces",
+			config: map[string]string{corsCharKeyOrigin: corsCharOriginA + " , " + corsCharOriginB},
+			method: http.MethodGet, origin: corsCharOriginA, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine(corsCharOriginA), corsCharVaryLine},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "comma list with empty entry is skipped",
+			config: map[string]string{corsCharKeyOrigin: corsCharOriginA + ", ," + corsCharOriginB},
+			method: http.MethodGet, origin: corsCharOriginB, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine(corsCharOriginB), corsCharVaryLine},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "only separators degrades to wildcard",
+			config: map[string]string{corsCharKeyOrigin: ", , ,"}, method: http.MethodGet, origin: corsCharOriginEvil,
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "origin match is exact and untrimmed",
+			config: map[string]string{corsCharKeyOrigin: corsCharOriginA}, method: http.MethodGet, origin: corsCharOriginA + " ",
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "origin match is case sensitive",
+			config: map[string]string{corsCharKeyOrigin: corsCharOriginA}, method: http.MethodGet, origin: "HTTPS://A.COM",
+			routes:   twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+	}
+}
+
+func corsCharCustomHeaderCases() []corsCharCase {
+	twoRoutes := []string{http.MethodGet, http.MethodPost}
+	baseMethods := corsCharMethodsLine("GET, POST, OPTIONS")
+
+	return []corsCharCase{
+		{
+			name:   "custom allow-headers is concatenated onto the defaults",
+			config: map[string]string{corsCharKeyHeaders: "clientid"}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine + ", clientid", baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "empty custom allow-headers keeps the defaults",
+			config: map[string]string{corsCharKeyHeaders: ""}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "custom allow-methods fully replaces routes derived value",
+			config: map[string]string{corsCharKeyMethods: "GET, PUT"}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, corsCharMethodsLine("GET, PUT"), corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "empty custom allow-methods keeps routes derived value",
+			config: map[string]string{corsCharKeyMethods: ""}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name: "credentials max-age and expose-headers pass through",
+			config: map[string]string{
+				"Access-Control-Allow-Credentials": "true",
+				"Access-Control-Max-Age":           "600",
+				"Access-Control-Expose-Headers":    "X-Foo, X-Bar",
+			},
+			method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{
+				"Access-Control-Allow-Credentials: true",
+				corsCharAllowHeadersLine,
+				baseMethods,
+				corsCharOriginLine("*"),
+				"Access-Control-Expose-Headers: X-Foo, X-Bar",
+				"Access-Control-Max-Age: 600",
+			},
+			expCode: http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "empty valued custom header is still emitted with an empty value",
+			config: map[string]string{"Access-Control-Max-Age": ""}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{
+				corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*"), "Access-Control-Max-Age: ",
+			},
+			expCode: http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name: "everything combined",
+			config: map[string]string{
+				corsCharKeyOrigin:                  corsCharOriginA + ", " + corsCharOriginB,
+				corsCharKeyHeaders:                 "clientid",
+				corsCharKeyMethods:                 "GET, DELETE",
+				"Access-Control-Allow-Credentials": "true",
+				"Access-Control-Max-Age":           "86400",
+			},
+			method: http.MethodOptions, origin: corsCharOriginB, routes: twoRoutes,
+			expLines: []string{
+				"Access-Control-Allow-Credentials: true",
+				corsCharAllowHeadersLine + ", clientid",
+				corsCharMethodsLine("GET, DELETE"),
+				corsCharOriginLine(corsCharOriginB),
+				"Access-Control-Max-Age: 86400",
+				corsCharVaryLine,
+			},
+			expCode: http.StatusOK, expBody: "", expInner: 0,
+		},
+	}
+}
+
+// corsCharGarbageKeyCases pins what happens for config keys that are not the
+// canonical, exactly-cased header names the implementation compares against.
+func corsCharGarbageKeyCases() []corsCharCase {
+	twoRoutes := []string{http.MethodGet, http.MethodPost}
+	baseMethods := corsCharMethodsLine("GET, POST, OPTIONS")
+
+	return []corsCharCase{
+		{
+			name:   "arbitrary key is blindly set and canonicalized",
+			config: map[string]string{"x-garbage": "boom"}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*"), "X-Garbage: boom"},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "key with a space is not canonicalizable and is stored verbatim",
+			config: map[string]string{"Bad Key": "v"}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, "Bad Key: v", baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "underscore is a token char so only the first letter is upper cased",
+			config: map[string]string{"x_under_score": "v"}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*"), "X_under_score: v"},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "lower cased allow-headers key bypasses the concat branch and replaces the defaults",
+			config: map[string]string{"access-control-allow-headers": "only-this"}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{corsCharKeyHeaders + ": only-this", baseMethods, corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "upper cased allow-methods key overwrites the routes derived value",
+			config: map[string]string{"ACCESS-CONTROL-ALLOW-METHODS": "TRACE"}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, corsCharMethodsLine("TRACE"), corsCharOriginLine("*")},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "mixed case max-age key is canonicalized",
+			config: map[string]string{"ACCESS-CONTROL-MAX-AGE": "60"}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{
+				corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*"), "Access-Control-Max-Age: 60",
+			},
+			expCode: http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name:   "lower cased origin key escapes the guard and overwrites the negotiated origin",
+			config: map[string]string{"access-control-allow-origin": corsCharOriginEvil}, method: http.MethodGet, routes: twoRoutes,
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine(corsCharOriginEvil)},
+			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+		{
+			name: "lower cased origin key overwrites a properly negotiated origin but Vary survives",
+			config: map[string]string{
+				corsCharKeyOrigin:             corsCharOriginA,
+				"access-control-allow-origin": corsCharOriginEvil,
+			},
+			method: http.MethodGet, origin: corsCharOriginA, routes: twoRoutes,
+			expLines: []string{
+				corsCharAllowHeadersLine, baseMethods, corsCharOriginLine(corsCharOriginEvil), corsCharVaryLine,
+			},
+			expCode: http.StatusFound, expBody: corsCharBody, expInner: 1,
+		},
+	}
+}
+
+func corsCharAllCases() []corsCharCase {
+	cases := corsCharBaselineCases()
+	cases = append(cases, corsCharOriginMatchingCases()...)
+	cases = append(cases, corsCharCustomHeaderCases()...)
+	cases = append(cases, corsCharGarbageKeyCases()...)
+
+	return cases
+}
+
+func Test_CORSContract_ResponseSnapshot(t *testing.T) {
+	cases := corsCharAllCases()
+
+	for i := range cases {
+		tc := &cases[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			routes := tc.routes
+			w, spy := corsCharRun(t, tc.config, &routes, tc.method, tc.origin)
+
+			assert.Equal(t, corsCharSorted(tc.expLines), corsCharHeaderLines(w.Header()))
+			assert.Equal(t, tc.expCode, w.Code)
+			assert.Equal(t, tc.expBody, w.Body.String())
+			assert.Equal(t, tc.expInner, spy.called)
+		})
+	}
+}
+
+func Test_CORSContract_AllowMethodsJoin(t *testing.T) {
+	cases := []struct {
+		name   string
+		routes []string
+		exp    string
+	}{
+		{name: "nil slice", routes: nil, exp: "OPTIONS"},
+		{name: "empty slice", routes: []string{}, exp: "OPTIONS"},
+		{name: "single element", routes: []string{http.MethodGet}, exp: "GET, OPTIONS"},
+		{name: "two elements", routes: []string{http.MethodGet, http.MethodPut}, exp: "GET, PUT, OPTIONS"},
+		{name: "element already containing commas", routes: []string{"GET,POST"}, exp: "GET,POST, OPTIONS"},
+		{name: "element already containing OPTIONS is duplicated", routes: []string{"OPTIONS"}, exp: "OPTIONS, OPTIONS"},
+		{name: "empty string element", routes: []string{""}, exp: ", OPTIONS"},
+		{name: "whitespace preserved", routes: []string{" GET "}, exp: " GET , OPTIONS"},
+	}
+
+	for i := range cases {
+		tc := &cases[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			routes := tc.routes
+			w, _ := corsCharRun(t, nil, &routes, http.MethodGet, "")
+
+			assert.Equal(t, corsCharSorted([]string{
+				corsCharAllowHeadersLine, corsCharMethodsLine(tc.exp), corsCharOriginLine("*"),
+			}), corsCharHeaderLines(w.Header()))
+		})
+	}
+}
+
+// Test_CORSContract_RoutesReadAtRequestTime pins that the routes slice is
+// dereferenced per request, so routes registered after the middleware was
+// constructed do show up in Access-Control-Allow-Methods.
+func Test_CORSContract_RoutesReadAtRequestTime(t *testing.T) {
+	routes := []string{http.MethodGet}
+	handler := CORS(nil, &routes)(&corsCharSpyHandler{})
+
+	first := httptest.NewRecorder()
+	handler.ServeHTTP(first, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody))
+	require.Equal(t, "GET, OPTIONS", first.Header().Get(corsCharKeyMethods))
+
+	routes = []string{http.MethodGet, http.MethodPost}
+
+	second := httptest.NewRecorder()
+	handler.ServeHTTP(second, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody))
+	assert.Equal(t, "GET, POST, OPTIONS", second.Header().Get(corsCharKeyMethods))
+
+	// Replacing the whole slice through the same variable is also picked up.
+	routes = []string{http.MethodDelete}
+
+	third := httptest.NewRecorder()
+	handler.ServeHTTP(third, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody))
+	assert.Equal(t, "DELETE, OPTIONS", third.Header().Get(corsCharKeyMethods))
+}
+
+// Test_CORSContract_RoutesBackingArrayAliasing pins a latent aliasing quirk:
+// setMiddlewareHeaders does `routes = append(routes, "OPTIONS")` on a copy of
+// the dereferenced slice header. When cap > len the append writes "OPTIONS"
+// into the CALLER's backing array at index len, clobbering whatever was there.
+// This is NOT visible through the caller's slice (its length is unchanged) but
+// it is visible through any alias with a larger length, and it is silently
+// overwritten again by the caller's next append.
+func Test_CORSContract_RoutesBackingArrayAliasing(t *testing.T) {
+	backing := []string{http.MethodGet, "SENTINEL-1", "SENTINEL-2", "SENTINEL-3"}
+	routes := backing[:1]
+	require.Equal(t, 4, cap(routes), "precondition: cap must exceed len for aliasing to be observable")
+
+	w, _ := corsCharRun(t, nil, &routes, http.MethodGet, "")
+	require.Equal(t, "GET, OPTIONS", w.Header().Get(corsCharKeyMethods))
+
+	// The caller's slice length is untouched...
+	assert.Equal(t, []string{http.MethodGet}, routes)
+	// ...but index 1 of the shared backing array was overwritten in place.
+	assert.Equal(t, []string{http.MethodGet, "OPTIONS", "SENTINEL-2", "SENTINEL-3"}, backing)
+	assert.Equal(t, "OPTIONS", backing[1], "SENTINEL-1 was clobbered by the middleware")
+
+	// A later caller-side append overwrites the injected "OPTIONS" again, so the
+	// caller never observes corruption of its own logical contents.
+	routes = append(routes, http.MethodPost)
+	assert.Equal(t, []string{http.MethodGet, http.MethodPost}, routes)
+	assert.Equal(t, http.MethodPost, backing[1])
+
+	w2, _ := corsCharRun(t, nil, &routes, http.MethodGet, "")
+	assert.Equal(t, "GET, POST, OPTIONS", w2.Header().Get(corsCharKeyMethods))
+	assert.Equal(t, "OPTIONS", backing[2], "SENTINEL-2 clobbered on the second request")
+}
+
+// Test_CORSContract_NoAliasingWhenCapEqualsLen pins the complementary case:
+// when cap == len the append allocates, so the caller's array is untouched.
+func Test_CORSContract_NoAliasingWhenCapEqualsLen(t *testing.T) {
+	routes := []string{http.MethodGet}
+	require.Equal(t, len(routes), cap(routes))
+
+	w, _ := corsCharRun(t, nil, &routes, http.MethodGet, "")
+
+	require.Equal(t, "GET, OPTIONS", w.Header().Get(corsCharKeyMethods))
+	assert.Equal(t, []string{http.MethodGet}, routes)
+	assert.Equal(t, 1, cap(routes))
+}
+
+// Test_CORSContract_ParseOriginsEvaluatedOnce pins that the allowed-origin set
+// is computed ONCE at construction time, so mutating the config map afterwards
+// does not change origin matching, even though the header-setting loop does
+// read the map on every request.
+func Test_CORSContract_ParseOriginsEvaluatedOnce(t *testing.T) {
+	cfg := map[string]string{corsCharKeyOrigin: corsCharOriginA}
+	routes := []string{http.MethodGet}
+	handler := CORS(cfg, &routes)(&corsCharSpyHandler{})
+
+	cfg[corsCharKeyOrigin] = corsCharOriginB
+
+	// The stale set still matches the ORIGINAL origin.
+	stale := httptest.NewRecorder()
+	reqA := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	reqA.Header.Set("Origin", corsCharOriginA)
+	handler.ServeHTTP(stale, reqA)
+
+	assert.Equal(t, corsCharSorted([]string{
+		corsCharAllowHeadersLine, corsCharMethodsLine("GET, OPTIONS"),
+		corsCharOriginLine(corsCharOriginA), corsCharVaryLine,
+	}), corsCharHeaderLines(stale.Header()))
+
+	// The newly configured origin is NOT honored.
+	fresh := httptest.NewRecorder()
+	reqB := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	reqB.Header.Set("Origin", corsCharOriginB)
+	handler.ServeHTTP(fresh, reqB)
+
+	assert.Equal(t, corsCharSorted([]string{
+		corsCharAllowHeadersLine, corsCharMethodsLine("GET, OPTIONS"),
+	}), corsCharHeaderLines(fresh.Header()))
+}
+
+// Test_CORSContract_ConfigMutationAffectsHeaderLoop pins the other half: the
+// custom-header loop DOES read the map per request, so keys added after
+// construction show up immediately.
+func Test_CORSContract_ConfigMutationAffectsHeaderLoop(t *testing.T) {
+	cfg := map[string]string{}
+	routes := []string{http.MethodGet}
+	handler := CORS(cfg, &routes)(&corsCharSpyHandler{})
+
+	before := httptest.NewRecorder()
+	handler.ServeHTTP(before, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody))
+	require.Equal(t, corsCharSorted([]string{
+		corsCharAllowHeadersLine, corsCharMethodsLine("GET, OPTIONS"), corsCharOriginLine("*"),
+	}), corsCharHeaderLines(before.Header()))
+
+	cfg["Access-Control-Max-Age"] = "42"
+	cfg[corsCharKeyHeaders] = "clientid"
+	cfg[corsCharKeyMethods] = "GET, PATCH"
+
+	after := httptest.NewRecorder()
+	handler.ServeHTTP(after, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody))
+
+	assert.Equal(t, corsCharSorted([]string{
+		corsCharAllowHeadersLine + ", clientid",
+		corsCharMethodsLine("GET, PATCH"),
+		corsCharOriginLine("*"),
+		"Access-Control-Max-Age: 42",
+	}), corsCharHeaderLines(after.Header()))
+}
+
+// Test_CORSContract_CustomHeaderLoopIsOrderIndependent pins that Go's random
+// map iteration order over the custom-header loop cannot change the final
+// header set.
+func Test_CORSContract_CustomHeaderLoopIsOrderIndependent(t *testing.T) {
+	cfg := map[string]string{
+		corsCharKeyOrigin:                  corsCharOriginA,
+		corsCharKeyHeaders:                 "clientid",
+		corsCharKeyMethods:                 "GET, PATCH",
+		"Access-Control-Allow-Credentials": "true",
+		"Access-Control-Expose-Headers":    "X-A, X-B",
+		"Access-Control-Max-Age":           "600",
+		"X-Custom-One":                     "1",
+		"X-Custom-Two":                     "2",
+		"x-custom-three":                   "3",
+	}
+
+	expected := corsCharSorted([]string{
+		"Access-Control-Allow-Credentials: true",
+		corsCharAllowHeadersLine + ", clientid",
+		corsCharMethodsLine("GET, PATCH"),
+		corsCharOriginLine(corsCharOriginA),
+		"Access-Control-Expose-Headers: X-A, X-B",
+		"Access-Control-Max-Age: 600",
+		"X-Custom-One: 1",
+		"X-Custom-Three: 3",
+		"X-Custom-Two: 2",
+		corsCharVaryLine,
+	})
+
+	for range 50 {
+		routes := []string{http.MethodGet}
+		w, _ := corsCharRun(t, cfg, &routes, http.MethodGet, corsCharOriginA)
+
+		require.Equal(t, expected, corsCharHeaderLines(w.Header()))
+	}
+}
+
+// Test_CORSContract_VaryIsAddedNotSet pins that Vary is added once per request
+// and that repeated requests on fresh recorders never accumulate values.
+func Test_CORSContract_VaryIsAddedNotSet(t *testing.T) {
+	cfg := map[string]string{corsCharKeyOrigin: corsCharOriginA}
+	routes := []string{http.MethodGet}
+	handler := CORS(cfg, &routes)(&corsCharSpyHandler{})
+
+	for range 3 {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+		req.Header.Set("Origin", corsCharOriginA)
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, []string{"Origin"}, w.Header().Values("Vary"))
+	}
+}
+
+// Test_CORSContract_VaryAccumulatesOnSharedResponseWriter pins that the
+// middleware uses Add (not Set) for Vary, so a pre-existing Vary value is
+// preserved and appended to.
+func Test_CORSContract_VaryAccumulatesOnSharedResponseWriter(t *testing.T) {
+	cfg := map[string]string{corsCharKeyOrigin: corsCharOriginA}
+	routes := []string{http.MethodGet}
+	handler := CORS(cfg, &routes)(&corsCharSpyHandler{})
+
+	w := httptest.NewRecorder()
+	w.Header().Add("Vary", "Accept-Encoding")
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/hello", http.NoBody)
+	req.Header.Set("Origin", corsCharOriginA)
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, []string{"Accept-Encoding", "Origin"}, w.Header().Values("Vary"))
+	assert.Equal(t, "Vary: Accept-Encoding, Origin", corsCharHeaderLines(w.Header())[3])
+}
+
+func Test_CORSContract_ParseOriginsExact(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		exp  map[string]bool
+	}{
+		{name: "empty", in: "", exp: map[string]bool{"*": true}},
+		{name: "single space", in: " ", exp: map[string]bool{"*": true}},
+		{name: "single comma", in: ",", exp: map[string]bool{"*": true}},
+		{name: "wildcard with spaces", in: "  *  ", exp: map[string]bool{"*": true}},
+		{name: "wildcard mixed with explicit origins", in: "*," + corsCharOriginA,
+			exp: map[string]bool{"*": true, corsCharOriginA: true}},
+		{name: "duplicates collapse", in: corsCharOriginA + "," + corsCharOriginA,
+			exp: map[string]bool{corsCharOriginA: true}},
+		{name: "tabs and newlines are trimmed", in: "\t" + corsCharOriginA + "\n",
+			exp: map[string]bool{corsCharOriginA: true}},
+		{name: "empty entries dropped", in: corsCharOriginA + ", ," + corsCharOriginB,
+			exp: map[string]bool{corsCharOriginA: true, corsCharOriginB: true}},
+		{name: "semicolons are not separators", in: corsCharOriginA + ";" + corsCharOriginB,
+			exp: map[string]bool{corsCharOriginA + ";" + corsCharOriginB: true}},
+		{name: "trailing comma", in: corsCharOriginA + ",", exp: map[string]bool{corsCharOriginA: true}},
+	}
+
+	for i := range cases {
+		tc := &cases[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.exp, parseOrigins(tc.in))
+		})
+	}
+}
+
+// Test_CORSContract_WildcardBeatsExplicitMatch pins that a "*" entry anywhere in
+// the list short-circuits dynamic matching and suppresses Vary entirely.
+func Test_CORSContract_WildcardBeatsExplicitMatch(t *testing.T) {
+	routes := []string{http.MethodGet}
+	cfg := map[string]string{corsCharKeyOrigin: corsCharOriginA + ",*"}
+
+	w, _ := corsCharRun(t, cfg, &routes, http.MethodGet, corsCharOriginA)
+
+	assert.Equal(t, corsCharSorted([]string{
+		corsCharAllowHeadersLine, corsCharMethodsLine("GET, OPTIONS"), corsCharOriginLine("*"),
+	}), corsCharHeaderLines(w.Header()))
+	assert.Empty(t, w.Header().Values("Vary"))
+}
+
+// Test_CORSContract_OptionsSkipsInnerHandlerForEveryConfig pins that OPTIONS
+// short-circuits regardless of configuration or origin match.
+func Test_CORSContract_OptionsSkipsInnerHandlerForEveryConfig(t *testing.T) {
+	configs := []map[string]string{
+		nil,
+		{},
+		{corsCharKeyOrigin: "*"},
+		{corsCharKeyOrigin: corsCharOriginA},
+		{corsCharKeyOrigin: corsCharOriginA, corsCharKeyMethods: "GET"},
+		{"x-garbage": "boom"},
+	}
+
+	origins := []string{"", corsCharOriginA, corsCharOriginEvil}
+
+	for i, cfg := range configs {
+		for _, origin := range origins {
+			routes := []string{http.MethodGet}
+			w, spy := corsCharRun(t, cfg, &routes, http.MethodOptions, origin)
+
+			assert.Equal(t, http.StatusOK, w.Code, "config %d origin %q", i, origin)
+			assert.Empty(t, w.Body.String(), "config %d origin %q", i, origin)
+			assert.Equal(t, 0, spy.called, "config %d origin %q", i, origin)
+		}
+	}
+}
+
+// Test_CORSContract_NonOptionsMethodsAlwaysReachInner pins that every
+// non-OPTIONS method falls through to the inner handler unchanged.
+func Test_CORSContract_NonOptionsMethodsAlwaysReachInner(t *testing.T) {
+	methods := []string{
+		http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodDelete, http.MethodHead, http.MethodTrace, http.MethodConnect,
+	}
+
+	for _, m := range methods {
+		routes := []string{http.MethodGet}
+		w, spy := corsCharRun(t, map[string]string{corsCharKeyOrigin: "*"}, &routes, m, corsCharOriginA)
+
+		assert.Equal(t, http.StatusFound, w.Code, "method %s", m)
+		assert.Equal(t, corsCharBody, w.Body.String(), "method %s", m)
+		assert.Equal(t, 1, spy.called, "method %s", m)
+		assert.Equal(t, corsCharSorted([]string{
+			corsCharAllowHeadersLine, corsCharMethodsLine("GET, OPTIONS"), corsCharOriginLine("*"),
+		}), corsCharHeaderLines(w.Header()), "method %s", m)
+	}
+}
+
+// Test_CORSContract_SetMiddlewareHeadersDirectSnapshot pins the unexported
+// helper directly, including the case where the passed allowedOrigins set
+// disagrees with the config map (which the exported CORS wrapper cannot do).
+func Test_CORSContract_SetMiddlewareHeadersDirectSnapshot(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   map[string]string
+		routes   []string
+		origin   string
+		allowed  map[string]bool
+		expLines []string
+	}{
+		{
+			name: "nil allowed origins set emits no origin header", config: map[string]string{},
+			routes: []string{http.MethodGet}, origin: corsCharOriginA, allowed: nil,
+			expLines: []string{corsCharAllowHeadersLine, corsCharMethodsLine("GET, OPTIONS")},
+		},
+		{
+			name: "empty allowed origins set emits no origin header", config: map[string]string{},
+			routes: []string{http.MethodGet}, origin: corsCharOriginA, allowed: map[string]bool{},
+			expLines: []string{corsCharAllowHeadersLine, corsCharMethodsLine("GET, OPTIONS")},
+		},
+		{
+			name: "false valued entry does not match", config: map[string]string{},
+			routes: []string{http.MethodGet}, origin: corsCharOriginA,
+			allowed:  map[string]bool{corsCharOriginA: false},
+			expLines: []string{corsCharAllowHeadersLine, corsCharMethodsLine("GET, OPTIONS")},
+		},
+		{
+			name:   "empty string origin can be allowed and is echoed as an empty header",
+			config: map[string]string{}, routes: []string{http.MethodGet}, origin: "",
+			allowed: map[string]bool{"": true},
+			expLines: []string{
+				corsCharAllowHeadersLine, corsCharMethodsLine("GET, OPTIONS"),
+				corsCharKeyOrigin + ": ", corsCharVaryLine,
+			},
+		},
+		{
+			name: "allowed set overrides what the config map says", config: map[string]string{corsCharKeyOrigin: corsCharOriginA},
+			routes: []string{http.MethodGet}, origin: corsCharOriginEvil,
+			allowed: map[string]bool{corsCharOriginEvil: true},
+			expLines: []string{
+				corsCharAllowHeadersLine, corsCharMethodsLine("GET, OPTIONS"),
+				corsCharOriginLine(corsCharOriginEvil), corsCharVaryLine,
+			},
+		},
+	}
+
+	for i := range cases {
+		tc := &cases[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			setMiddlewareHeaders(tc.config, tc.routes, w, tc.origin, tc.allowed)
+
+			assert.Equal(t, corsCharSorted(tc.expLines), corsCharHeaderLines(w.Header()))
 		})
 	}
 }

--- a/pkg/gofr/http/middleware/logger_test.go
+++ b/pkg/gofr/http/middleware/logger_test.go
@@ -5,17 +5,23 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 
 	"gofr.dev/pkg/gofr/logging"
+	"gofr.dev/pkg/gofr/service"
 	"gofr.dev/pkg/gofr/testutil"
 )
 
@@ -490,4 +496,1317 @@ func BenchmarkGetIPAddress(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = getIPAddress(req)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Characterization suite: HTTP logging middleware + RequestLog wire format.
+//
+// Everything below is a *characterization* test: it pins the behavior of the
+// code exactly as it is today (bugs included) so that any future refactor —
+// including replacing encoding/json with a hand-rolled encoder — has to
+// reproduce the current bytes verbatim. Nothing here asserts what the code
+// *should* do; deviations found while writing these tests are documented in
+// comments rather than fixed.
+//
+// All identifiers added here are prefixed `logChar` to stay collision-free with
+// the rest of the package's tests.
+// ---------------------------------------------------------------------------
+
+// logCharStartTimeLayout mirrors the layout string handleRequestLog passes to
+// time.Format. Duplicated (not referenced) on purpose: if production changes
+// the layout, this test must fail rather than silently follow.
+const logCharStartTimeLayout = "2006-01-02T15:04:05.999999999-07:00"
+
+// logCharPanicEnvelope is the exact body panicRecovery writes. The map is a
+// map[string]any, so encoding/json sorts the keys alphabetically
+// (code, message, status) — NOT declaration order — and json.Encoder.Encode
+// appends a trailing newline.
+const logCharPanicEnvelope = `{"code":500,"message":"Some unexpected error has occurred","status":"ERROR"}` + "\n"
+
+// errLogCharPanic is the sentinel used by the panic(error) case. Named errFoo
+// to satisfy revive's error-naming rule.
+var errLogCharPanic = errors.New("boom from an error value")
+
+// logCharRecord is one captured call into the middleware's `logger` interface.
+type logCharRecord struct {
+	level string // "LOG" or "ERROR"
+	arg   any    // the single argument the middleware passes
+}
+
+// logCharRecorder implements the package-private `logger` interface and records
+// every call, preserving order and which method (Log vs Error) was used.
+type logCharRecorder struct {
+	mu      sync.Mutex
+	records []logCharRecord
+}
+
+func (r *logCharRecorder) Log(args ...any) { r.capture("LOG", args) }
+
+func (r *logCharRecorder) Error(args ...any) { r.capture("ERROR", args) }
+
+func (r *logCharRecorder) capture(level string, args []any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var a any
+	if len(args) == 1 {
+		a = args[0]
+	} else {
+		a = args
+	}
+
+	r.records = append(r.records, logCharRecord{level: level, arg: a})
+}
+
+func (r *logCharRecorder) all() []logCharRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]logCharRecord(nil), r.records...)
+}
+
+// requestLog returns the i-th record asserted to be a *RequestLog.
+func (r *logCharRecorder) requestLog(t *testing.T, i int) *RequestLog {
+	t.Helper()
+
+	recs := r.all()
+	require.Greater(t, len(recs), i, "expected at least %d log record(s)", i+1)
+
+	rl, ok := recs[i].arg.(*RequestLog)
+	require.True(t, ok, "record %d is %T, want *RequestLog", i, recs[i].arg)
+
+	return rl
+}
+
+// logCharFullRequestLog is a RequestLog with every field non-zero, used as the
+// baseline for wire-format assertions.
+func logCharFullRequestLog() RequestLog {
+	return RequestLog{
+		TraceID:      "e1f2d3c4b5a6978877665544332211ff",
+		SpanID:       "0011223344556677",
+		StartTime:    "2024-03-01T12:34:56.789-05:00",
+		ResponseTime: 1234,
+		Method:       http.MethodGet,
+		UserAgent:    "curl/8.4.0",
+		IP:           "192.0.2.10",
+		URI:          "/api/v1/users?q=1",
+		Response:     200,
+	}
+}
+
+// logCharNewRequest builds a request bound to the test context.
+func logCharNewRequest(t *testing.T, method, target string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), method, target, http.NoBody)
+	require.NoError(t, err)
+
+	return req
+}
+
+// logCharServe runs one request through a freshly built Logging middleware.
+func logCharServe(t *testing.T, probes LogProbes, l logger, h http.HandlerFunc,
+	req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rr := httptest.NewRecorder()
+	Logging(probes, l)(h).ServeHTTP(rr, req)
+
+	return rr
+}
+
+// logCharStatusHandler returns a handler that writes the given status.
+func logCharStatusHandler(status int) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A. RequestLog JSON wire format
+// ---------------------------------------------------------------------------
+
+// Test_LoggingContract_RequestLogJSONShape pins the complete serialized form of
+// a fully populated RequestLog: every field name, the exact field ORDER
+// (encoding/json emits struct fields in declaration order, which is
+// deterministic), and the JSON types — response_time and response are JSON
+// numbers, never strings.
+func Test_LoggingContract_RequestLogJSONShape(t *testing.T) {
+	const want = `{"trace_id":"e1f2d3c4b5a6978877665544332211ff","span_id":"0011223344556677",` +
+		`"start_time":"2024-03-01T12:34:56.789-05:00","response_time":1234,"method":"GET",` +
+		`"user_agent":"curl/8.4.0","ip":"192.0.2.10","uri":"/api/v1/users?q=1","response":200}`
+
+	rl := logCharFullRequestLog()
+
+	byValue, err := json.Marshal(rl)
+	require.NoError(t, err)
+	assert.JSONEq(t, want, string(byValue))
+	//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+	assert.Equal(t, []byte(want), byValue, "field order must stay in struct declaration order")
+
+	// The middleware always logs a *RequestLog; a pointer must marshal
+	// byte-identically to the value.
+	byPointer, err := json.Marshal(&rl)
+	require.NoError(t, err)
+	//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+	assert.Equal(t, []byte(want), byPointer, "a pointer marshals byte-identically to the value")
+
+	// Types, asserted structurally so a future encoder cannot quote the numbers.
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal(byValue, &generic))
+	assert.IsType(t, float64(0), generic["response_time"], "response_time must be a JSON number")
+	assert.IsType(t, float64(0), generic["response"], "response must be a JSON number")
+	assert.IsType(t, "", generic["trace_id"])
+	assert.Len(t, generic, 9, "RequestLog has exactly 9 wire fields")
+}
+
+// Test_LoggingContract_RequestLogFieldOrderKeys pins the ordered key list on its
+// own, independent of the values, so a field insertion is caught immediately.
+func Test_LoggingContract_RequestLogFieldOrderKeys(t *testing.T) {
+	want := []string{
+		"trace_id", "span_id", "start_time", "response_time",
+		"method", "user_agent", "ip", "uri", "response",
+	}
+
+	b, err := json.Marshal(logCharFullRequestLog())
+	require.NoError(t, err)
+
+	dec := json.NewDecoder(strings.NewReader(string(b)))
+
+	tok, err := dec.Token()
+	require.NoError(t, err)
+	require.Equal(t, json.Delim('{'), tok)
+
+	got := make([]string, 0, len(want))
+
+	for dec.More() {
+		k, kerr := dec.Token()
+		require.NoError(t, kerr)
+
+		got = append(got, k.(string))
+
+		var discard any
+
+		require.NoError(t, dec.Decode(&discard))
+	}
+
+	assert.Equal(t, want, got)
+}
+
+// Test_LoggingContract_RequestLogOmitempty pins exactly which fields DISAPPEAR
+// when they hold their zero value. Every field carries `omitempty`, so a 0
+// response_time, a 0 response status, and empty strings all vanish from the
+// wire — consumers cannot rely on the keys being present.
+func Test_LoggingContract_RequestLogOmitempty(t *testing.T) {
+	const base = `{"trace_id":"e1f2d3c4b5a6978877665544332211ff","span_id":"0011223344556677",` +
+		`"start_time":"2024-03-01T12:34:56.789-05:00","response_time":1234,"method":"GET",` +
+		`"user_agent":"curl/8.4.0","ip":"192.0.2.10","uri":"/api/v1/users?q=1","response":200}`
+
+	tests := []struct {
+		name   string
+		mutate func(*RequestLog)
+		want   string
+	}{
+		{"all fields set", func(*RequestLog) {}, base},
+		{
+			"zero response_time drops the key",
+			func(rl *RequestLog) { rl.ResponseTime = 0 },
+			`{"trace_id":"e1f2d3c4b5a6978877665544332211ff","span_id":"0011223344556677",` +
+				`"start_time":"2024-03-01T12:34:56.789-05:00","method":"GET",` +
+				`"user_agent":"curl/8.4.0","ip":"192.0.2.10","uri":"/api/v1/users?q=1","response":200}`,
+		},
+		{
+			"zero response drops the key",
+			func(rl *RequestLog) { rl.Response = 0 },
+			`{"trace_id":"e1f2d3c4b5a6978877665544332211ff","span_id":"0011223344556677",` +
+				`"start_time":"2024-03-01T12:34:56.789-05:00","response_time":1234,"method":"GET",` +
+				`"user_agent":"curl/8.4.0","ip":"192.0.2.10","uri":"/api/v1/users?q=1"}`,
+		},
+		{
+			"empty user_agent, ip and uri drop their keys",
+			func(rl *RequestLog) { rl.UserAgent, rl.IP, rl.URI = "", "", "" },
+			`{"trace_id":"e1f2d3c4b5a6978877665544332211ff","span_id":"0011223344556677",` +
+				`"start_time":"2024-03-01T12:34:56.789-05:00","response_time":1234,` +
+				`"method":"GET","response":200}`,
+		},
+		{
+			"empty method drops the key",
+			func(rl *RequestLog) { rl.Method = "" },
+			`{"trace_id":"e1f2d3c4b5a6978877665544332211ff","span_id":"0011223344556677",` +
+				`"start_time":"2024-03-01T12:34:56.789-05:00","response_time":1234,` +
+				`"user_agent":"curl/8.4.0","ip":"192.0.2.10","uri":"/api/v1/users?q=1","response":200}`,
+		},
+		{
+			"empty trace_id and span_id drop their keys",
+			func(rl *RequestLog) { rl.TraceID, rl.SpanID = "", "" },
+			`{"start_time":"2024-03-01T12:34:56.789-05:00","response_time":1234,"method":"GET",` +
+				`"user_agent":"curl/8.4.0","ip":"192.0.2.10","uri":"/api/v1/users?q=1","response":200}`,
+		},
+		{
+			"empty start_time drops the key",
+			func(rl *RequestLog) { rl.StartTime = "" },
+			`{"trace_id":"e1f2d3c4b5a6978877665544332211ff","span_id":"0011223344556677",` +
+				`"response_time":1234,"method":"GET",` +
+				`"user_agent":"curl/8.4.0","ip":"192.0.2.10","uri":"/api/v1/users?q=1","response":200}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rl := logCharFullRequestLog()
+			tc.mutate(&rl)
+
+			b, err := json.Marshal(&rl)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, string(b))
+		})
+	}
+}
+
+// Test_LoggingContract_RequestLogZeroValueIsEmptyObject is the extreme
+// omitempty case: a zero RequestLog serializes to "{}" — no keys at all.
+func Test_LoggingContract_RequestLogZeroValueIsEmptyObject(t *testing.T) {
+	b, err := json.Marshal(&RequestLog{})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{}`, string(b))
+	assert.Equal(t, `{}`, string(b))
+}
+
+// Test_LoggingContract_RequestLogEscaping pins encoding/json's exact escaping
+// for hostile field values. These byte strings are the contract: a hand-rolled
+// encoder must reproduce them character for character.
+//
+// Notable behaviors pinned here:
+//   - `<`, `>` and `&` become \u003c, \u003e, \u0026 (encoding/json HTML-escapes
+//     by default, for both Marshal and Encoder).
+//   - `'` is NOT escaped.
+//   - Control chars use the short forms \n \r \t \b \f where they exist and
+//     \u00XX otherwise; DEL (U+007F) is NOT escaped and passes through raw.
+//   - U+2028 / U+2029 ARE escaped (JS line separators).
+//   - Non-ASCII (CJK, emoji, accented) passes through as raw UTF-8, unescaped.
+//   - Invalid UTF-8 bytes are replaced by the escaped form of U+FFFD.
+func Test_LoggingContract_RequestLogEscaping(t *testing.T) {
+	tests := []struct {
+		name string
+		in   RequestLog
+		want string
+	}{
+		{
+			"double quote and backslash in uri",
+			RequestLog{URI: "/a\"b\\c"},
+			`{"uri":"/a\"b\\c"}`,
+		},
+		{
+			"control characters use short forms where they exist, \\u00XX otherwise",
+			RequestLog{URI: "/a\nb\tc\x00d\x1fe\rf\bg\fx"},
+			`{"uri":"/a\nb\tc\u0000d\u001fe\rf\bg\fx"}`,
+		},
+		{
+			"DEL 0x7f is NOT escaped",
+			RequestLog{URI: "/\x7f/end"},
+			"{\"uri\":\"/\x7f/end\"}",
+		},
+		{
+			"HTML significant characters in uri are escaped",
+			RequestLog{URI: "/q?x=<a>&y='z'"},
+			`{"uri":"/q?x=\u003ca\u003e\u0026y='z'"}`,
+		},
+		{
+			"HTML significant characters in user_agent are escaped",
+			RequestLog{UserAgent: "Mozilla/5.0 <script>alert(\"x\")&</script>"},
+			`{"user_agent":"Mozilla/5.0 \u003cscript\u003ealert(\"x\")\u0026\u003c/script\u003e"}`,
+		},
+		{
+			"tab and HTML characters in ip",
+			RequestLog{IP: "10.0.0.1\t<b>"},
+			`{"ip":"10.0.0.1\t\u003cb\u003e"}`,
+		},
+		{
+			"quotes, backslash and HTML characters in method",
+			RequestLog{Method: "GE\"T\\<>&"},
+			`{"method":"GE\"T\\\u003c\u003e\u0026"}`,
+		},
+		{
+			"CJK, emoji and combining marks pass through as raw UTF-8",
+			RequestLog{URI: "/\u65e5\u672c\u8a9e/\U0001F680/e\u0301"},
+			"{\"uri\":\"/\u65e5\u672c\u8a9e/\U0001F680/e\u0301\"}",
+		},
+		{
+			"line and paragraph separators are escaped",
+			RequestLog{URI: "/\u2028\u2029"},
+			`{"uri":"/\u2028\u2029"}`,
+		},
+		{
+			"invalid UTF-8 bytes become the escaped replacement character",
+			RequestLog{URI: "/\xff\xfe/ok"},
+			`{"uri":"/\ufffd\ufffd/ok"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(&tc.in)
+			require.NoError(t, err, "encoding/json never fails on a RequestLog, even with invalid UTF-8")
+			assert.Equal(t, tc.want, string(b))
+		})
+	}
+}
+
+// Test_LoggingContract_MarshalVersusEncoder pins the difference between the two
+// encoding entry points. The production path is json.NewEncoder(out).Encode in
+// pkg/gofr/logging — so the real log line ends with exactly one "\n" and HTML
+// escaping is ON (Encoder defaults to SetEscapeHTML(true), same as Marshal).
+func Test_LoggingContract_MarshalVersusEncoder(t *testing.T) {
+	const body = `{"uri":"/q?a=\u003cb\u003e\u0026c=1","response":200}`
+
+	rl := &RequestLog{URI: "/q?a=<b>&c=1", Response: 200}
+
+	marshaled, err := json.Marshal(rl)
+	require.NoError(t, err)
+	//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+	assert.Equal(t, []byte(body), marshaled, "json.Marshal adds no trailing newline")
+
+	var buf bytes.Buffer
+	require.NoError(t, json.NewEncoder(&buf).Encode(rl))
+	//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+	assert.Equal(t, []byte(body+"\n"), buf.Bytes(), "json.Encoder.Encode appends exactly one newline")
+	assert.Equal(t, 1, strings.Count(buf.String(), "\n"))
+}
+
+// Test_LoggingContract_StartTimeLayout pins the rendered shape of the
+// "2006-01-02T15:04:05.999999999-07:00" layout used for start_time. The
+// `.999999999` verb TRIMS trailing zeros, so a whole-second instant renders
+// with NO fractional part at all — a consumer parsing a fixed-width timestamp
+// will break. The `-07:00` verb always renders a numeric offset, so UTC becomes
+// "+00:00" rather than "Z".
+func Test_LoggingContract_StartTimeLayout(t *testing.T) {
+	plus0530 := time.FixedZone("+0530", 5*3600+1800)
+	minus0500 := time.FixedZone("-0500", -5*3600)
+
+	tests := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{"whole second in UTC has no fractional part", time.Date(2024, 3, 1, 12, 34, 56, 0, time.UTC), "2024-03-01T12:34:56+00:00"},
+		{"whole second keeps the numeric offset", time.Date(2024, 3, 1, 12, 34, 56, 0, plus0530), "2024-03-01T12:34:56+05:30"},
+		{"milliseconds", time.Date(2024, 3, 1, 12, 34, 56, 123000000, time.UTC), "2024-03-01T12:34:56.123+00:00"},
+		{"microseconds", time.Date(2024, 3, 1, 12, 34, 56, 123456000, time.UTC), "2024-03-01T12:34:56.123456+00:00"},
+		{"nanoseconds", time.Date(2024, 3, 1, 12, 34, 56, 123456789, time.UTC), "2024-03-01T12:34:56.123456789+00:00"},
+		{"trailing zeros are trimmed", time.Date(2024, 3, 1, 12, 34, 56, 100000000, time.UTC), "2024-03-01T12:34:56.1+00:00"},
+		{"leading zeros are kept", time.Date(2024, 3, 1, 12, 34, 56, 1, time.UTC), "2024-03-01T12:34:56.000000001+00:00"},
+		{"negative offset", time.Date(2024, 3, 1, 12, 34, 56, 500000000, minus0500), "2024-03-01T12:34:56.5-05:00"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.in.Format(logCharStartTimeLayout))
+		})
+	}
+}
+
+// Test_LoggingContract_StartTimeIsParseableFromMiddleware confirms the layout
+// pinned above is the one the middleware really uses, by round-tripping the
+// start_time emitted for a real request.
+func Test_LoggingContract_StartTimeIsParseableFromMiddleware(t *testing.T) {
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/x")
+
+	logCharServe(t, LogProbes{}, rec, logCharStatusHandler(http.StatusOK), req)
+
+	rl := rec.requestLog(t, 0)
+
+	parsed, err := time.Parse(logCharStartTimeLayout, rl.StartTime)
+	require.NoError(t, err, "start_time %q must parse with the production layout", rl.StartTime)
+	assert.WithinDuration(t, time.Now(), parsed, time.Minute)
+
+	// Parsing alone is too weak a pin: time.Parse is lenient about the number
+	// of fractional digits, so a production layout of ".000000000" (fixed
+	// 9 digits, no trailing-zero trimming) would still parse here. Re-render
+	// the parsed instant with the layout pinned above and require byte
+	// equality — that fails the moment the production layout verb changes.
+	assert.Equal(t, rl.StartTime, parsed.Format(logCharStartTimeLayout),
+		"start_time must round-trip byte-for-byte through the pinned layout")
+}
+
+// ---------------------------------------------------------------------------
+// B. Middleware behavior
+// ---------------------------------------------------------------------------
+
+// Test_LoggingContract_StatusRoutesLogVsError pins the severity routing
+// threshold at exactly 500: anything below goes to logger.Log, 500 and above to
+// logger.Error. 499 vs 500 is the boundary pair.
+func Test_LoggingContract_StatusRoutesLogVsError(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{"200 is logged at Log level", http.StatusOK, "LOG"},
+		{"204 is logged at Log level", http.StatusNoContent, "LOG"},
+		{"301 is logged at Log level", http.StatusMovedPermanently, "LOG"},
+		{"400 is logged at Log level", http.StatusBadRequest, "LOG"},
+		{"404 is logged at Log level", http.StatusNotFound, "LOG"},
+		{"499 is logged at Log level", 499, "LOG"},
+		{"500 crosses to Error level", http.StatusInternalServerError, "ERROR"},
+		{"503 is logged at Error level", http.StatusServiceUnavailable, "ERROR"},
+		{"599 is logged at Error level", 599, "ERROR"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &logCharRecorder{}
+			req := logCharNewRequest(t, http.MethodGet, "http://dummy/status")
+
+			rr := logCharServe(t, LogProbes{}, rec, logCharStatusHandler(tc.status), req)
+
+			records := rec.all()
+			require.Len(t, records, 1, "exactly one log line per request")
+			assert.Equal(t, tc.want, records[0].level)
+			assert.Equal(t, tc.status, rec.requestLog(t, 0).Response)
+			assert.Equal(t, tc.status, rr.Code)
+		})
+	}
+}
+
+// Test_LoggingContract_HandlerWritesNothingLogs200 pins the implicit-200
+// normalization: a handler that never calls WriteHeader or Write still logs
+// response 200 (Status() maps the internal 0 to http.StatusOK) — so the
+// omitempty on `response` never actually elides the key in practice.
+func Test_LoggingContract_HandlerWritesNothingLogs200(t *testing.T) {
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/empty")
+
+	logCharServe(t, LogProbes{}, rec, func(http.ResponseWriter, *http.Request) {}, req)
+
+	records := rec.all()
+	require.Len(t, records, 1)
+	assert.Equal(t, "LOG", records[0].level)
+	assert.Equal(t, http.StatusOK, rec.requestLog(t, 0).Response)
+
+	b, err := json.Marshal(rec.requestLog(t, 0))
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"response":200`)
+}
+
+// Test_LoggingContract_RequestLogPopulatedFields pins the value shapes the
+// middleware fills in for a realistic request.
+func Test_LoggingContract_RequestLogPopulatedFields(t *testing.T) {
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodPost, "http://dummy/api/v1/users?q=1")
+	req.RequestURI = "/api/v1/users?q=1"
+	req.Header.Set("User-Agent", "gofr-test/1.0")
+	req.RemoteAddr = "198.51.100.7:44321"
+
+	logCharServe(t, LogProbes{}, rec, logCharStatusHandler(http.StatusCreated), req)
+
+	rl := rec.requestLog(t, 0)
+	assert.Equal(t, http.MethodPost, rl.Method)
+	assert.Equal(t, "gofr-test/1.0", rl.UserAgent)
+	assert.Equal(t, "198.51.100.7:44321", rl.IP, "RemoteAddr is used verbatim, port included")
+	assert.Equal(t, "/api/v1/users?q=1", rl.URI, "uri comes from r.RequestURI, not r.URL")
+	assert.Equal(t, http.StatusCreated, rl.Response)
+	assert.Equal(t, zeroTraceID, rl.TraceID)
+	assert.Equal(t, zeroSpanID, rl.SpanID)
+	assert.GreaterOrEqual(t, rl.ResponseTime, int64(0), "response_time is microseconds, derived from time.Since")
+}
+
+// Test_LoggingContract_ResponseTimeIsMicroseconds pins the UNIT of the
+// response_time field. The exact number is wall-clock dependent, so instead of
+// a value we pin an order-of-magnitude window around a handler that sleeps a
+// known duration: 20ms is 20_000µs, which falls inside the window below but
+// would land far outside it if the field were ever switched to nanoseconds
+// (20_000_000) or milliseconds (20).
+func Test_LoggingContract_ResponseTimeIsMicroseconds(t *testing.T) {
+	const sleep = 20 * time.Millisecond
+
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/slow")
+
+	logCharServe(t, LogProbes{}, rec, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(sleep)
+		w.WriteHeader(http.StatusOK)
+	}), req)
+
+	rl := rec.requestLog(t, 0)
+
+	// Lower bound is half the sleep (coarse timers / CI jitter can under-report
+	// slightly); upper bound is 100x the sleep, which a scheduler hiccup can
+	// plausibly reach but a unit change cannot fit inside.
+	assert.Greater(t, rl.ResponseTime, int64(sleep/time.Microsecond)/2,
+		"response_time %d is too small to be microseconds for a %v handler", rl.ResponseTime, sleep)
+	assert.Less(t, rl.ResponseTime, int64(sleep/time.Microsecond)*100,
+		"response_time %d is too large to be microseconds for a %v handler", rl.ResponseTime, sleep)
+}
+
+// Test_LoggingContract_PanicRecoveryShapes pins panic handling for all three
+// branches of panicRecovery's type switch, the 500 status, and the EXACT bytes
+// of the JSON envelope written to the client.
+func Test_LoggingContract_PanicRecoveryShapes(t *testing.T) {
+	tests := []struct {
+		name      string
+		panicWith any
+		wantError string
+	}{
+		{"panic with a string uses the string verbatim", "boom from a string", "boom from a string"},
+		{"panic with an error uses Error()", errLogCharPanic, "boom from an error value"},
+		{"panic with any other type is labeled", struct{ A int }{1}, "Unknown panic type"},
+		{"panic with an int is labeled", 42, "Unknown panic type"},
+		{"panic with nil-ish non-error value is labeled", []string{"x"}, "Unknown panic type"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &logCharRecorder{}
+			req := logCharNewRequest(t, http.MethodGet, "http://dummy/panic")
+
+			rr := logCharServe(t, LogProbes{}, rec, func(http.ResponseWriter, *http.Request) {
+				panic(tc.panicWith)
+			}, req)
+
+			logCharAssertPanicRecord(t, rec, tc.wantError)
+
+			assert.Equal(t, http.StatusInternalServerError, rr.Code)
+			//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+			assert.Equal(t, logCharPanicEnvelope, rr.Body.String(),
+				"panic envelope keys are map-sorted (code, message, status) with a trailing newline")
+		})
+	}
+}
+
+// logCharAssertPanicRecord pins the panicLog record: it is always the LAST
+// record, always at Error level, and always a panicLog value (not a pointer).
+func logCharAssertPanicRecord(t *testing.T, rec *logCharRecorder, wantErr string) {
+	t.Helper()
+
+	records := rec.all()
+	require.NotEmpty(t, records)
+
+	last := records[len(records)-1]
+	assert.Equal(t, "ERROR", last.level)
+
+	pl, ok := last.arg.(panicLog)
+	require.True(t, ok, "panic record is %T, want panicLog", last.arg)
+	assert.Equal(t, wantErr, pl.Error)
+	assert.NotEmpty(t, pl.StackTrace)
+
+	b, err := json.Marshal(pl)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(b), `{"error":"`), "panicLog field order is error then stack_trace")
+	assert.Contains(t, string(b), `","stack_trace":"`)
+}
+
+// Test_LoggingContract_PanicLogJSONShape pins the panicLog wire format,
+// including its omitempty behavior.
+func Test_LoggingContract_PanicLogJSONShape(t *testing.T) {
+	b, err := json.Marshal(panicLog{Error: "boom", StackTrace: "goroutine 1 [running]:"})
+	require.NoError(t, err)
+	//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+	assert.Equal(t, `{"error":"boom","stack_trace":"goroutine 1 [running]:"}`, string(b))
+
+	empty, err := json.Marshal(panicLog{})
+	require.NoError(t, err)
+	assert.Equal(t, `{}`, string(empty), "both panicLog fields are omitempty")
+
+	only, err := json.Marshal(panicLog{Error: "boom"})
+	require.NoError(t, err)
+	//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+	assert.Equal(t, `{"error":"boom"}`, string(only))
+}
+
+// Test_LoggingContract_PanicAlsoEmitsRequestLogFirst pins a subtle and
+// surprising ordering consequence of the defer registration order in Logging:
+//
+//	defer pool.Put            (registered 1st -> runs 3rd)
+//	defer panicRecovery       (registered 2nd -> runs 2nd)
+//	defer handleRequestLog    (registered 3rd -> runs 1st)
+//
+// So on a panic the REQUEST log is emitted BEFORE the panic log, and because
+// panicRecovery has not yet written the 500 at that point, the request log
+// records response 200 for a request the client sees as a 500.
+func Test_LoggingContract_PanicAlsoEmitsRequestLogFirst(t *testing.T) {
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/panic")
+
+	rr := logCharServe(t, LogProbes{}, rec, func(http.ResponseWriter, *http.Request) {
+		panic("kaboom")
+	}, req)
+
+	records := rec.all()
+	require.Len(t, records, 2, "a panic emits both a request log and a panic log")
+
+	rl, ok := records[0].arg.(*RequestLog)
+	require.True(t, ok, "the request log comes FIRST")
+	assert.Equal(t, "LOG", records[0].level,
+		"request log is routed to Log, not Error, because Status() is still 200 when it runs")
+	assert.Equal(t, http.StatusOK, rl.Response,
+		"request log reports 200 even though the client receives 500")
+
+	_, ok = records[1].arg.(panicLog)
+	assert.True(t, ok, "the panic log comes SECOND")
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+// Test_LoggingContract_PanicAfterWriteKeepsFirstStatus pins that WriteHeader is
+// idempotent: when the handler has already committed a status, panicRecovery's
+// WriteHeader(500) is a no-op and the envelope is APPENDED to whatever the
+// handler already wrote.
+func Test_LoggingContract_PanicAfterWriteKeepsFirstStatus(t *testing.T) {
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/panic-after-write")
+
+	rr := logCharServe(t, LogProbes{}, rec, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("partial"))
+
+		panic("late boom")
+	}, req)
+
+	assert.Equal(t, http.StatusTeapot, rr.Code, "the first WriteHeader wins; no superfluous-header panic")
+	assert.Equal(t, "partial"+logCharPanicEnvelope, rr.Body.String())
+	assert.Equal(t, http.StatusTeapot, rec.requestLog(t, 0).Response)
+}
+
+// Test_LoggingContract_PanicOnProbePathSkipsRequestLog pins that the probe-skip
+// early return happens AFTER the panicRecovery defer is registered, so panics
+// on probe paths are still recovered and logged — but no request log is emitted.
+func Test_LoggingContract_PanicOnProbePathSkipsRequestLog(t *testing.T) {
+	rec := &logCharRecorder{}
+	probes := LogProbes{Disabled: true, Paths: []string{service.HealthPath, service.AlivePath}}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy"+service.HealthPath)
+
+	rr := logCharServe(t, probes, rec, func(http.ResponseWriter, *http.Request) {
+		panic("probe boom")
+	}, req)
+
+	records := rec.all()
+	require.Len(t, records, 1, "only the panic log; no request log on a skipped path")
+
+	pl, ok := records[0].arg.(panicLog)
+	require.True(t, ok)
+	assert.Equal(t, "probe boom", pl.Error)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+	assert.Equal(t, logCharPanicEnvelope, rr.Body.String())
+}
+
+// Test_LoggingContract_ProbeFiltering pins which (Disabled, Paths, urlPath)
+// combinations suppress the request log entirely.
+func Test_LoggingContract_ProbeFiltering(t *testing.T) {
+	defaults := []string{service.HealthPath, service.AlivePath}
+
+	tests := []struct {
+		name     string
+		probes   LogProbes
+		path     string
+		wantLogs int
+	}{
+		{"disabled + health path is silent", LogProbes{Disabled: true, Paths: defaults}, service.HealthPath, 0},
+		{"disabled + alive path is silent", LogProbes{Disabled: true, Paths: defaults}, service.AlivePath, 0},
+		{"disabled + unrelated path still logs", LogProbes{Disabled: true, Paths: defaults}, "/api/users", 1},
+		{"disabled + prefix of a probe path still logs", LogProbes{Disabled: true, Paths: defaults}, "/.well-known", 1},
+		{"disabled + probe path with trailing slash still logs",
+			LogProbes{Disabled: true, Paths: defaults}, service.HealthPath + "/", 1},
+		{"not disabled + health path still logs", LogProbes{Disabled: false, Paths: defaults}, service.HealthPath, 1},
+		{"not disabled + alive path still logs", LogProbes{Disabled: false, Paths: defaults}, service.AlivePath, 1},
+		{"disabled with empty path list logs everything", LogProbes{Disabled: true}, service.HealthPath, 1},
+		{"disabled with a custom path is silent", LogProbes{Disabled: true, Paths: []string{"/ping"}}, "/ping", 0},
+		{"zero-value LogProbes logs everything", LogProbes{}, service.HealthPath, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &logCharRecorder{}
+			req := logCharNewRequest(t, http.MethodGet, "http://dummy"+tc.path)
+
+			logCharServe(t, tc.probes, rec, logCharStatusHandler(http.StatusOK), req)
+
+			assert.Len(t, rec.all(), tc.wantLogs)
+		})
+	}
+}
+
+// Test_LoggingContract_ProbePathPassesRawWriterToHandler pins a real asymmetry
+// in Logging: on the skipped (probe) path it calls inner.ServeHTTP(w, r) with
+// the RAW ResponseWriter, while on the normal path it calls
+// inner.ServeHTTP(srw, r) with the pooled *StatusResponseWriter.
+//
+// Consequence: on probe paths the downstream chain (and the handler) do NOT see
+// a *StatusResponseWriter. Any downstream middleware that type-asserts on it —
+// pkg/gofr/http/middleware/tracer.go does exactly that — silently falls back to
+// its own wrapper. Reported as a latent inconsistency, pinned here as-is.
+func Test_LoggingContract_ProbePathPassesRawWriterToHandler(t *testing.T) {
+	probes := LogProbes{Disabled: true, Paths: []string{service.HealthPath, service.AlivePath}}
+
+	var (
+		skippedIsWrapped bool
+		normalIsWrapped  bool
+	)
+
+	handler := func(target *bool) http.HandlerFunc {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			_, ok := w.(*StatusResponseWriter)
+			*target = ok
+		}
+	}
+
+	logCharServe(t, probes, &logCharRecorder{}, handler(&skippedIsWrapped),
+		logCharNewRequest(t, http.MethodGet, "http://dummy"+service.HealthPath))
+
+	logCharServe(t, probes, &logCharRecorder{}, handler(&normalIsWrapped),
+		logCharNewRequest(t, http.MethodGet, "http://dummy/api/users"))
+
+	assert.False(t, skippedIsWrapped, "probe path hands the handler the RAW ResponseWriter")
+	assert.True(t, normalIsWrapped, "normal path hands the handler the pooled *StatusResponseWriter")
+}
+
+// Test_LoggingContract_ProbePathStillSetsCorrelationID pins that the
+// X-Correlation-ID header is set BEFORE the probe short-circuit, so probe
+// responses still carry it even though nothing is logged.
+func Test_LoggingContract_ProbePathStillSetsCorrelationID(t *testing.T) {
+	rec := &logCharRecorder{}
+	probes := LogProbes{Disabled: true, Paths: []string{service.HealthPath, service.AlivePath}}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy"+service.AlivePath)
+
+	rr := logCharServe(t, probes, rec, logCharStatusHandler(http.StatusOK), req)
+
+	assert.Empty(t, rec.all())
+	assert.Equal(t, zeroTraceID, rr.Header().Get("X-Correlation-ID"))
+}
+
+// Test_LoggingContract_IsLogProbeDisabled pins the predicate directly.
+func Test_LoggingContract_IsLogProbeDisabled(t *testing.T) {
+	paths := []string{service.HealthPath, service.AlivePath}
+
+	tests := []struct {
+		name   string
+		probes LogProbes
+		path   string
+		want   bool
+	}{
+		{"health path with probes disabled", LogProbes{Disabled: true, Paths: paths}, service.HealthPath, true},
+		{"alive path with probes disabled", LogProbes{Disabled: true, Paths: paths}, service.AlivePath, true},
+		{"health path with probes enabled", LogProbes{Disabled: false, Paths: paths}, service.HealthPath, false},
+		{"unknown path with probes disabled", LogProbes{Disabled: true, Paths: paths}, "/other", false},
+		{"empty path list", LogProbes{Disabled: true, Paths: nil}, service.HealthPath, false},
+		{"empty string path matches an empty entry", LogProbes{Disabled: true, Paths: []string{""}}, "", true},
+		{"match is exact, not prefix", LogProbes{Disabled: true, Paths: paths}, service.HealthPath + "?x=1", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isLogProbeDisabled(tc.probes, tc.path))
+		})
+	}
+}
+
+// Test_LoggingContract_CorrelationIDWithoutSpan pins the no-trace default: the
+// header and both log ID fields carry the all-zero W3C strings, not "".
+func Test_LoggingContract_CorrelationIDWithoutSpan(t *testing.T) {
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/no-span")
+
+	rr := logCharServe(t, LogProbes{}, rec, logCharStatusHandler(http.StatusOK), req)
+
+	assert.Equal(t, "00000000000000000000000000000000", rr.Header().Get("X-Correlation-ID"))
+	assert.Len(t, rr.Header().Get("X-Correlation-ID"), 32)
+
+	rl := rec.requestLog(t, 0)
+	assert.Equal(t, "00000000000000000000000000000000", rl.TraceID)
+	assert.Equal(t, "0000000000000000", rl.SpanID)
+	assert.Len(t, rl.SpanID, 16)
+}
+
+// Test_LoggingContract_CorrelationIDWithRecordingSpan pins that a real sampled
+// span's IDs flow into both the header and the log line. Uses a locally
+// constructed TracerProvider so no OTel process globals are touched.
+func Test_LoggingContract_CorrelationIDWithRecordingSpan(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+
+	t.Cleanup(func() { _ = tp.Shutdown(t.Context()) })
+
+	ctx, span := tp.Tracer("logchar").Start(t.Context(), "logchar-op")
+	defer span.End()
+
+	require.True(t, span.IsRecording())
+	require.True(t, span.SpanContext().IsValid())
+
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/traced").WithContext(ctx)
+
+	rr := logCharServe(t, LogProbes{}, rec, logCharStatusHandler(http.StatusOK), req)
+
+	wantTrace := span.SpanContext().TraceID().String()
+	wantSpan := span.SpanContext().SpanID().String()
+
+	assert.Equal(t, wantTrace, rr.Header().Get("X-Correlation-ID"))
+	assert.Equal(t, wantTrace, rec.requestLog(t, 0).TraceID)
+	assert.Equal(t, wantSpan, rec.requestLog(t, 0).SpanID)
+	assert.NotEqual(t, zeroTraceID, wantTrace)
+}
+
+// Test_LoggingContract_CorrelationIDWithNeverSampledSpan pins the default
+// no-exporter deployment shape described in pkg/gofr/otel.go: a NeverSample
+// provider still mints VALID trace/span IDs, so correlation IDs stay unique
+// per request even though the span is not recording.
+func Test_LoggingContract_CorrelationIDWithNeverSampledSpan(t *testing.T) {
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.NeverSample()))
+
+	t.Cleanup(func() { _ = tp.Shutdown(t.Context()) })
+
+	ctx, span := tp.Tracer("logchar").Start(t.Context(), "logchar-op")
+	defer span.End()
+
+	require.False(t, span.IsRecording(), "NeverSample spans do not record")
+	require.True(t, span.SpanContext().IsValid(), "but the SpanContext is still valid")
+
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/never-sampled").WithContext(ctx)
+
+	rr := logCharServe(t, LogProbes{}, rec, logCharStatusHandler(http.StatusOK), req)
+
+	wantTrace := span.SpanContext().TraceID().String()
+
+	assert.Equal(t, wantTrace, rr.Header().Get("X-Correlation-ID"))
+	assert.NotEqual(t, zeroTraceID, wantTrace)
+	assert.Equal(t, wantTrace, rec.requestLog(t, 0).TraceID)
+	assert.Equal(t, span.SpanContext().SpanID().String(), rec.requestLog(t, 0).SpanID)
+}
+
+// Test_LoggingContract_CorrelationIDWithRemoteSpanContext pins that a
+// SpanContext injected directly (as the W3C propagator would after extracting
+// traceparent) is honored without any TracerProvider involved.
+func Test_LoggingContract_CorrelationIDWithRemoteSpanContext(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	require.NoError(t, err)
+
+	spanID, err := trace.SpanIDFromHex("00f067aa0ba902b7") // spellchecker:disable-line
+	require.NoError(t, err)
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled, Remote: true,
+	})
+	ctx := trace.ContextWithSpanContext(t.Context(), sc)
+
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/remote").WithContext(ctx)
+
+	rr := logCharServe(t, LogProbes{}, rec, logCharStatusHandler(http.StatusOK), req)
+
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", rr.Header().Get("X-Correlation-ID"))
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", rec.requestLog(t, 0).TraceID)
+	assert.Equal(t, "00f067aa0ba902b7", rec.requestLog(t, 0).SpanID) // spellchecker:disable-line
+}
+
+// Test_LoggingContract_GetIPAddress pins X-Forwarded-For parsing, including two
+// sharp edges:
+//   - RemoteAddr is used VERBATIM, port included — it is never split.
+//   - A whitespace-only XFF header yields the EMPTY string rather than falling
+//     back to RemoteAddr, because the empty check runs BEFORE TrimSpace. The
+//     resulting empty `ip` is then dropped from the log line by omitempty.
+func Test_LoggingContract_GetIPAddress(t *testing.T) {
+	const remote = "10.0.0.9:54321"
+
+	tests := []struct {
+		name string
+		xff  string
+		want string
+	}{
+		{"no XFF falls back to RemoteAddr with its port", "", remote},
+		{"single XFF entry", "203.0.113.5", "203.0.113.5"},
+		{"comma list takes the first entry", "203.0.113.5, 70.41.3.18, 150.172.238.178", "203.0.113.5"},
+		{"first entry is trimmed", "  203.0.113.5  , 70.41.3.18", "203.0.113.5"},
+		{"surrounding whitespace on a single entry is trimmed", "\t203.0.113.5 ", "203.0.113.5"},
+		{"XFF with a port keeps the port", "192.168.0.1:8080", "192.168.0.1:8080"},
+		{"lone comma falls back to RemoteAddr", ",", remote},
+		{"leading comma falls back to RemoteAddr", ",203.0.113.5", remote},
+		{"whitespace-only XFF yields the empty string, NOT RemoteAddr", " ", ""},
+		{"whitespace before a comma yields the empty string", " , 203.0.113.5", ""},
+		{"IPv6 entry", "2001:db8::1, 203.0.113.5", "2001:db8::1"},
+		{"trailing comma keeps the first entry", "203.0.113.5,", "203.0.113.5"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := logCharNewRequest(t, http.MethodGet, "http://dummy/ip")
+			req.RemoteAddr = remote
+
+			if tc.xff != "" {
+				req.Header.Set("X-Forwarded-For", tc.xff)
+			}
+
+			assert.Equal(t, tc.want, getIPAddress(req))
+		})
+	}
+}
+
+// Test_LoggingContract_EmptyIPIsOmittedFromWire pins the omitempty consequence
+// of the whitespace-only XFF edge above: the `ip` key disappears entirely.
+func Test_LoggingContract_EmptyIPIsOmittedFromWire(t *testing.T) {
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/ip")
+	req.RequestURI = "/ip"
+	req.RemoteAddr = "10.0.0.9:54321"
+	req.Header.Set("X-Forwarded-For", " ")
+
+	logCharServe(t, LogProbes{}, rec, logCharStatusHandler(http.StatusOK), req)
+
+	rl := rec.requestLog(t, 0)
+	assert.Empty(t, rl.IP)
+
+	b, err := json.Marshal(rl)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), `"ip"`, "an empty ip is dropped from the wire by omitempty")
+}
+
+// Test_LoggingContract_EmptyUserAgentIsOmittedFromWire pins the same for
+// user_agent, which is trivially reachable (most non-browser clients send none).
+func Test_LoggingContract_EmptyUserAgentIsOmittedFromWire(t *testing.T) {
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/ua")
+	req.RequestURI = "/ua"
+
+	logCharServe(t, LogProbes{}, rec, logCharStatusHandler(http.StatusOK), req)
+
+	rl := rec.requestLog(t, 0)
+	assert.Empty(t, rl.UserAgent)
+
+	b, err := json.Marshal(rl)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), `"user_agent"`)
+}
+
+// Test_LoggingContract_PoolResetsStateAcrossRequests pins that the pooled
+// StatusResponseWriter is fully reset per request: a 500 followed by a
+// write-nothing request through the SAME middleware instance must log 500 then
+// 200, never a leaked 500.
+func Test_LoggingContract_PoolResetsStateAcrossRequests(t *testing.T) {
+	rec := &logCharRecorder{}
+	mw := Logging(LogProbes{}, rec)
+
+	first := mw(logCharStatusHandler(http.StatusInternalServerError))
+	first.ServeHTTP(httptest.NewRecorder(), logCharNewRequest(t, http.MethodGet, "http://dummy/one"))
+
+	second := mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	rr := httptest.NewRecorder()
+	second.ServeHTTP(rr, logCharNewRequest(t, http.MethodGet, "http://dummy/two"))
+
+	records := rec.all()
+	require.Len(t, records, 2)
+	assert.Equal(t, "ERROR", records[0].level)
+	assert.Equal(t, http.StatusInternalServerError, rec.requestLog(t, 0).Response)
+	assert.Equal(t, "LOG", records[1].level)
+	assert.Equal(t, http.StatusOK, rec.requestLog(t, 1).Response, "wroteHeader/status must be reset on pool Get")
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// Test_LoggingContract_PoolNilsResponseWriterAfterRequest pins that the pooled
+// wrapper's ResponseWriter pointer is cleared once the request completes, so a
+// stale writer cannot leak across requests through the pool.
+func Test_LoggingContract_PoolNilsResponseWriterAfterRequest(t *testing.T) {
+	var captured *StatusResponseWriter
+
+	rec := &logCharRecorder{}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/pool")
+
+	logCharServe(t, LogProbes{}, rec, func(w http.ResponseWriter, _ *http.Request) {
+		captured, _ = w.(*StatusResponseWriter)
+
+		w.WriteHeader(http.StatusOK)
+	}, req)
+
+	require.NotNil(t, captured)
+	assert.Nil(t, captured.ResponseWriter, "ResponseWriter is nil'd before the wrapper returns to the pool")
+	assert.Equal(t, http.StatusOK, captured.Status(), "status/wroteHeader are NOT cleared on Put, only on the next Get")
+}
+
+// Test_LoggingContract_DoubleWrapPropagatesStatus pins the production chain
+// shape: Tracer wraps the writer, then Logging wraps it AGAIN from its pool.
+// The status a handler writes must surface through both layers.
+func Test_LoggingContract_DoubleWrapPropagatesStatus(t *testing.T) {
+	rec := &logCharRecorder{}
+	rr := httptest.NewRecorder()
+	outer := &StatusResponseWriter{ResponseWriter: rr}
+
+	Logging(LogProbes{}, rec)(logCharStatusHandler(http.StatusServiceUnavailable)).
+		ServeHTTP(outer, logCharNewRequest(t, http.MethodGet, "http://dummy/double"))
+
+	assert.Equal(t, http.StatusServiceUnavailable, outer.Status(), "outer wrapper sees the status")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code, "the real writer sees the status")
+	assert.Equal(t, http.StatusServiceUnavailable, rec.requestLog(t, 0).Response)
+	assert.Equal(t, zeroTraceID, rr.Header().Get("X-Correlation-ID"), "header set through both wrappers")
+}
+
+// ---------------------------------------------------------------------------
+// C. StatusResponseWriter
+// ---------------------------------------------------------------------------
+
+// Test_LoggingContract_SRWDuplicateWriteHeader pins that the second (and any
+// later) WriteHeader call is dropped without a "superfluous response.WriteHeader
+// call" from net/http.
+func Test_LoggingContract_SRWDuplicateWriteHeader(t *testing.T) {
+	rr := httptest.NewRecorder()
+	srw := &StatusResponseWriter{ResponseWriter: rr}
+
+	srw.WriteHeader(http.StatusTeapot)
+	srw.WriteHeader(http.StatusOK)
+	srw.WriteHeader(http.StatusBadGateway)
+
+	assert.Equal(t, http.StatusTeapot, srw.Status())
+	assert.Equal(t, http.StatusTeapot, rr.Code)
+	assert.True(t, srw.wroteHeader)
+}
+
+// Test_LoggingContract_SRWWriteThenWriteHeader pins that a bare Write commits an
+// implicit 200 and a subsequent WriteHeader cannot change it.
+func Test_LoggingContract_SRWWriteThenWriteHeader(t *testing.T) {
+	rr := httptest.NewRecorder()
+	srw := &StatusResponseWriter{ResponseWriter: rr}
+
+	n, err := srw.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, http.StatusOK, srw.Status())
+
+	srw.WriteHeader(http.StatusInternalServerError)
+
+	assert.Equal(t, http.StatusOK, srw.Status(), "the implicit 200 from Write wins")
+	assert.Equal(t, "hello", rr.Body.String())
+}
+
+// Test_LoggingContract_SRWStatusDefaultsTo200 pins Status()'s zero-normalization
+// on an untouched writer.
+func Test_LoggingContract_SRWStatusDefaultsTo200(t *testing.T) {
+	srw := &StatusResponseWriter{ResponseWriter: httptest.NewRecorder()}
+
+	assert.Equal(t, 0, srw.status, "the raw field is still zero")
+	assert.Equal(t, http.StatusOK, srw.Status(), "Status() normalizes zero to 200")
+	assert.False(t, srw.wroteHeader)
+}
+
+// Test_LoggingContract_SRWUnwrap pins that Unwrap returns the exact wrapped
+// writer and that http.NewResponseController reaches Flush through it.
+func Test_LoggingContract_SRWUnwrap(t *testing.T) {
+	rr := httptest.NewRecorder()
+	srw := &StatusResponseWriter{ResponseWriter: rr}
+
+	assert.Same(t, rr, srw.Unwrap())
+
+	_, err := srw.Write([]byte("chunk"))
+	require.NoError(t, err)
+
+	require.NoError(t, http.NewResponseController(srw).Flush())
+	assert.True(t, rr.Flushed, "Flush reached the recorder via Unwrap")
+	assert.Equal(t, "chunk", rr.Body.String())
+}
+
+// Test_LoggingContract_SRWResponseControllerUnsupported pins that capabilities
+// the wrapped writer does not have surface as http.ErrNotSupported rather than
+// being masked by the wrapper.
+func Test_LoggingContract_SRWResponseControllerUnsupported(t *testing.T) {
+	srw := &StatusResponseWriter{ResponseWriter: httptest.NewRecorder()}
+
+	err := http.NewResponseController(srw).SetWriteDeadline(time.Now().Add(time.Second))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, http.ErrNotSupported)
+}
+
+// Test_LoggingContract_SRWHijackNotSupported pins the exact error produced when
+// the wrapped writer is not an http.Hijacker, including the sentinel wrapping.
+func Test_LoggingContract_SRWHijackNotSupported(t *testing.T) {
+	srw := &StatusResponseWriter{ResponseWriter: httptest.NewRecorder()}
+
+	conn, rw, err := srw.Hijack()
+
+	require.Error(t, err)
+	assert.Nil(t, conn)
+	assert.Nil(t, rw)
+	require.ErrorIs(t, err, errHijackNotSupported)
+	assert.Equal(t, "response writer does not support hijacking: cannot hijack connection", err.Error())
+	assert.Equal(t, "response writer does not support hijacking", errHijackNotSupported.Error())
+}
+
+// ---------------------------------------------------------------------------
+// D. PrettyPrint (terminal path)
+// ---------------------------------------------------------------------------
+
+// Test_LoggingContract_PrettyPrintExactBytes pins the exact ANSI byte sequence
+// PrettyPrint emits, including the %-6d status padding, the %8d duration
+// padding, and the trailing " \n" (space then newline).
+func Test_LoggingContract_PrettyPrintExactBytes(t *testing.T) {
+	const (
+		grey  = "\u001B[38;5;8m"
+		reset = "\u001B[0m"
+	)
+
+	tests := []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{"2xx uses color 34", 200, grey + "abc \u001B[38;5;34m200   " + reset + "       42" + grey + "µs" + reset + " GET /x \n"},
+		{"4xx uses color 220", 404, grey + "abc \u001B[38;5;220m404   " + reset + "       42" + grey + "µs" + reset + " GET /x \n"},
+		{"5xx uses color 202", 500, grey + "abc \u001B[38;5;202m500   " + reset + "       42" + grey + "µs" + reset + " GET /x \n"},
+		{"1xx falls through to color 0", 100, grey + "abc \u001B[38;5;0m100   " + reset + "       42" + grey + "µs" + reset + " GET /x \n"},
+		{"3xx falls through to color 0", 302, grey + "abc \u001B[38;5;0m302   " + reset + "       42" + grey + "µs" + reset + " GET /x \n"},
+		{"6xx falls through to color 0", 600, grey + "abc \u001B[38;5;0m600   " + reset + "       42" + grey + "µs" + reset + " GET /x \n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rl := &RequestLog{TraceID: "abc", Response: tc.status, ResponseTime: 42, Method: http.MethodGet, URI: "/x"}
+
+			var buf bytes.Buffer
+			rl.PrettyPrint(&buf)
+
+			assert.Equal(t, tc.want, buf.String())
+		})
+	}
+}
+
+// Test_LoggingContract_PrettyPrintPaddingOverflow pins that the %-6d and %8d
+// widths are MINIMUMS: oversized values push the line wider rather than being
+// truncated, and there is no separator besides the padding.
+func Test_LoggingContract_PrettyPrintPaddingOverflow(t *testing.T) {
+	rl := &RequestLog{TraceID: "t", Response: 1234567, ResponseTime: 1234567890, Method: "PATCH", URI: "/long/path"}
+
+	var buf bytes.Buffer
+	rl.PrettyPrint(&buf)
+
+	want := "\u001B[38;5;8mt \u001B[38;5;0m1234567\u001B[0m 1234567890\u001B[38;5;8mµs\u001B[0m PATCH /long/path \n"
+	assert.Equal(t, want, buf.String())
+}
+
+// Test_LoggingContract_PrettyPrintEmptyRequestLog pins the zero-value render —
+// PrettyPrint applies no omitempty logic, so empty fields become empty columns.
+func Test_LoggingContract_PrettyPrintEmptyRequestLog(t *testing.T) {
+	var buf bytes.Buffer
+	(&RequestLog{}).PrettyPrint(&buf)
+
+	want := "\u001B[38;5;8m \u001B[38;5;0m0     \u001B[0m        0\u001B[38;5;8mµs\u001B[0m   \n"
+	assert.Equal(t, want, buf.String())
+}
+
+// Test_LoggingContract_ColorForStatusCodeBoundaries pins every boundary of the
+// status -> color mapping used by PrettyPrint.
+func Test_LoggingContract_ColorForStatusCodeBoundaries(t *testing.T) {
+	tests := []struct {
+		status int
+		want   int
+	}{
+		{0, 0}, {100, 0}, {199, 0},
+		{200, 34}, {299, 34},
+		{300, 0}, {399, 0},
+		{400, 220}, {499, 220},
+		{500, 202}, {599, 202},
+		{600, 0}, {-1, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("status_%d", tc.status), func(t *testing.T) {
+			assert.Equal(t, tc.want, colorForStatusCode(tc.status))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// E. Misc
+// ---------------------------------------------------------------------------
+
+// Test_LoggingContract_HandleRequestLogNilLogger pins that a nil logger is a
+// silent no-op in handleRequestLog rather than a nil-pointer panic. (Note:
+// panicRecovery has no such guard — it calls logger.Error unconditionally.)
+func Test_LoggingContract_HandleRequestLogNilLogger(t *testing.T) {
+	srw := &StatusResponseWriter{ResponseWriter: httptest.NewRecorder()}
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/nil-logger")
+
+	assert.NotPanics(t, func() {
+		handleRequestLog(srw, req, time.Now(), zeroTraceID, zeroSpanID, nil)
+	})
+}
+
+// Test_LoggingContract_ZeroIDConstants pins the literal zero-ID constants used
+// when no valid SpanContext is in scope.
+func Test_LoggingContract_ZeroIDConstants(t *testing.T) {
+	assert.Equal(t, "00000000000000000000000000000000", zeroTraceID)
+	assert.Equal(t, "0000000000000000", zeroSpanID)
+	assert.Equal(t, zeroTraceID, trace.TraceID{}.String(), "matches the W3C invalid TraceID rendering")
+	assert.Equal(t, zeroSpanID, trace.SpanID{}.String(), "matches the W3C invalid SpanID rendering")
+}
+
+// Test_LoggingContract_MethodIsNotNormalized pins that the log records
+// r.Method verbatim — no upper-casing (unlike the Tracer middleware, which does
+// strings.ToUpper for the span name).
+func Test_LoggingContract_MethodIsNotNormalized(t *testing.T) {
+	rec := &logCharRecorder{}
+
+	req := logCharNewRequest(t, http.MethodGet, "http://dummy/case")
+	req.Method = "get"
+
+	logCharServe(t, LogProbes{}, rec, logCharStatusHandler(http.StatusOK), req)
+
+	assert.Equal(t, "get", rec.requestLog(t, 0).Method)
+}
+
+// Test_LoggingContract_OneLogPerRequest pins that a normal request produces
+// exactly one record and that repeated requests do not accumulate duplicates.
+func Test_LoggingContract_OneLogPerRequest(t *testing.T) {
+	rec := &logCharRecorder{}
+	mw := Logging(LogProbes{}, rec)(logCharStatusHandler(http.StatusOK))
+
+	const n = 5
+
+	for i := range n {
+		mw.ServeHTTP(httptest.NewRecorder(), logCharNewRequest(t, http.MethodGet, fmt.Sprintf("http://dummy/%d", i)))
+	}
+
+	assert.Len(t, rec.all(), n)
+}
+
+// Test_LoggingContract_ConcurrentRequestsShareThePool exercises the sync.Pool
+// under -race with concurrent requests and pins that each request still gets an
+// independent, correctly-scoped status.
+func Test_LoggingContract_ConcurrentRequestsShareThePool(t *testing.T) {
+	rec := &logCharRecorder{}
+	mw := Logging(LogProbes{}, rec)
+
+	const n = 32
+
+	var wg sync.WaitGroup
+
+	for i := range n {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			status := http.StatusOK
+			if i%2 == 0 {
+				status = http.StatusInternalServerError
+			}
+
+			h := mw(logCharStatusHandler(status))
+			rr := httptest.NewRecorder()
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://dummy/c", http.NoBody)
+			h.ServeHTTP(rr, req)
+
+			assert.Equal(t, status, rr.Code)
+		}(i)
+	}
+
+	wg.Wait()
+
+	records := rec.all()
+	require.Len(t, records, n)
+
+	var errs int
+
+	for _, r := range records {
+		if r.level == "ERROR" {
+			errs++
+		}
+	}
+
+	assert.Equal(t, n/2, errs, "half the requests were 500s; no status leaked across pooled writers")
 }

--- a/pkg/gofr/http/middleware/metrics_test.go
+++ b/pkg/gofr/http/middleware/metrics_test.go
@@ -5,11 +5,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type mockMetrics struct {
@@ -195,4 +200,1012 @@ func TestMetrics_StaticFileWithQueryParam(t *testing.T) {
 
 	mockMetrics.AssertCalled(t, "RecordHistogram", mock.Anything, "app_http_response", mock.Anything,
 		[]string{"path", "/static/example.js", "method", "GET", "status", "200"})
+}
+
+// ---------------------------------------------------------------------------
+// Characterization suite for the Metrics HTTP middleware.
+//
+// Everything below pins CURRENT behavior of pkg/gofr/http/middleware/metrics.go
+// exactly as it is today. Where the behavior looks like a latent bug the test
+// still asserts the observed value and says so in a comment — these tests are
+// a tripwire, not a specification of what SHOULD happen.
+//
+// All identifiers introduced here are prefixed with metChar to stay collision
+// free with the other _test.go files in this package.
+// ---------------------------------------------------------------------------
+
+// Recorded call kinds captured by metCharRecorder.
+const (
+	metCharKindHistogram = "RecordHistogram"
+	metCharKindAttrs     = "RecordHistogramAttrs"
+	metCharKindCounter   = "IncrementCounter"
+	metCharKindUpDown    = "DeltaUpDownCounter"
+	metCharKindGauge     = "SetGauge"
+)
+
+// metCharMetricName is the only metric the middleware is allowed to emit.
+const metCharMetricName = "app_http_response"
+
+// metCharCall is a single, fully captured metrics call.
+type metCharCall struct {
+	kind   string
+	name   string
+	value  float64
+	labels []string
+	attrs  []attribute.KeyValue
+}
+
+// metCharRecorder implements the unexported `metrics` interface ONLY, so the
+// middleware takes the slow (string varargs) path. It is mutex protected
+// because the concurrency test drives it from many goroutines under -race.
+type metCharRecorder struct {
+	mu    sync.Mutex
+	calls []metCharCall
+}
+
+func (f *metCharRecorder) record(c *metCharCall) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.calls = append(f.calls, *c)
+}
+
+// all returns a copy of every call recorded so far.
+func (f *metCharRecorder) all() []metCharCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := make([]metCharCall, len(f.calls))
+	copy(out, f.calls)
+
+	return out
+}
+
+// one asserts that exactly one metrics call was recorded and returns it.
+func (f *metCharRecorder) one(t *testing.T) *metCharCall {
+	t.Helper()
+
+	calls := f.all()
+	require.Len(t, calls, 1, "expected exactly one recorded metrics call")
+
+	return &calls[0]
+}
+
+func (f *metCharRecorder) IncrementCounter(_ context.Context, name string, labels ...string) {
+	f.record(&metCharCall{kind: metCharKindCounter, name: name, labels: labels})
+}
+
+func (f *metCharRecorder) DeltaUpDownCounter(_ context.Context, name string, value float64, labels ...string) {
+	f.record(&metCharCall{kind: metCharKindUpDown, name: name, value: value, labels: labels})
+}
+
+func (f *metCharRecorder) RecordHistogram(_ context.Context, name string, value float64, labels ...string) {
+	f.record(&metCharCall{kind: metCharKindHistogram, name: name, value: value, labels: append([]string(nil), labels...)})
+}
+
+func (f *metCharRecorder) SetGauge(name string, value float64, labels ...string) {
+	f.record(&metCharCall{kind: metCharKindGauge, name: name, value: value, labels: labels})
+}
+
+// metCharAttrRecorder additionally implements the unexported metricsAttrer
+// optional interface, which switches the middleware onto the fast path.
+type metCharAttrRecorder struct {
+	*metCharRecorder
+}
+
+func (f *metCharAttrRecorder) RecordHistogramAttrs(_ context.Context, name string,
+	value float64, attrs ...attribute.KeyValue) {
+	f.record(&metCharCall{
+		kind:  metCharKindAttrs,
+		name:  name,
+		value: value,
+		attrs: append([]attribute.KeyValue(nil), attrs...),
+	})
+}
+
+func metCharNewAttrRecorder() *metCharAttrRecorder {
+	return &metCharAttrRecorder{metCharRecorder: &metCharRecorder{}}
+}
+
+// metCharLabelSet normalizes a recorded call to a flat key/value string slice
+// so the fast and slow paths can be compared directly. For the fast path it
+// also pins that EVERY attribute value is of type attribute.STRING.
+func metCharLabelSet(t *testing.T, c *metCharCall) []string {
+	t.Helper()
+
+	if c.kind == metCharKindHistogram {
+		return c.labels
+	}
+
+	labels := make([]string, 0, len(c.attrs)*2)
+
+	for _, kv := range c.attrs {
+		require.Equal(t, attribute.STRING, kv.Value.Type(),
+			"attribute %q must carry a STRING value, got %v", kv.Key, kv.Value.Type())
+
+		labels = append(labels, string(kv.Key), kv.Value.AsString())
+	}
+
+	return labels
+}
+
+// metCharOKHandler writes an explicit 200.
+func metCharOKHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// metCharRegister builds a plain mux Path() registration for tpl.
+func metCharRegister(tpl string) func(r *mux.Router, h http.Handler) {
+	return func(r *mux.Router, h http.Handler) {
+		r.Handle(tpl, h)
+	}
+}
+
+// metCharChain builds the handler under test. When register is nil the Metrics
+// middleware wraps h directly, so mux.CurrentRoute(r) is nil (the 404 shape).
+// The returned handler owns exactly ONE Metrics instance, so repeated requests
+// through it exercise the routeAttrs/statusAttrs caches.
+func metCharChain(m metrics, register func(r *mux.Router, h http.Handler), h http.Handler) http.Handler {
+	if register == nil {
+		return Metrics(m)(h)
+	}
+
+	router := mux.NewRouter()
+	register(router, h)
+	router.Use(Metrics(m))
+
+	return router
+}
+
+// metCharServe drives one request through handler.
+func metCharServe(t *testing.T, handler http.Handler, method, target string) {
+	t.Helper()
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequestWithContext(t.Context(), method, target, http.NoBody))
+}
+
+// metCharWant builds the canonical expected label slice in the exact order the
+// middleware emits it.
+func metCharWant(path, method, status string) []string {
+	return []string{"path", path, "method", method, "status", status}
+}
+
+// ---------------------------------------------------------------------------
+// 1. Metric identity, value unit, and exact slow-path label varargs.
+// ---------------------------------------------------------------------------
+
+// Test_MetricsContractSlowPathExactCall pins that an implementation satisfying
+// only the `metrics` interface receives exactly one RecordHistogram call, with
+// the exact metric name, a duration expressed in SECONDS as a float64, and the
+// exact ordered varargs slice ["path", p, "method", m, "status", "<code>"]
+// where status is a STRING produced by fmt.Sprintf("%d").
+func Test_MetricsContractSlowPathExactCall(t *testing.T) {
+	rec := &metCharRecorder{}
+
+	slow := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(5 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := metCharChain(rec, metCharRegister("/users/{id}"), slow)
+	metCharServe(t, handler, http.MethodGet, "/users/42")
+
+	call := rec.one(t)
+
+	require.Equal(t, metCharKindHistogram, call.kind, "slow path must use RecordHistogram")
+	require.Equal(t, "app_http_response", call.name, "metric name is fixed")
+	require.Equal(t, metCharMetricName, call.name)
+
+	// Value is duration.Seconds(): a float64 in seconds, so a 5ms handler must
+	// land above 0.004 and comfortably below one second. This pins the UNIT —
+	// a switch to milliseconds/nanoseconds would break it.
+	require.Positive(t, call.value, "duration must be strictly positive")
+	require.Greater(t, call.value, 0.004, "5ms handler must record >= ~0.005 seconds")
+	require.Less(t, call.value, 1.0, "value must be seconds, not milliseconds/nanos")
+
+	require.Equal(t, metCharWant("/users/{id}", http.MethodGet, "200"), call.labels,
+		"exact ordered varargs label slice")
+
+	// status is a string, never an int.
+	require.Equal(t, "200", call.labels[5])
+	require.IsType(t, "", call.labels[5])
+}
+
+// Test_MetricsContractNoOtherMetricsEmitted pins that the middleware emits the
+// response histogram and nothing else — no counters, no gauges.
+func Test_MetricsContractNoOtherMetricsEmitted(t *testing.T) {
+	rec := &metCharRecorder{}
+	handler := metCharChain(rec, metCharRegister("/ping"), metCharOKHandler())
+
+	metCharServe(t, handler, http.MethodGet, "/ping")
+
+	for _, c := range rec.all() {
+		require.Equal(t, metCharKindHistogram, c.kind, "only RecordHistogram may be called")
+		require.Equal(t, metCharMetricName, c.name)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Fast path (metricsAttrer) — exact attribute.KeyValue triple.
+// ---------------------------------------------------------------------------
+
+// Test_MetricsContractFastPathExactAttrs pins that when the metrics
+// implementation also provides RecordHistogramAttrs, the middleware calls it
+// (and never RecordHistogram) with exactly three attributes, in order:
+// path(string), method(string), status(STRING — not Int).
+func Test_MetricsContractFastPathExactAttrs(t *testing.T) {
+	rec := metCharNewAttrRecorder()
+	handler := metCharChain(rec, metCharRegister("/users/{id}"), metCharOKHandler())
+
+	metCharServe(t, handler, http.MethodGet, "/users/42")
+
+	call := rec.one(t)
+
+	require.Equal(t, metCharKindAttrs, call.kind, "fast path must use RecordHistogramAttrs")
+	require.Equal(t, metCharMetricName, call.name)
+	require.GreaterOrEqual(t, call.value, 0.0)
+	require.Less(t, call.value, 1.0, "value is seconds")
+
+	require.Len(t, call.attrs, 3, "exactly three attributes")
+
+	require.Equal(t, attribute.Key("path"), call.attrs[0].Key)
+	require.Equal(t, attribute.STRING, call.attrs[0].Value.Type())
+	require.Equal(t, "/users/{id}", call.attrs[0].Value.AsString())
+
+	require.Equal(t, attribute.Key("method"), call.attrs[1].Key)
+	require.Equal(t, attribute.STRING, call.attrs[1].Value.Type())
+	require.Equal(t, http.MethodGet, call.attrs[1].Value.AsString())
+
+	// The status attribute is deliberately a STRING, matching the slow path's
+	// fmt.Sprintf("%d"). attribute.Int would change the OTLP wire type.
+	require.Equal(t, attribute.Key("status"), call.attrs[2].Key)
+	require.Equal(t, attribute.STRING, call.attrs[2].Value.Type(),
+		"status must be attribute.String, NOT attribute.Int")
+	require.Equal(t, "200", call.attrs[2].Value.AsString())
+
+	// RecordHistogram must not be called at all on the fast path.
+	for _, c := range rec.all() {
+		require.NotEqual(t, metCharKindHistogram, c.kind,
+			"RecordHistogram must not be used when RecordHistogramAttrs exists")
+	}
+}
+
+// Test_MetricsContractFastAndSlowPathsAgree pins that both code paths produce
+// semantically identical label sets for the same traffic.
+func Test_MetricsContractFastAndSlowPathsAgree(t *testing.T) {
+	type req struct {
+		route  string
+		method string
+		target string
+	}
+
+	reqs := []req{
+		{"/users/{id}", http.MethodGet, "/users/42"},
+		{"/users/{id}", http.MethodPost, "/users/7"},
+		{"/assets/{name}", http.MethodGet, "/assets/logo.png"},
+		{"/", http.MethodGet, "/"},
+		{"/static/{f}", http.MethodGet, "/static/app"},
+	}
+
+	for _, r := range reqs {
+		t.Run(r.method+" "+r.target, func(t *testing.T) {
+			slowRec := &metCharRecorder{}
+			fastRec := metCharNewAttrRecorder()
+
+			metCharServe(t, metCharChain(slowRec, metCharRegister(r.route), metCharOKHandler()), r.method, r.target)
+			metCharServe(t, metCharChain(fastRec, metCharRegister(r.route), metCharOKHandler()), r.method, r.target)
+
+			slow := slowRec.one(t)
+			fast := fastRec.one(t)
+
+			require.Equal(t, slow.name, fast.name)
+			require.Equal(t, metCharLabelSet(t, slow), metCharLabelSet(t, fast),
+				"fast and slow paths must produce identical labels")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Path label resolution.
+// ---------------------------------------------------------------------------
+
+// metCharPathCase is one path-label characterization case.
+type metCharPathCase struct {
+	name     string
+	route    string // mux Path() template; empty means "no router at all".
+	register func(r *mux.Router, h http.Handler)
+	method   string
+	target   string
+	wantPath string
+}
+
+func metCharRunPathCases(t *testing.T, cases []metCharPathCase) {
+	t.Helper()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			register := tc.register
+			if register == nil && tc.route != "" {
+				register = metCharRegister(tc.route)
+			}
+
+			rec := &metCharRecorder{}
+			handler := metCharChain(rec, register, metCharOKHandler())
+
+			metCharServe(t, handler, tc.method, tc.target)
+
+			call := rec.one(t)
+			require.Equal(t, metCharMetricName, call.name)
+			require.Equal(t, metCharWant(tc.wantPath, tc.method, "200"), call.labels)
+		})
+	}
+}
+
+// Test_MetricsContractPathLabelResolution pins how the path label is derived
+// from the mux route template versus the raw r.URL.Path.
+func Test_MetricsContractPathLabelResolution(t *testing.T) {
+	metCharRunPathCases(t, []metCharPathCase{
+		{
+			name:     "route template wins over raw path",
+			route:    "/users/{id}",
+			method:   http.MethodGet,
+			target:   "/users/42",
+			wantPath: "/users/{id}",
+		},
+		{
+			name:     "multi segment template",
+			route:    "/orgs/{org}/repos/{repo}",
+			method:   http.MethodGet,
+			target:   "/orgs/gofr/repos/gofr",
+			wantPath: "/orgs/{org}/repos/{repo}",
+		},
+		{
+			name:     "no mux route at all falls back to raw path",
+			method:   http.MethodGet,
+			target:   "/no/such/route",
+			wantPath: "/no/such/route",
+		},
+		{
+			name:     "route without a Path matcher falls back to raw path",
+			register: func(r *mux.Router, h http.Handler) { r.NewRoute().Methods(http.MethodGet).Handler(h) },
+			method:   http.MethodGet,
+			target:   "/anything/at/all",
+			wantPath: "/anything/at/all",
+		},
+		{
+			name:     "PathPrefix route collapses sub paths onto the prefix template",
+			register: func(r *mux.Router, h http.Handler) { r.PathPrefix("/api/").Handler(h) },
+			method:   http.MethodGet,
+			target:   "/api/deeply/nested/thing",
+			wantPath: "/api",
+		},
+	})
+}
+
+// Test_MetricsContractTrailingSlashTrimming pins strings.TrimSuffix(path, "/").
+//
+// LATENT BUG pinned here: a request to exactly "/" is first forced onto the
+// raw path ("/") and then trimmed, producing an EMPTY STRING as the path
+// label. That is almost certainly unintended (an empty `path` dimension in
+// Prometheus/OTLP), but it is current behavior and is characterized, not
+// fixed.
+func Test_MetricsContractTrailingSlashTrimming(t *testing.T) {
+	metCharRunPathCases(t, []metCharPathCase{
+		{
+			name:     "trailing slash trimmed from template",
+			route:    "/users/",
+			method:   http.MethodGet,
+			target:   "/users/",
+			wantPath: "/users",
+		},
+		{
+			name:     "trailing slash trimmed from raw path when unrouted",
+			method:   http.MethodGet,
+			target:   "/raw/path/",
+			wantPath: "/raw/path",
+		},
+		{
+			name:     "root route yields an EMPTY path label (latent bug)",
+			route:    "/",
+			method:   http.MethodGet,
+			target:   "/",
+			wantPath: "",
+		},
+		{
+			name:     "root request without a router also yields an EMPTY path label",
+			method:   http.MethodGet,
+			target:   "/",
+			wantPath: "",
+		},
+	})
+}
+
+// Test_MetricsContractStaticPrefixForcesRawPath pins the `path == "/" ||
+// strings.HasPrefix(path, "/static")` branch.
+//
+// Note the check is applied to the RESOLVED path (usually the route TEMPLATE),
+// not to r.URL.Path — and "/staticfiles" also satisfies HasPrefix("/static"),
+// which is a very likely unintended prefix match.
+func Test_MetricsContractStaticPrefixForcesRawPath(t *testing.T) {
+	metCharRunPathCases(t, []metCharPathCase{
+		{
+			name:     "template under /static forces the raw url path",
+			route:    "/static/{file}",
+			method:   http.MethodGet,
+			target:   "/static/bundle",
+			wantPath: "/static/bundle",
+		},
+		{
+			name:     "template /staticfiles also matches HasPrefix /static (unintended)",
+			route:    "/staticfiles/{id}",
+			method:   http.MethodGet,
+			target:   "/staticfiles/42",
+			wantPath: "/staticfiles/42",
+		},
+		{
+			name:     "template /statically also matches HasPrefix /static (unintended)",
+			route:    "/statically/{id}",
+			method:   http.MethodGet,
+			target:   "/statically/9",
+			wantPath: "/statically/9",
+		},
+		{
+			name:     "url under /static but template elsewhere keeps the template",
+			route:    "/{a}/{b}",
+			method:   http.MethodGet,
+			target:   "/static/thing",
+			wantPath: "/{a}/{b}",
+		},
+		{
+			name:     "template /staticky-ish sibling that does not match prefix keeps template",
+			route:    "/stati/{id}",
+			method:   http.MethodGet,
+			target:   "/stati/1",
+			wantPath: "/stati/{id}",
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 4. Static-file extension special case.
+// ---------------------------------------------------------------------------
+
+// metCharStaticExts is the exact extension allow-list in metrics.go.
+func metCharStaticExts() []string {
+	return []string{
+		".css", ".js", ".png", ".jpg", ".jpeg", ".gif", ".ico",
+		".svg", ".txt", ".html", ".json", ".woff", ".woff2", ".ttf", ".eot", ".pdf",
+	}
+}
+
+// Test_MetricsContractStaticExtensionForcesRawPath pins that for every
+// extension in the allow-list the RAW url path replaces the matched route
+// template.
+func Test_MetricsContractStaticExtensionForcesRawPath(t *testing.T) {
+	for _, ext := range metCharStaticExts() {
+		t.Run(ext, func(t *testing.T) {
+			target := "/assets/logo" + ext
+			rec := &metCharRecorder{}
+			handler := metCharChain(rec, metCharRegister("/assets/{name}"), metCharOKHandler())
+
+			metCharServe(t, handler, http.MethodGet, target)
+
+			require.Equal(t, metCharWant(target, http.MethodGet, "200"), rec.one(t).labels)
+		})
+	}
+}
+
+// Test_MetricsContractStaticExtensionIsCaseInsensitive pins that the extension
+// is lower-cased before the switch, so upper and mixed case also force the raw
+// path.
+func Test_MetricsContractStaticExtensionIsCaseInsensitive(t *testing.T) {
+	targets := []string{
+		"/assets/LOGO.PNG",
+		"/assets/style.CSS",
+		"/assets/data.JsOn",
+		"/assets/font.WOFF2",
+		"/assets/page.HtMl",
+	}
+
+	for _, target := range targets {
+		t.Run(target, func(t *testing.T) {
+			rec := &metCharRecorder{}
+			handler := metCharChain(rec, metCharRegister("/assets/{name}"), metCharOKHandler())
+
+			metCharServe(t, handler, http.MethodGet, target)
+
+			require.Equal(t, metCharWant(target, http.MethodGet, "200"), rec.one(t).labels)
+		})
+	}
+}
+
+// Test_MetricsContractNonStaticExtensionKeepsTemplate pins the negative side of
+// the allow-list: extensions that are NOT listed leave the route template in
+// place, so cardinality stays bounded.
+func Test_MetricsContractNonStaticExtensionKeepsTemplate(t *testing.T) {
+	metCharRunPathCases(t, []metCharPathCase{
+		{
+			name:     "webp is not in the allow-list",
+			route:    "/assets/{name}",
+			method:   http.MethodGet,
+			target:   "/assets/pic.webp",
+			wantPath: "/assets/{name}",
+		},
+		{
+			name:     "source map keeps template even though the name contains .js",
+			route:    "/assets/{name}",
+			method:   http.MethodGet,
+			target:   "/assets/app.js.map",
+			wantPath: "/assets/{name}",
+		},
+		{
+			name:     "no extension at all keeps template",
+			route:    "/assets/{name}",
+			method:   http.MethodGet,
+			target:   "/assets/logo",
+			wantPath: "/assets/{name}",
+		},
+		{
+			name:     "dot only in a directory segment is not an extension",
+			route:    "/v1.0/{id}",
+			method:   http.MethodGet,
+			target:   "/v1.0/42",
+			wantPath: "/v1.0/{id}",
+		},
+		{
+			name:     "dotted directory plus static file still forces raw path",
+			route:    "/v1.0/{name}",
+			method:   http.MethodGet,
+			target:   "/v1.0/logo.png",
+			wantPath: "/v1.0/logo.png",
+		},
+	})
+}
+
+// Test_MetricsContractExtensionIgnoresQueryString pins that filepath.Ext is
+// taken from r.URL.Path only — the query string neither contributes an
+// extension nor leaks into the label.
+func Test_MetricsContractExtensionIgnoresQueryString(t *testing.T) {
+	metCharRunPathCases(t, []metCharPathCase{
+		{
+			name:     "static file with query string records the bare path",
+			route:    "/assets/{name}",
+			method:   http.MethodGet,
+			target:   "/assets/logo.png?v=42",
+			wantPath: "/assets/logo.png",
+		},
+		{
+			name:     "css only in the query string does not force the raw path",
+			route:    "/assets/{name}",
+			method:   http.MethodGet,
+			target:   "/assets/logo?fallback=a.css",
+			wantPath: "/assets/{name}",
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 5. /graphql skip.
+// ---------------------------------------------------------------------------
+
+// Test_MetricsContractGraphQLRecordsNothing pins that when the RESOLVED path
+// is exactly "/graphql" the middleware records nothing at all, while the inner
+// handler still runs.
+func Test_MetricsContractGraphQLRecordsNothing(t *testing.T) {
+	cases := []struct {
+		name   string
+		route  string
+		target string
+	}{
+		{"routed /graphql", "/graphql", "/graphql"},
+		{"unrouted /graphql", "", "/graphql"},
+		{"unrouted /graphql/ trailing slash is trimmed then skipped", "", "/graphql/"},
+		{"route template /graphql/ is trimmed then skipped", "/graphql/", "/graphql/"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var register func(r *mux.Router, h http.Handler)
+			if tc.route != "" {
+				register = metCharRegister(tc.route)
+			}
+
+			var served bool
+
+			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				served = true
+
+				w.WriteHeader(http.StatusOK)
+			})
+
+			rec := &metCharRecorder{}
+			metCharServe(t, metCharChain(rec, register, inner), http.MethodGet, tc.target)
+
+			require.True(t, served, "inner handler must still run for /graphql")
+			require.Empty(t, rec.all(), "no metric may be recorded for /graphql")
+		})
+	}
+}
+
+// Test_MetricsContractGraphQLSkipIsPathBasedNotURLBased pins that the skip
+// keys off the RESOLVED path label, not r.URL.Path: a wildcard route serving
+// the /graphql url still records (with the template as the label), and a
+// /graphql sub-path is not skipped.
+func Test_MetricsContractGraphQLSkipIsPathBasedNotURLBased(t *testing.T) {
+	metCharRunPathCases(t, []metCharPathCase{
+		{
+			name:     "wildcard route serving /graphql is still recorded",
+			route:    "/{resource}",
+			method:   http.MethodPost,
+			target:   "/graphql",
+			wantPath: "/{resource}",
+		},
+		{
+			name:     "graphql sub path is not skipped",
+			route:    "/graphql/playground",
+			method:   http.MethodGet,
+			target:   "/graphql/playground",
+			wantPath: "/graphql/playground",
+		},
+		{
+			name:     "graphqlx is not skipped",
+			method:   http.MethodGet,
+			target:   "/graphqlx",
+			wantPath: "/graphqlx",
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 6. Status label.
+// ---------------------------------------------------------------------------
+
+// Test_MetricsContractStatusLabel pins the status label across explicit
+// WriteHeader, implicit 200 via Write, and a handler that does nothing at all
+// (StatusResponseWriter.Status normalizes 0 to 200 — the label is "200", never
+// "0").
+func Test_MetricsContractStatusLabel(t *testing.T) {
+	cases := []struct {
+		name       string
+		handler    http.Handler
+		wantStatus string
+	}{
+		{
+			name: "explicit 200",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+			wantStatus: "200",
+		},
+		{
+			name: "explicit 404",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			wantStatus: "404",
+		},
+		{
+			name: "explicit 500",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}),
+			wantStatus: "500",
+		},
+		{
+			name: "body only write implies 200",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("hello"))
+			}),
+			wantStatus: "200",
+		},
+		{
+			name:       "handler writes nothing at all normalizes 0 to 200",
+			handler:    http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}),
+			wantStatus: "200",
+		},
+		{
+			name: "first WriteHeader wins over a later one",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+				w.WriteHeader(http.StatusInternalServerError)
+			}),
+			wantStatus: "418",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			slowRec := &metCharRecorder{}
+			fastRec := metCharNewAttrRecorder()
+
+			metCharServe(t, metCharChain(slowRec, metCharRegister("/s"), tc.handler), http.MethodGet, "/s")
+			metCharServe(t, metCharChain(fastRec, metCharRegister("/s"), tc.handler), http.MethodGet, "/s")
+
+			want := metCharWant("/s", http.MethodGet, tc.wantStatus)
+
+			require.Equal(t, want, slowRec.one(t).labels)
+			require.Equal(t, want, metCharLabelSet(t, fastRec.one(t)))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. Method label.
+// ---------------------------------------------------------------------------
+
+// Test_MetricsContractMethodLabelIsRawRequestMethod pins that the method label
+// is r.Method verbatim — it is NOT upper-cased (unlike the tracer middleware),
+// so a lowercase "get" is recorded as "get".
+func Test_MetricsContractMethodLabelIsRawRequestMethod(t *testing.T) {
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodDelete, "get", "PaTcH", "CUSTOMVERB"}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			rec := &metCharRecorder{}
+			// No router: mux would reject the odd verbs before the middleware runs.
+			handler := metCharChain(rec, nil, metCharOKHandler())
+
+			metCharServe(t, handler, method, "/verb")
+
+			call := rec.one(t)
+			require.Equal(t, metCharWant("/verb", method, "200"), call.labels)
+			require.Equal(t, method, call.labels[3], "method label is verbatim r.Method")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 8. StatusResponseWriter wrapping / reuse.
+// ---------------------------------------------------------------------------
+
+// Test_MetricsContractResponseWriterReuse pins the wrapping contract.
+//
+//   - When the incoming ResponseWriter is ALREADY a *StatusResponseWriter
+//     (Logging ran first), Metrics reuses it — no double wrapping, and the
+//     inner handler sees the very same pointer.
+//   - Otherwise Metrics allocates one. Note that the code does NOT reassign
+//     the local `w` — but it passes `srw` to inner.ServeHTTP, so the inner
+//     handler DOES receive the wrapper (and Unwrap() returns the original
+//     writer). This test pins that, since the non-reassignment reads like a
+//     bug at a glance.
+func Test_MetricsContractResponseWriterReuse(t *testing.T) {
+	t.Run("already wrapped is reused not double wrapped", func(t *testing.T) {
+		rec := &metCharRecorder{}
+		rr := httptest.NewRecorder()
+		outer := &StatusResponseWriter{ResponseWriter: rr}
+
+		var seen http.ResponseWriter
+
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			seen = w
+
+			w.WriteHeader(http.StatusAccepted)
+		})
+
+		handler := metCharChain(rec, nil, inner)
+		handler.ServeHTTP(outer, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/w", http.NoBody))
+
+		require.Same(t, outer, seen, "existing *StatusResponseWriter must be reused")
+		require.Equal(t, http.StatusAccepted, outer.Status())
+		require.Equal(t, metCharWant("/w", http.MethodGet, "202"), rec.one(t).labels)
+	})
+
+	t.Run("plain writer is wrapped and the wrapper reaches the inner handler", func(t *testing.T) {
+		rec := &metCharRecorder{}
+		rr := httptest.NewRecorder()
+
+		var seen http.ResponseWriter
+
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			seen = w
+
+			w.WriteHeader(http.StatusCreated)
+		})
+
+		handler := metCharChain(rec, nil, inner)
+		handler.ServeHTTP(rr, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/w", http.NoBody))
+
+		srw, ok := seen.(*StatusResponseWriter)
+		require.True(t, ok, "inner handler receives the newly created *StatusResponseWriter")
+		require.NotSame(t, http.ResponseWriter(rr), seen)
+		require.Same(t, rr, srw.Unwrap(), "wrapper unwraps to the original writer")
+		require.Equal(t, http.StatusCreated, rr.Code, "status still reaches the real writer")
+		require.Equal(t, metCharWant("/w", http.MethodGet, "201"), rec.one(t).labels)
+	})
+
+	t.Run("graphql skip path also passes the wrapper through", func(t *testing.T) {
+		rec := &metCharRecorder{}
+		rr := httptest.NewRecorder()
+
+		var seen http.ResponseWriter
+
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			seen = w
+
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := metCharChain(rec, nil, inner)
+		handler.ServeHTTP(rr, httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/graphql", http.NoBody))
+
+		require.IsType(t, &StatusResponseWriter{}, seen)
+		require.Empty(t, rec.all())
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 9. Caching of route/status attributes.
+// ---------------------------------------------------------------------------
+
+// Test_MetricsContractAttributeCacheKeying pins that the per-instance
+// routeAttrs/statusAttrs caches are keyed correctly: repeated requests produce
+// identical labels, and different methods on the SAME path produce different,
+// correct labels (a path-only cache key would leak the first method).
+func Test_MetricsContractAttributeCacheKeying(t *testing.T) {
+	rec := metCharNewAttrRecorder()
+
+	handler := metCharChain(rec, func(r *mux.Router, h http.Handler) {
+		r.Handle("/users/{id}", h)
+		r.Handle("/orders/{id}", h)
+	}, metCharOKHandler())
+
+	metCharServe(t, handler, http.MethodGet, "/users/1")
+	metCharServe(t, handler, http.MethodGet, "/users/2")
+	metCharServe(t, handler, http.MethodPost, "/users/3")
+	metCharServe(t, handler, http.MethodGet, "/orders/9")
+	metCharServe(t, handler, http.MethodPost, "/users/4")
+
+	calls := rec.all()
+	require.Len(t, calls, 5)
+
+	want := [][]string{
+		metCharWant("/users/{id}", http.MethodGet, "200"),
+		metCharWant("/users/{id}", http.MethodGet, "200"),
+		metCharWant("/users/{id}", http.MethodPost, "200"),
+		metCharWant("/orders/{id}", http.MethodGet, "200"),
+		metCharWant("/users/{id}", http.MethodPost, "200"),
+	}
+
+	for i := range calls {
+		require.Equal(t, want[i], metCharLabelSet(t, &calls[i]), "call %d", i)
+	}
+}
+
+// Test_MetricsContractStatusCacheKeying pins that the status attribute cache
+// returns the right value per status code, including after a repeat.
+func Test_MetricsContractStatusCacheKeying(t *testing.T) {
+	rec := metCharNewAttrRecorder()
+
+	codes := []int{http.StatusOK, http.StatusNotFound, http.StatusOK, http.StatusInternalServerError, http.StatusNotFound}
+
+	handler := metCharChain(rec, metCharRegister("/c/{code}"),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			code, _ := strconv.Atoi(mux.Vars(r)["code"])
+
+			w.WriteHeader(code)
+		}))
+
+	for _, code := range codes {
+		metCharServe(t, handler, http.MethodGet, "/c/"+strconv.Itoa(code))
+	}
+
+	calls := rec.all()
+	require.Len(t, calls, len(codes))
+
+	for i := range calls {
+		require.Equal(t, metCharWant("/c/{code}", http.MethodGet, strconv.Itoa(codes[i])),
+			metCharLabelSet(t, &calls[i]))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 10. Concurrency.
+// ---------------------------------------------------------------------------
+
+// Test_MetricsContractConcurrentRequests fires many concurrent requests through
+// a SINGLE Metrics instance across several routes, methods and statuses and
+// asserts the recorded multiset of label sets is exactly what is expected. Run
+// under -race this also covers the sync.Map caches.
+func Test_MetricsContractConcurrentRequests(t *testing.T) {
+	const iterations = 40
+
+	rec := metCharNewAttrRecorder()
+
+	handler := metCharChain(rec, func(r *mux.Router, h http.Handler) {
+		r.Handle("/users/{id}", h)
+		r.Handle("/orders/{id}", h)
+		r.Handle("/assets/{name}", h)
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("fail") == "1" {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	type reqSpec struct {
+		method string
+		target string
+		want   []string
+	}
+
+	specs := []reqSpec{
+		{http.MethodGet, "/users/1", metCharWant("/users/{id}", http.MethodGet, "200")},
+		{http.MethodPost, "/users/2", metCharWant("/users/{id}", http.MethodPost, "200")},
+		{http.MethodGet, "/orders/3?fail=1", metCharWant("/orders/{id}", http.MethodGet, "500")},
+		{http.MethodGet, "/assets/logo.png", metCharWant("/assets/logo.png", http.MethodGet, "200")},
+	}
+
+	var wg sync.WaitGroup
+
+	for range iterations {
+		for _, spec := range specs {
+			wg.Add(1)
+
+			go func(spec reqSpec) {
+				defer wg.Done()
+
+				rr := httptest.NewRecorder()
+				req := httptest.NewRequestWithContext(t.Context(), spec.method, spec.target, http.NoBody)
+
+				handler.ServeHTTP(rr, req)
+			}(spec)
+		}
+	}
+
+	wg.Wait()
+
+	got := make(map[string]int, len(specs))
+
+	concurrentCalls := rec.all()
+
+	for i := range concurrentCalls {
+		require.Equal(t, metCharMetricName, concurrentCalls[i].name)
+		require.Equal(t, metCharKindAttrs, concurrentCalls[i].kind)
+
+		got[strings.Join(metCharLabelSet(t, &concurrentCalls[i]), "|")]++
+	}
+
+	want := make(map[string]int, len(specs))
+	for _, spec := range specs {
+		want[strings.Join(spec.want, "|")] = iterations
+	}
+
+	require.Equal(t, want, got, "exact multiset of recorded label sets")
+}
+
+// Test_MetricsContractConcurrentSlowPath repeats the concurrency check for an
+// implementation that only satisfies `metrics`, so the slow varargs path is
+// exercised under -race as well.
+func Test_MetricsContractConcurrentSlowPath(t *testing.T) {
+	const iterations = 30
+
+	rec := &metCharRecorder{}
+	handler := metCharChain(rec, metCharRegister("/users/{id}"), metCharOKHandler())
+
+	var wg sync.WaitGroup
+
+	for range iterations {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			metCharServe(t, handler, http.MethodGet, "/users/1")
+		}()
+	}
+
+	wg.Wait()
+
+	calls := rec.all()
+	require.Len(t, calls, iterations)
+
+	for _, c := range calls {
+		require.Equal(t, metCharWant("/users/{id}", http.MethodGet, "200"), c.labels)
+	}
 }

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -12,10 +14,13 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	otelTrace "go.opentelemetry.io/otel/trace"
+
+	"gofr.dev/pkg/gofr/version"
 )
 
 // W3C TraceContext fixture values reused across the propagation tests.
@@ -309,4 +314,688 @@ func TestTracer_EmitsOTelHTTPSemconvAttributes(t *testing.T) {
 	assert.Equal(t, "GET", attrs[attribute.Key("http.request.method")].AsString())
 	assert.Equal(t, "/users/{id}", attrs[attribute.Key("http.route")].AsString())
 	assert.Equal(t, int64(http.StatusCreated), attrs[attribute.Key("http.response.status_code")].AsInt64())
+}
+
+// ---------------------------------------------------------------------------
+// Characterization suite for the Tracer HTTP middleware.
+//
+// Every identifier below is prefixed with `tracerChar` so this file can be
+// merged with sibling _test.go additions in the same package without
+// collisions. Nothing here is aspirational: every assertion pins the CURRENT
+// behavior of pkg/gofr/http/middleware/tracer.go as observed against the
+// unmodified source.
+// ---------------------------------------------------------------------------
+
+// tracerCharScopeName returns the exact instrumentation-scope (tracer) name
+// the middleware resolves at chain-build time.
+func tracerCharScopeName() string { return "gofr-" + version.Framework }
+
+// tracerCharInstallRecordingTP installs an sdktrace provider with an in-memory
+// span recorder and restores the previously installed global provider on
+// cleanup. The provider MUST be installed before Tracer() is called because
+// Tracer resolves otel.Tracer(...) once at chain-build time.
+func tracerCharInstallRecordingTP(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(rec))
+
+	otel.SetTracerProvider(tp)
+
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+
+		otel.SetTracerProvider(prev)
+	})
+
+	return rec
+}
+
+// tracerCharInstallNeverSampleTP installs exactly the provider GoFr's
+// initTracer builds when no exporter is configured (otel.go), plus a recorder
+// so tests can prove nothing is ever exported.
+func tracerCharInstallNeverSampleTP(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(
+		trace.WithSampler(trace.NeverSample()),
+		trace.WithSpanProcessor(rec),
+	)
+
+	otel.SetTracerProvider(tp)
+
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+
+		otel.SetTracerProvider(prev)
+	})
+
+	return rec
+}
+
+// tracerCharAttrs returns the span's attributes sorted by key so an exact
+// expected slice can be compared — an added, renamed or retyped attribute
+// then fails the comparison.
+func tracerCharAttrs(s trace.ReadOnlySpan) []attribute.KeyValue {
+	attrs := s.Attributes()
+	out := make([]attribute.KeyValue, len(attrs))
+	copy(out, attrs)
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+
+	return out
+}
+
+// tracerCharLogger captures the RequestLog values emitted by the Logging
+// middleware.
+type tracerCharLogger struct {
+	logs   []*RequestLog
+	errors []*RequestLog
+}
+
+func (l *tracerCharLogger) Log(args ...any) {
+	if rl, ok := args[0].(*RequestLog); ok {
+		l.logs = append(l.logs, rl)
+	}
+}
+
+func (l *tracerCharLogger) Error(args ...any) {
+	if rl, ok := args[0].(*RequestLog); ok {
+		l.errors = append(l.errors, rl)
+	}
+}
+
+// last returns the single RequestLog captured on either channel.
+func (l *tracerCharLogger) last() *RequestLog {
+	if len(l.errors) > 0 {
+		return l.errors[len(l.errors)-1]
+	}
+
+	if len(l.logs) > 0 {
+		return l.logs[len(l.logs)-1]
+	}
+
+	return nil
+}
+
+// Test_TracerContract_InstrumentationScopeName pins the exact tracer name.
+func Test_TracerContract_InstrumentationScopeName(t *testing.T) {
+	rec := tracerCharInstallRecordingTP(t)
+
+	handler := Tracer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/scope", http.NoBody)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+
+	assert.Equal(t, "gofr-dev", tracerCharScopeName(),
+		"version.Framework changed; the scope name below moves with it")
+	assert.Equal(t, tracerCharScopeName(), spans[0].InstrumentationScope().Name)
+	assert.Empty(t, spans[0].InstrumentationScope().Version,
+		"middleware passes no WithInstrumentationVersion")
+	assert.Empty(t, spans[0].InstrumentationScope().SchemaURL)
+}
+
+// Test_TracerContract_SpanName pins "METHOD /route-template" across the mux
+// route-resolution paths.
+func Test_TracerContract_SpanName(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(h http.Handler) http.Handler
+		// method/target of the inbound request.
+		method string
+		target string
+		want   string
+	}{
+		{
+			name: "mux matched route uses path template",
+			build: func(h http.Handler) http.Handler {
+				r := mux.NewRouter()
+				r.Handle("/users/{id}", h).Methods(http.MethodGet)
+
+				return r
+			},
+			method: http.MethodGet,
+			target: "/users/42",
+			want:   "GET /users/{id}",
+		},
+		{
+			name: "mux PathPrefix-only route still yields a template",
+			build: func(h http.Handler) http.Handler {
+				r := mux.NewRouter()
+				r.PathPrefix("/static").Handler(h)
+
+				return r
+			},
+			method: http.MethodGet,
+			target: "/static/css/app.css",
+			want:   "GET /static",
+		},
+		{
+			name: "mux route without any path matcher falls back to URL.Path",
+			build: func(h http.Handler) http.Handler {
+				r := mux.NewRouter()
+				r.Methods(http.MethodGet).Handler(h)
+
+				return r
+			},
+			method: http.MethodGet,
+			target: "/no/path/matcher",
+			want:   "GET /no/path/matcher",
+		},
+		{
+			name: "unmatched route (404 handler, CurrentRoute nil) falls back to URL.Path",
+			build: func(h http.Handler) http.Handler {
+				r := mux.NewRouter()
+				r.Handle("/known", http.NotFoundHandler())
+				r.NotFoundHandler = h
+
+				return r
+			},
+			method: http.MethodGet,
+			target: "/definitely/unknown",
+			want:   "GET /definitely/unknown",
+		},
+		{
+			name:   "lowercase inbound method is upper-cased",
+			build:  func(h http.Handler) http.Handler { return h },
+			method: "get",
+			target: "/lower",
+			want:   "GET /lower",
+		},
+		{
+			name:   "standalone handler (no mux) uses URL.Path",
+			build:  func(h http.Handler) http.Handler { return h },
+			method: http.MethodDelete,
+			target: "/standalone",
+			want:   "DELETE /standalone",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := tracerCharInstallRecordingTP(t)
+
+			srv := tc.build(Tracer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+			req := httptest.NewRequestWithContext(t.Context(), tc.method, tc.target, http.NoBody)
+
+			srv.ServeHTTP(httptest.NewRecorder(), req)
+
+			spans := rec.Ended()
+			require.Len(t, spans, 1)
+			assert.Equal(t, tc.want, spans[0].Name())
+			// http.route always equals the route portion of the span name.
+			assert.Equal(t, strings.TrimPrefix(tc.want, strings.ToUpper(tc.method)+" "),
+				tracerCharAttrs(spans[0])[2].Value.AsString())
+		})
+	}
+}
+
+// Test_TracerContract_ExactAttributeSet pins the complete attribute set —
+// keys, values AND value types — for a matched route.
+func Test_TracerContract_ExactAttributeSet(t *testing.T) {
+	rec := tracerCharInstallRecordingTP(t)
+
+	router := mux.NewRouter()
+	router.Handle("/users/{id}", Tracer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusCreated) },
+	))).Methods(http.MethodGet)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/users/42", http.NoBody)
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+
+	want := []attribute.KeyValue{
+		attribute.String("http.request.method", "GET"),
+		attribute.Int("http.response.status_code", http.StatusCreated),
+		attribute.String("http.route", "/users/{id}"),
+	}
+
+	got := tracerCharAttrs(spans[0])
+	assert.Equal(t, want, got, "complete attribute set (sorted by key) changed")
+
+	// Pin the value TYPES explicitly so an int->string retype fails loudly.
+	assert.Equal(t, attribute.STRING, got[0].Value.Type())
+	assert.Equal(t, attribute.INT64, got[1].Value.Type())
+	assert.Equal(t, attribute.STRING, got[2].Value.Type())
+	assert.Equal(t, int64(http.StatusCreated), got[1].Value.AsInt64())
+}
+
+// Test_TracerContract_StatusCodeAttribute pins http.response.status_code
+// across the ways a handler can (not) set a status.
+func Test_TracerContract_StatusCodeAttribute(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    int64
+	}{
+		{
+			name:    "explicit WriteHeader 404",
+			handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) },
+			want:    http.StatusNotFound,
+		},
+		{
+			name:    "explicit WriteHeader 500",
+			handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusInternalServerError) },
+			want:    http.StatusInternalServerError,
+		},
+		{
+			name:    "body only, implicit 200 via StatusResponseWriter.Write",
+			handler: func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("hello")) },
+			want:    http.StatusOK,
+		},
+		{
+			name:    "handler does nothing, Status() normalizes 0 to 200",
+			handler: func(http.ResponseWriter, *http.Request) {},
+			want:    http.StatusOK,
+		},
+		{
+			name: "WriteHeader then Write keeps the explicit status",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = w.Write([]byte("ok"))
+			},
+			want: http.StatusAccepted,
+		},
+		{
+			name: "duplicate WriteHeader keeps the first status",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			want: http.StatusTeapot,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := tracerCharInstallRecordingTP(t)
+
+			handler := Tracer(tc.handler)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/status", http.NoBody)
+
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			spans := rec.Ended()
+			require.Len(t, spans, 1)
+
+			attrs := tracerCharAttrs(spans[0])
+			require.Len(t, attrs, 3)
+			assert.Equal(t, attribute.Key("http.response.status_code"), attrs[1].Key)
+			assert.Equal(t, tc.want, attrs[1].Value.AsInt64())
+		})
+	}
+}
+
+// Test_TracerContract_SpanKindStatusAndEvents pins that the middleware emits
+// an Internal span with an Unset status and no events — even for a 5xx.
+func Test_TracerContract_SpanKindStatusAndEvents(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			rec := tracerCharInstallRecordingTP(t)
+
+			handler := Tracer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+			}))
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/kind", http.NoBody)
+
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			spans := rec.Ended()
+			require.Len(t, spans, 1)
+
+			got := spans[0]
+			assert.Equal(t, otelTrace.SpanKindInternal, got.SpanKind(),
+				"middleware never calls trace.WithSpanKind, so the SDK default (Internal) applies")
+			assert.Equal(t, codes.Unset, got.Status().Code, "no SetStatus call anywhere in the middleware")
+			assert.Empty(t, got.Status().Description)
+			assert.Empty(t, got.Events(), "middleware records no events (no RecordError)")
+			assert.Empty(t, got.Links())
+			assert.True(t, got.EndTime().After(got.StartTime()) || got.EndTime().Equal(got.StartTime()))
+		})
+	}
+}
+
+// Test_TracerContract_ReusesStatusResponseWriter pins the ResponseWriter
+// wrapping behavior in all three chain arrangements.
+func Test_TracerContract_ReusesStatusResponseWriter(t *testing.T) {
+	t.Run("chained after Logging it reuses the existing StatusResponseWriter", func(t *testing.T) {
+		tracerCharInstallRecordingTP(t)
+
+		var fromLogging, inHandler http.ResponseWriter
+
+		capture := func(inner http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fromLogging = w
+				inner.ServeHTTP(w, r)
+			})
+		}
+
+		handler := Logging(LogProbes{}, &tracerCharLogger{})(
+			capture(Tracer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				inHandler = w
+			}))))
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/reuse", http.NoBody)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+
+		loggingSRW, ok := fromLogging.(*StatusResponseWriter)
+		require.True(t, ok, "Logging must hand a *StatusResponseWriter to the next middleware")
+
+		handlerSRW, ok := inHandler.(*StatusResponseWriter)
+		require.True(t, ok)
+		assert.Same(t, loggingSRW, handlerSRW, "Tracer must not double-wrap after Logging")
+	})
+
+	t.Run("standalone it wraps locally exactly once", func(t *testing.T) {
+		tracerCharInstallRecordingTP(t)
+
+		var inHandler http.ResponseWriter
+
+		handler := Tracer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			inHandler = w
+		}))
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/wrap", http.NoBody)
+		handler.ServeHTTP(rr, req)
+
+		srw, ok := inHandler.(*StatusResponseWriter)
+		require.True(t, ok, "Tracer must wrap when it is not preceded by Logging")
+		assert.NotSame(t, http.ResponseWriter(rr), inHandler)
+		assert.Same(t, rr, srw.Unwrap(), "exactly one layer of wrapping")
+	})
+
+	t.Run("production order (Tracer outer, Logging inner) double-wraps", func(t *testing.T) {
+		tracerCharInstallRecordingTP(t)
+
+		var layers []http.ResponseWriter
+
+		// The unwrap chain must be read INSIDE the handler: Logging returns its
+		// StatusResponseWriter to a sync.Pool on the way out and nils the
+		// embedded ResponseWriter, so the chain is unreadable afterwards.
+		handler := Tracer(Logging(LogProbes{}, &tracerCharLogger{})(
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				for cur := w; cur != nil; {
+					layers = append(layers, cur)
+
+					srw, ok := cur.(*StatusResponseWriter)
+					if !ok {
+						break
+					}
+
+					cur = srw.Unwrap()
+				}
+			})))
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/double", http.NoBody)
+		handler.ServeHTTP(rr, req)
+
+		// LATENT: production wires r.Use(Tracer, Logging, ...) so Tracer is the
+		// OUTER middleware and its type assertion always fails -> it wraps
+		// locally, and Logging then wraps that wrapper again. Two
+		// StatusResponseWriter layers are live on every production request,
+		// contradicting the "we are not after Logging ... uncommon" comment in
+		// tracer.go.
+		require.Len(t, layers, 3, "expected raw recorder wrapped by two StatusResponseWriters")
+		assert.IsType(t, &StatusResponseWriter{}, layers[0])
+		assert.IsType(t, &StatusResponseWriter{}, layers[1])
+		assert.Same(t, rr, layers[2])
+	})
+}
+
+// Test_TracerContract_InboundTraceparent pins W3C trace-context continuation.
+func Test_TracerContract_InboundTraceparent(t *testing.T) {
+	installPropagators(t)
+
+	rec := tracerCharInstallRecordingTP(t)
+
+	var handlerBaggage baggage.Baggage
+
+	handler := Tracer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		handlerBaggage = baggage.FromContext(r.Context())
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/inbound", http.NoBody)
+	req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+	req.Header.Set("Baggage", "tenant=acme,region=us-east")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+
+	got := spans[0]
+
+	// Trace ID is inherited verbatim from the fixture header.
+	assert.Equal(t, w3cFixtureTraceID, got.SpanContext().TraceID().String())
+	// The span's own ID is fresh and non-deterministic — pin validity/shape only.
+	assert.True(t, got.SpanContext().SpanID().IsValid())
+	assert.Len(t, got.SpanContext().SpanID().String(), 16)
+	assert.NotEqual(t, w3cFixtureParentSpan, got.SpanContext().SpanID().String())
+
+	assert.Equal(t, w3cFixtureParentSpan, got.Parent().SpanID().String())
+	assert.Equal(t, w3cFixtureTraceID, got.Parent().TraceID().String())
+	assert.True(t, got.Parent().IsRemote(), "parent must be marked remote")
+	assert.True(t, got.Parent().IsSampled())
+
+	require.Equal(t, 2, handlerBaggage.Len(), "baggage must survive into the handler context")
+	assert.Equal(t, "acme", handlerBaggage.Member("tenant").Value())
+	assert.Equal(t, "us-east", handlerBaggage.Member("region").Value())
+}
+
+// Test_TracerContract_NoInboundTraceparentIsRoot pins that a request without a
+// traceparent produces a fresh root span.
+func Test_TracerContract_NoInboundTraceparentIsRoot(t *testing.T) {
+	installPropagators(t)
+
+	rec := tracerCharInstallRecordingTP(t)
+
+	handler := Tracer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/root", http.NoBody)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+
+	got := spans[0]
+	assert.False(t, got.Parent().IsValid(), "expected a root span")
+	assert.Equal(t, zeroTraceID, got.Parent().TraceID().String())
+	assert.True(t, got.SpanContext().TraceID().IsValid())
+	assert.Len(t, got.SpanContext().TraceID().String(), 32)
+	assert.NotEqual(t, zeroTraceID, got.SpanContext().TraceID().String())
+}
+
+// Test_TracerContract_NeverSampleKeepsValidIDs is the key regression guard for
+// GoFr's default (no exporter configured) deployment: initTracer installs an
+// sdktrace provider with NeverSample — NOT a noop provider — precisely so the
+// span context handed to handlers still carries a valid TraceID/SpanID that
+// X-Correlation-ID and the trace_id log field can use.
+func Test_TracerContract_NeverSampleKeepsValidIDs(t *testing.T) {
+	installPropagators(t)
+
+	rec := tracerCharInstallNeverSampleTP(t)
+
+	var (
+		sc        otelTrace.SpanContext
+		recording bool
+	)
+
+	handler := Tracer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		span := otelTrace.SpanFromContext(r.Context())
+		sc = span.SpanContext()
+		recording = span.IsRecording()
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/never", http.NoBody)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.True(t, sc.IsValid(), "NeverSample must still yield a valid span context")
+	assert.True(t, sc.TraceID().IsValid())
+	assert.True(t, sc.SpanID().IsValid())
+	assert.NotEqual(t, zeroTraceID, sc.TraceID().String())
+	assert.NotEqual(t, zeroSpanID, sc.SpanID().String())
+	assert.Len(t, sc.TraceID().String(), 32)
+	assert.Len(t, sc.SpanID().String(), 16)
+	assert.False(t, sc.IsSampled(), "NeverSample must clear the sampled flag")
+	assert.False(t, recording, "a dropped span must not be recording")
+	assert.Empty(t, rec.Ended(), "nothing may be exported under NeverSample")
+}
+
+// Test_TracerContract_NeverSampleWithInboundTraceparent pins that NeverSample
+// is NOT parent-based: an inbound sampled=01 traceparent still gets dropped,
+// though the trace ID is inherited so the trace stays correlatable.
+func Test_TracerContract_NeverSampleWithInboundTraceparent(t *testing.T) {
+	installPropagators(t)
+
+	rec := tracerCharInstallNeverSampleTP(t)
+
+	var sc otelTrace.SpanContext
+
+	handler := Tracer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		sc = otelTrace.SpanFromContext(r.Context()).SpanContext()
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/never-parent", http.NoBody)
+	req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.True(t, sc.IsValid())
+	assert.Equal(t, w3cFixtureTraceID, sc.TraceID().String())
+	assert.False(t, sc.IsSampled())
+	assert.Empty(t, rec.Ended())
+}
+
+// tracerCharChain builds the two possible orderings of Logging and Tracer.
+func tracerCharChain(loggingOuter bool, lg logger, h http.Handler) http.Handler {
+	logging := Logging(LogProbes{}, lg)
+
+	if loggingOuter {
+		return logging(Tracer(h))
+	}
+
+	return Tracer(logging(h))
+}
+
+// Test_TracerContract_CorrelationIDWithLogging characterizes the interaction
+// between Tracer and the Logging middleware's X-Correlation-ID header and
+// trace_id/span_id log fields, for BOTH chain orders and BOTH provider
+// configurations.
+//
+// FINDING: production (pkg/gofr/http_server.go) registers
+// r.Use(middleware.Tracer, middleware.Logging(...)) — with gorilla/mux the
+// FIRST registered middleware is the OUTERMOST, so production runs
+// Tracer-outer / Logging-inner. That is the order in which Logging observes
+// the span Tracer just started, and the correlation ID is real. The
+// Logging-outer order (which reads the span context BEFORE Tracer starts a
+// span) yields the all-zeros constants instead.
+func Test_TracerContract_CorrelationIDWithLogging(t *testing.T) {
+	tests := []struct {
+		name         string
+		loggingOuter bool
+		neverSample  bool
+		traceparent  bool
+		wantZeroIDs  bool
+	}{
+		{name: "production order, recording provider", wantZeroIDs: false},
+		{name: "production order, NeverSample provider", neverSample: true, wantZeroIDs: false},
+		{name: "production order, inbound traceparent", traceparent: true, wantZeroIDs: false},
+		{name: "logging outer, recording provider", loggingOuter: true, wantZeroIDs: true},
+		{name: "logging outer, NeverSample provider", loggingOuter: true, neverSample: true, wantZeroIDs: true},
+		{name: "logging outer, inbound traceparent", loggingOuter: true, traceparent: true, wantZeroIDs: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			installPropagators(t)
+
+			if tc.neverSample {
+				tracerCharInstallNeverSampleTP(t)
+			} else {
+				tracerCharInstallRecordingTP(t)
+			}
+
+			lg := &tracerCharLogger{}
+
+			var inHandler otelTrace.SpanContext
+
+			handler := tracerCharChain(tc.loggingOuter, lg,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					inHandler = otelTrace.SpanFromContext(r.Context()).SpanContext()
+					_, _ = w.Write([]byte("ok"))
+				}))
+
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/corr", http.NoBody)
+
+			if tc.traceparent {
+				req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+			}
+
+			handler.ServeHTTP(rr, req)
+
+			rl := lg.last()
+			require.NotNil(t, rl, "Logging must emit a RequestLog")
+			assert.Equal(t, http.StatusOK, rl.Response)
+
+			corr := rr.Header().Get("X-Correlation-ID")
+			assert.Equal(t, rl.TraceID, corr, "header and log field always agree")
+
+			if tc.wantZeroIDs {
+				assert.Equal(t, zeroTraceID, rl.TraceID,
+					"Logging read the span context before Tracer started a span")
+				assert.Equal(t, zeroSpanID, rl.SpanID)
+
+				return
+			}
+
+			require.True(t, inHandler.IsValid())
+			assert.Equal(t, inHandler.TraceID().String(), rl.TraceID,
+				"log trace_id must equal the span Tracer started")
+			assert.Equal(t, inHandler.SpanID().String(), rl.SpanID)
+			assert.Len(t, rl.TraceID, 32)
+			assert.Len(t, rl.SpanID, 16)
+
+			if tc.traceparent {
+				assert.Equal(t, w3cFixtureTraceID, rl.TraceID,
+					"inbound traceparent must surface as the correlation ID")
+			}
+		})
+	}
+}
+
+// Test_TracerContract_StatusFlowsThroughLoggingChain pins that the span's
+// http.response.status_code is correct in the production chain order, where
+// Tracer's own StatusResponseWriter sits outside Logging's.
+func Test_TracerContract_StatusFlowsThroughLoggingChain(t *testing.T) {
+	rec := tracerCharInstallRecordingTP(t)
+
+	lg := &tracerCharLogger{}
+	handler := Tracer(Logging(LogProbes{}, lg)(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/chain", http.NoBody)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+
+	attrs := tracerCharAttrs(spans[0])
+	assert.Equal(t, int64(http.StatusServiceUnavailable), attrs[1].Value.AsInt64())
+	assert.Equal(t, codes.Unset, spans[0].Status().Code, "5xx does not mark the span as errored")
+
+	require.Len(t, lg.errors, 1, "5xx is logged via Error")
+	assert.Equal(t, http.StatusServiceUnavailable, lg.errors[0].Response)
 }

--- a/pkg/gofr/logging/logger_test.go
+++ b/pkg/gofr/logging/logger_test.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -463,4 +465,433 @@ func BenchmarkLoggerInfofJSON(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		l.Infof("handled %s in %d us", "GET /users", 1234)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Characterization suite: the JSON log-entry envelope on the wire.
+//
+// These tests pin the enclosing logEntry that wraps every message written by
+// this package — the outer object that a log shipper actually parses. The
+// payload used throughout is shaped exactly like
+// middleware.RequestLog (redeclared locally as logCharRequestLog to avoid an
+// import cycle), because the per-request access log is by far the highest
+// volume consumer of this envelope.
+//
+// Nothing here asserts what the code *should* do — only what it does today.
+// All added identifiers are prefixed `logChar`.
+// ---------------------------------------------------------------------------
+
+// logCharRequestLog mirrors gofr.dev/pkg/gofr/http/middleware.RequestLog field
+// for field, tag for tag. Redeclared rather than imported so the logging
+// package keeps no dependency on the HTTP middleware.
+type logCharRequestLog struct {
+	TraceID      string `json:"trace_id,omitempty"`
+	SpanID       string `json:"span_id,omitempty"`
+	StartTime    string `json:"start_time,omitempty"`
+	ResponseTime int64  `json:"response_time,omitempty"`
+	Method       string `json:"method,omitempty"`
+	UserAgent    string `json:"user_agent,omitempty"`
+	IP           string `json:"ip,omitempty"`
+	URI          string `json:"uri,omitempty"`
+	Response     int    `json:"response,omitempty"`
+}
+
+// logCharSampleRequestLog is a fully populated access-log payload.
+func logCharSampleRequestLog() *logCharRequestLog {
+	return &logCharRequestLog{
+		TraceID:      "e1f2d3c4b5a6978877665544332211ff",
+		SpanID:       "0011223344556677",
+		StartTime:    "2024-03-01T12:34:56.789-05:00",
+		ResponseTime: 1234,
+		Method:       "GET",
+		UserAgent:    "curl/8.4.0",
+		IP:           "192.0.2.10",
+		URI:          "/api/v1/users?q=1",
+		Response:     200,
+	}
+}
+
+// logCharTimeRe and logCharVersionRe normalize the two non-deterministic parts
+// of a log line so the rest can be compared byte for byte.
+var (
+	logCharTimeRe    = regexp.MustCompile(`"time":"[^"]*"`)
+	logCharVersionRe = regexp.MustCompile(`"gofrVersion":"[^"]*"`)
+)
+
+// logCharNormalize replaces the wall-clock timestamp and the framework version
+// with fixed placeholders.
+func logCharNormalize(line string) string {
+	line = logCharTimeRe.ReplaceAllString(line, `"time":"<TIME>"`)
+
+	return logCharVersionRe.ReplaceAllString(line, `"gofrVersion":"<VERSION>"`)
+}
+
+// Test_LogWireFormat_RequestLogEnvelopeExact pins the ENTIRE log line for an
+// access-log entry, byte for byte after timestamp/version normalization:
+//   - the envelope keys and their order: level, time, message, gofrVersion;
+//   - `trace_id` is ABSENT at the envelope level (it is omitempty and nothing
+//     populates it for a request log — the trace ID travels inside `message`);
+//   - `level` renders as the level NAME, via Level.MarshalJSON;
+//   - the payload is nested as a JSON object under `message`, preserving the
+//     RequestLog field order;
+//   - exactly one trailing newline, courtesy of json.Encoder.Encode.
+func Test_LogWireFormat_RequestLogEnvelopeExact(t *testing.T) {
+	const want = `{"level":"INFO","time":"<TIME>","message":{` +
+		`"trace_id":"e1f2d3c4b5a6978877665544332211ff","span_id":"0011223344556677",` +
+		`"start_time":"2024-03-01T12:34:56.789-05:00","response_time":1234,"method":"GET",` +
+		`"user_agent":"curl/8.4.0","ip":"192.0.2.10","uri":"/api/v1/users?q=1","response":200},` +
+		`"gofrVersion":"<VERSION>"}` + "\n"
+
+	buf := &bytes.Buffer{}
+	newBufLogger(buf).Log(logCharSampleRequestLog())
+
+	//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+	assert.Equal(t, want, logCharNormalize(buf.String()))
+}
+
+// Test_LogWireFormat_ErrorEnvelopeExact pins the same line at ERROR level and
+// that it is routed to errorOut, leaving normalOut untouched.
+func Test_LogWireFormat_ErrorEnvelopeExact(t *testing.T) {
+	const want = `{"level":"ERROR","time":"<TIME>","message":{` +
+		`"trace_id":"e1f2d3c4b5a6978877665544332211ff","span_id":"0011223344556677",` +
+		`"start_time":"2024-03-01T12:34:56.789-05:00","response_time":1234,"method":"GET",` +
+		`"user_agent":"curl/8.4.0","ip":"192.0.2.10","uri":"/api/v1/users?q=1","response":500},` +
+		`"gofrVersion":"<VERSION>"}` + "\n"
+
+	normal := &bytes.Buffer{}
+	errs := &bytes.Buffer{}
+	l := &logger{level: DEBUG, normalOut: normal, errorOut: errs}
+
+	payload := logCharSampleRequestLog()
+	payload.Response = 500
+
+	l.Error(payload)
+
+	assert.Empty(t, normal.String(), "ERROR must not reach normalOut")
+	//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+	assert.Equal(t, want, logCharNormalize(errs.String()))
+}
+
+// Test_LogWireFormat_EnvelopeKeyOrder pins the ordered envelope key list on its
+// own, so inserting an envelope field is caught even if values change.
+func Test_LogWireFormat_EnvelopeKeyOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		log  func(l *logger)
+		want []string
+	}{
+		{
+			"without a trace ID",
+			func(l *logger) { l.Log(logCharSampleRequestLog()) },
+			[]string{"level", "time", "message", "gofrVersion"},
+		},
+		{
+			"with a trace ID, which slots between message and gofrVersion",
+			func(l *logger) {
+				l.Log(map[string]any{traceIDMarkerKey: "abc123"}, logCharSampleRequestLog())
+			},
+			[]string{"level", "time", "message", "trace_id", "gofrVersion"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			tc.log(newBufLogger(buf))
+
+			assert.Equal(t, tc.want, logCharTopLevelKeys(t, buf.Bytes()))
+		})
+	}
+}
+
+// logCharTopLevelKeys returns the top-level object keys of a JSON document in
+// wire order.
+func logCharTopLevelKeys(t *testing.T, b []byte) []string {
+	t.Helper()
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+
+	tok, err := dec.Token()
+	require.NoError(t, err)
+	require.Equal(t, json.Delim('{'), tok)
+
+	keys := make([]string, 0, 5)
+
+	for dec.More() {
+		k, kerr := dec.Token()
+		require.NoError(t, kerr)
+
+		key, ok := k.(string)
+		require.True(t, ok)
+
+		keys = append(keys, key)
+
+		var discard any
+
+		require.NoError(t, dec.Decode(&discard))
+	}
+
+	return keys
+}
+
+// Test_LogWireFormat_TraceIDEnvelopeExact pins the full line when a trace-ID
+// marker IS present: the marker map is stripped from the message and lifted
+// into the envelope's `trace_id`.
+func Test_LogWireFormat_TraceIDEnvelopeExact(t *testing.T) {
+	const want = `{"level":"INFO","time":"<TIME>","message":"handled",` +
+		`"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","gofrVersion":"<VERSION>"}` + "\n"
+
+	buf := &bytes.Buffer{}
+	newBufLogger(buf).Log(map[string]any{traceIDMarkerKey: "4bf92f3577b34da6a3ce929d0e0e4736"}, "handled")
+
+	//nolint:testifylint // byte equality is the contract; JSONEq ignores key order.
+	assert.Equal(t, want, logCharNormalize(buf.String()))
+}
+
+// Test_LogWireFormat_LevelRendering pins that every level serializes as its
+// upper-case NAME (not the underlying integer) via Level.MarshalJSON, and that
+// the unknown level renders as an empty string.
+func Test_LogWireFormat_LevelRendering(t *testing.T) {
+	tests := []struct {
+		level Level
+		want  string
+	}{
+		{DEBUG, `"DEBUG"`},
+		{INFO, `"INFO"`},
+		{NOTICE, `"NOTICE"`},
+		{WARN, `"WARN"`},
+		{ERROR, `"ERROR"`},
+		{FATAL, `"FATAL"`},
+		{Level(0), `""`},
+		{Level(99), `""`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			b, err := json.Marshal(tc.level)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, string(b))
+		})
+	}
+}
+
+// Test_LogWireFormat_MessageShapeByArity pins how `message` is typed depending
+// on how many args reach logf. One arg is embedded directly (object, string,
+// number...); zero or 2+ args become a JSON array — and zero args produce
+// `null`, because the nil []any marshals to null rather than [].
+func Test_LogWireFormat_MessageShapeByArity(t *testing.T) {
+	tests := []struct {
+		name string
+		log  func(l *logger)
+		want string
+	}{
+		{"no args yields null", func(l *logger) { l.Log() }, `null`},
+		{"one string arg is embedded as a string", func(l *logger) { l.Log("hello") }, `"hello"`},
+		{"one int arg is embedded as a number", func(l *logger) { l.Log(42) }, `42`},
+		{
+			"one struct arg is embedded as an object",
+			func(l *logger) { l.Log(&logCharRequestLog{Method: "GET", Response: 200}) },
+			`{"method":"GET","response":200}`,
+		},
+		{"two args become an array", func(l *logger) { l.Log("a", 1) }, `["a",1]`},
+		{"three args become an array", func(l *logger) { l.Log("a", 1, true) }, `["a",1,true]`},
+		{"a format string collapses to one string", func(l *logger) { l.Logf("a=%d", 7) }, `"a=7"`},
+		{"a nil arg is embedded as null", func(l *logger) { l.Log(nil) }, `null`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			tc.log(newBufLogger(buf))
+
+			assert.Equal(t, `{"level":"INFO","time":"<TIME>","message":`+tc.want+`,"gofrVersion":"<VERSION>"}`+"\n",
+				logCharNormalize(buf.String()))
+		})
+	}
+}
+
+// Test_LogWireFormat_HTMLEscapingOnTheRealPath pins that the production writer
+// (json.NewEncoder(out).Encode) HTML-escapes by default, exactly like
+// json.Marshal. A URI carrying `<`, `>` or `&` is rewritten on the wire, and
+// invalid UTF-8 becomes the escaped replacement character.
+func Test_LogWireFormat_HTMLEscapingOnTheRealPath(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{
+			"HTML significant characters",
+			"/q?x=<a>&y=1",
+			`{"uri":"/q?x=\u003ca\u003e\u0026y=1"}`,
+		},
+		{
+			"quote, backslash and control characters",
+			"/a\"b\\c\nd\te",
+			`{"uri":"/a\"b\\c\nd\te"}`,
+		},
+		{
+			"line and paragraph separators",
+			"/\u2028\u2029",
+			`{"uri":"/\u2028\u2029"}`,
+		},
+		{
+			"invalid UTF-8",
+			"/\xff/ok",
+			`{"uri":"/\ufffd/ok"}`,
+		},
+		{
+			"CJK and emoji stay raw",
+			"/日本語/\U0001F680",
+			"{\"uri\":\"/日本語/\U0001F680\"}",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			newBufLogger(buf).Log(&logCharRequestLog{URI: tc.uri})
+
+			assert.Equal(t, `{"level":"INFO","time":"<TIME>","message":`+tc.want+`,"gofrVersion":"<VERSION>"}`+"\n",
+				logCharNormalize(buf.String()))
+		})
+	}
+}
+
+// Test_LogWireFormat_TimeIsRFC3339Nano pins the envelope timestamp format:
+// time.Time marshals through its own MarshalJSON, i.e. RFC3339 with nanosecond
+// precision and TRAILING ZEROS REMOVED — so a whole-second instant renders
+// without a fractional part, and UTC renders as "Z" (unlike the RequestLog
+// `start_time` field, which uses a numeric offset). The two timestamps in a
+// single access-log line therefore use DIFFERENT formats.
+func Test_LogWireFormat_TimeIsRFC3339Nano(t *testing.T) {
+	buf := &bytes.Buffer{}
+	newBufLogger(buf).Log("x")
+
+	var envelope struct {
+		Time string `json:"time"`
+	}
+
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+
+	parsed, err := time.Parse(time.RFC3339Nano, envelope.Time)
+	require.NoError(t, err, "envelope time %q must be RFC3339Nano", envelope.Time)
+	assert.WithinDuration(t, time.Now(), parsed, time.Minute)
+
+	// The two timestamp formats in play, pinned side by side.
+	fixed := time.Date(2024, 3, 1, 12, 34, 56, 0, time.UTC)
+
+	marshaled, err := json.Marshal(fixed)
+	require.NoError(t, err)
+	assert.Equal(t, `"2024-03-01T12:34:56Z"`, string(marshaled), "envelope time: RFC3339Nano, UTC renders as Z")
+	assert.Equal(t, "2024-03-01T12:34:56+00:00",
+		fixed.Format("2006-01-02T15:04:05.999999999-07:00"), "RequestLog start_time: numeric offset")
+}
+
+// Test_LogWireFormat_OneLinePerEntry pins that entries are newline-delimited
+// with no pretty-printing: no indentation, one entry per line, and consecutive
+// entries append rather than overwrite.
+func Test_LogWireFormat_OneLinePerEntry(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := newBufLogger(buf)
+
+	l.Log(logCharSampleRequestLog())
+	l.Log(logCharSampleRequestLog())
+
+	out := buf.String()
+	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+
+	require.Len(t, lines, 2)
+	assert.Equal(t, 2, strings.Count(out, "\n"), "one newline per entry, none inside")
+	assert.Equal(t, logCharNormalize(lines[0]), logCharNormalize(lines[1]),
+		"identical payloads produce identical lines once the timestamp is normalized")
+
+	for _, line := range lines {
+		assert.NotContains(t, line, "  ", "entries are never indented")
+		require.True(t, json.Valid([]byte(line)))
+	}
+}
+
+// Test_LogWireFormat_BelowThresholdWritesNothing pins that a filtered-out level
+// produces ZERO bytes — not an empty JSON object, not a bare newline.
+func Test_LogWireFormat_BelowThresholdWritesNothing(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := &logger{level: ERROR, normalOut: buf, errorOut: buf}
+
+	l.Debug(logCharSampleRequestLog())
+	l.Info(logCharSampleRequestLog())
+	l.Log(logCharSampleRequestLog())
+	l.Notice(logCharSampleRequestLog())
+	l.Warn(logCharSampleRequestLog())
+
+	assert.Empty(t, buf.String())
+
+	l.Error(logCharSampleRequestLog())
+	assert.NotEmpty(t, buf.String())
+}
+
+// Test_LogWireFormat_PayloadOmitemptyPropagates pins that the nested payload's
+// omitempty tags apply inside the envelope too: a mostly-zero access log
+// collapses to a tiny `message` object, and a fully zero one to `{}`.
+func Test_LogWireFormat_PayloadOmitemptyPropagates(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload *logCharRequestLog
+		want    string
+	}{
+		{"fully zero payload collapses to an empty object", &logCharRequestLog{}, `{}`},
+		{
+			"only a status survives",
+			&logCharRequestLog{Response: 200},
+			`{"response":200}`,
+		},
+		{
+			"a zero response_time drops the key",
+			&logCharRequestLog{Method: "GET", ResponseTime: 0, Response: 204},
+			`{"method":"GET","response":204}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			newBufLogger(buf).Log(tc.payload)
+
+			assert.Equal(t, `{"level":"INFO","time":"<TIME>","message":`+tc.want+`,"gofrVersion":"<VERSION>"}`+"\n",
+				logCharNormalize(buf.String()))
+		})
+	}
+}
+
+// Test_LogWireFormat_GofrVersionIsPopulated pins that gofrVersion is always
+// present and non-empty (it has no omitempty tag, so it would appear even if
+// the value were empty).
+func Test_LogWireFormat_GofrVersionIsPopulated(t *testing.T) {
+	buf := &bytes.Buffer{}
+	newBufLogger(buf).Log(logCharSampleRequestLog())
+
+	var envelope struct {
+		GofrVersion string `json:"gofrVersion"`
+	}
+
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+	assert.NotEmpty(t, envelope.GofrVersion)
+	assert.Contains(t, buf.String(), `"gofrVersion":"`)
+}
+
+// Test_LogWireFormat_PrettyPrintPathIsNotJSON pins the alternative branch: when
+// isTerminal is true the entry is rendered as ANSI text and is NOT valid JSON,
+// which is why every wire-format assertion above depends on the sink not being
+// a terminal (checkIfTerminal returns false for a *bytes.Buffer).
+func Test_LogWireFormat_PrettyPrintPathIsNotJSON(t *testing.T) {
+	assert.False(t, checkIfTerminal(&bytes.Buffer{}), "a bytes.Buffer is never a terminal, so JSON is emitted")
+
+	buf := &bytes.Buffer{}
+	l := &logger{level: DEBUG, normalOut: buf, errorOut: buf, isTerminal: true, lock: make(chan struct{}, 1)}
+
+	l.Log("hello")
+
+	assert.False(t, json.Valid(buf.Bytes()), "the terminal branch emits ANSI text, not JSON")
+	assert.Contains(t, buf.String(), "hello")
+	assert.Contains(t, buf.String(), "INFO")
 }


### PR DESCRIPTION
## Summary

Locks the observable contract of the request-path middleware **before** any optimisation touches these files. Tests only — no production line is modified.

Line coverage of `cors.go`, `tracer.go`, `logger.go` and `metrics.go` was already ~100%, but that is *execution* coverage. Almost nothing asserted the actual output, so a refactor could rename a JSON field, change a header value, flip an attribute type or alter a metric label and the whole suite would still pass. Every assertion here is literal — no `Contains`.

107 test functions, 627 test nodes, ~900 assertions.

## What's pinned

- **cors** — each response snapshotted as an exact sorted header-line slice over a config × origin × method matrix, plus status, body, inner-handler call count, and the `Allow-Methods` join.
- **tracer** — exact instrumentation scope and span name, the complete attribute set with types pinned (`http.response.status_code` as INT64), span kind/status/events/links, W3C `traceparent` parent/child and baggage, and a guard that a valid non-zero TraceID/SpanID still exists under the `NeverSample` provider used when no exporter is configured.
- **logging** — byte-exact JSON wire format: all fields in declaration order, every `omitempty` disappearance case, and a full escaping battery (control chars, `<>&`, U+2028/9, invalid UTF-8, CJK/emoji) across each string field.
- **metrics** — exact metric name and ordered label vector on both the slow path and the attribute-cached fast path, asserted to parity, plus the static-extension and probe matrices.

## Mutation tested

11 deliberate mutations were applied to the production code and reverted. Nine failed loudly (renaming `http.route` → 17 failures, the metric name → 24, the `uri` tag → 19).

The three that **escaped** were tests too loose to keep, and were tightened until the same mutation fails:
1. CORS expectations referenced a production constant instead of a literal, so changing that constant passed → now 52 failures.
2. `start_time` was only asserted to re-parse; `time.Parse` is lenient, so `.999999999` → `.000000000` slipped through.
3. `response_time`'s **unit** was unpinned — a µs→ns swap passed silently.

## Behaviour found and characterized, not fixed

The suite records current behaviour warts included. It documents, among others: a panicking request being logged as `response:200` at Log level while the client receives 500; requests to `/` recorded with an empty metric path label; `HasPrefix(path,"/static")` also matching `/staticfiles/*`; CORS writing `"OPTIONS"` into the caller's backing array; and `getIPAddress` returning `""` for a whitespace-only `X-Forwarded-For`. Those are addressed in a follow-up.

## Tests

`go test -race ./pkg/gofr/http/middleware/ ./pkg/gofr/logging/` green, stable across `-shuffle=on` runs. `golangci-lint --new-from-rev` reports 0 issues.
