### PR TITLE
test(http): characterize the request/response contract

### DIFF
--- a/pkg/gofr/handler_test.go
+++ b/pkg/gofr/handler_test.go
@@ -512,3 +512,521 @@ func TestIntegration_ServerTimeout(t *testing.T) {
 	errorObj := errorResponse["error"].(map[string]any)
 	assert.Equal(t, "request timed out", errorObj["message"])
 }
+
+// ---------------------------------------------------------------------------
+// Characterization suite for handler.ServeHTTP.
+//
+// Pins the handler-execution contract with exact status codes and exact body
+// bytes for both execution paths (serveInline and serveWithGoroutine), for
+// timeout, cancellation, panic recovery and the WebSocket bypass. The two paths
+// are asserted against the SAME expectations wherever they should agree, so a
+// refactor cannot let them drift.
+// ---------------------------------------------------------------------------
+
+// charHandler builds a handler with a silent logger.
+func charHandler(fn Handler, timeout time.Duration) handler {
+	return handler{
+		function:       fn,
+		container:      &container.Container{Logger: logging.NewLogger(logging.FATAL)},
+		requestTimeout: timeout,
+	}
+}
+
+// charServe runs h against a fresh recorder for the given method.
+func charServe(t *testing.T, h handler, method string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), method, "/", http.NoBody))
+
+	return w
+}
+
+// TestHandler_Char_BothPathsAgree pins that serveInline (requestTimeout == 0)
+// and serveWithGoroutine (requestTimeout > 0) produce byte-identical responses
+// for every ordinary handler outcome. The timeout is generous so the deadline
+// branch never fires.
+func TestHandler_Char_BothPathsAgree(t *testing.T) {
+	cases := []struct {
+		name       string
+		method     string
+		fn         Handler
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			"nil-nil", http.MethodGet,
+			func(*Context) (any, error) { return nil, nil },
+			http.StatusOK, "{}\n",
+		},
+		{
+			"data", http.MethodGet,
+			func(*Context) (any, error) { return map[string]string{"m": "hi"}, nil },
+			http.StatusOK, "{\"data\":{\"m\":\"hi\"}}\n",
+		},
+		{
+			"post-created", http.MethodPost,
+			func(*Context) (any, error) { return "Created", nil },
+			http.StatusCreated, "{\"data\":\"Created\"}\n",
+		},
+		{
+			"delete-no-content", http.MethodDelete,
+			func(*Context) (any, error) { return nil, nil },
+			http.StatusNoContent, "{}\n",
+		},
+		{
+			"plain-error", http.MethodGet,
+			func(*Context) (any, error) { return nil, errTest },
+			http.StatusInternalServerError, "{\"error\":{\"message\":\"some error\"}}\n",
+		},
+		{
+			"status-coded-error", http.MethodGet,
+			func(*Context) (any, error) { return nil, gofrHTTP.ErrorEntityNotFound{Name: "id", Value: "3"} },
+			http.StatusNotFound, "{\"error\":{\"message\":\"No entity found with id: 3\"}}\n",
+		},
+		{
+			"data-and-error-partial", http.MethodGet,
+			func(*Context) (any, error) { return map[string]string{"p": "ok"}, errTest },
+			http.StatusPartialContent, "{\"error\":{\"message\":\"some error\"},\"data\":{\"p\":\"ok\"}}\n",
+		},
+		{
+			"invalid-route", http.MethodGet,
+			catchAllHandler,
+			http.StatusNotFound, "{\"error\":{\"message\":\"route not registered\"}}\n",
+		},
+		{
+			"liveness", http.MethodGet,
+			liveHandler,
+			http.StatusOK, "{\"data\":{\"status\":\"UP\"}}\n",
+		},
+	}
+
+	paths := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"inline", 0},
+		{"goroutine", time.Minute},
+	}
+
+	for _, p := range paths {
+		for _, tc := range cases {
+			t.Run(p.name+"/"+tc.name, func(t *testing.T) {
+				w := charServe(t, charHandler(tc.fn, p.timeout), tc.method)
+
+				assert.Equal(t, tc.wantStatus, w.Code, "status code")
+				assert.Equal(t, "application/json", w.Header().Get("Content-Type"), "Content-Type")
+				assert.Equal(t, tc.wantBody, w.Body.String(), "body bytes")
+			})
+		}
+	}
+}
+
+// TestHandler_Char_PanicRecovery pins panic recovery on BOTH paths: the client
+// gets a 500 with the generic "Internal Server Error" envelope, and neither the
+// panic value nor any stack frame leaks onto the wire.
+func TestHandler_Char_PanicRecovery(t *testing.T) {
+	const secret = "SUPER-SECRET-PANIC-VALUE"
+
+	errSecretPanic := errors.New(secret) //nolint:err113 // panic payload under test.
+
+	panics := []struct {
+		name string
+		fn   Handler
+	}{
+		{"string-panic", func(*Context) (any, error) { panic(secret) }},
+		{"error-panic", func(*Context) (any, error) { panic(errSecretPanic) }},
+		{"runtime-panic", func(*Context) (any, error) {
+			s := []int{1}
+			idx := len(s) + 1
+
+			return s[idx], nil // index out of range
+		}},
+	}
+
+	timeouts := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"inline", 0},
+		{"goroutine", time.Minute},
+	}
+
+	for _, to := range timeouts {
+		for _, p := range panics {
+			t.Run(to.name+"/"+p.name, func(t *testing.T) {
+				w := charServe(t, charHandler(p.fn, to.timeout), http.MethodGet)
+
+				assert.Equal(t, http.StatusInternalServerError, w.Code)
+				assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+				//nolint:testifylint // exact bytes are the contract.
+				assert.Equal(t, "{\"error\":{\"message\":\"Internal Server Error\"}}\n", w.Body.String())
+
+				// Nothing about the panic reaches the client.
+				assert.NotContains(t, w.Body.String(), secret)
+				assert.NotContains(t, w.Body.String(), "goroutine")
+				assert.NotContains(t, w.Body.String(), "handler_test.go")
+			})
+		}
+	}
+}
+
+// TestHandler_Char_PanicAfterPartialResult pins that a handler which panics
+// AFTER computing a value still yields the bare 500 envelope — the partial
+// result is discarded, not returned as 206.
+func TestHandler_Char_PanicAfterPartialResult(t *testing.T) {
+	for _, timeout := range []time.Duration{0, time.Minute} {
+		w := charServe(t, charHandler(func(*Context) (any, error) {
+			defer panic("late")
+
+			return map[string]string{"leaked": "value"}, nil
+		}, timeout), http.MethodGet)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		//nolint:testifylint // exact bytes are the contract.
+		assert.Equal(t, "{\"error\":{\"message\":\"Internal Server Error\"}}\n", w.Body.String())
+	}
+}
+
+// TestHandler_Char_ServerTimeout pins the server-side request timeout: the
+// deadline branch of serveWithGoroutine fires while the handler is still
+// running and the client gets exactly 408 with the timeout envelope. Any result
+// the handler eventually produces is dropped.
+func TestHandler_Char_ServerTimeout(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	h := charHandler(func(*Context) (any, error) {
+		<-release
+
+		return "too late", nil
+	}, 10*time.Millisecond)
+
+	w := charServe(t, h, http.MethodGet)
+
+	assert.Equal(t, http.StatusRequestTimeout, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	//nolint:testifylint // exact bytes are the contract.
+	assert.Equal(t, "{\"error\":{\"message\":\"request timed out\"}}\n", w.Body.String())
+}
+
+// TestHandler_Char_InlineDeadlineExceeded pins the inline path's post-hoc
+// deadline check: the handler runs to completion (Go cannot kill a goroutine),
+// but because the inherited context expired the result is dropped and the
+// client sees 408 rather than the handler's value.
+func TestHandler_Char_InlineDeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel()
+
+	var ran bool
+
+	h := charHandler(func(*Context) (any, error) {
+		ran = true
+
+		time.Sleep(20 * time.Millisecond)
+
+		return "computed anyway", nil
+	}, 0)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequestWithContext(ctx, http.MethodGet, "/", http.NoBody))
+
+	assert.True(t, ran, "the handler still runs to completion on the inline path")
+	assert.Equal(t, http.StatusRequestTimeout, w.Code)
+	//nolint:testifylint // exact bytes are the contract.
+	assert.Equal(t, "{\"error\":{\"message\":\"request timed out\"}}\n", w.Body.String())
+}
+
+// TestHandler_Char_ClientCanceled pins client cancellation on both paths: the
+// non-standard 499 with the "client closed request" envelope.
+func TestHandler_Char_ClientCanceled(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"inline", 0},
+		{"goroutine", time.Minute},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+
+			h := charHandler(func(*Context) (any, error) { return "ignored", nil }, tc.timeout)
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, httptest.NewRequestWithContext(ctx, http.MethodGet, "/", http.NoBody))
+
+			assert.Equal(t, gofrHTTP.StatusClientClosedRequest, w.Code)
+			assert.Equal(t, 499, w.Code)
+			//nolint:testifylint // exact bytes are the contract.
+			assert.Equal(t, "{\"error\":{\"message\":\"client closed request\"}}\n", w.Body.String())
+		})
+	}
+}
+
+// TestHandler_Char_PanicBeatsCancellation pins the precedence on the inline
+// path: a handler that panics on an already-canceled context reports the panic
+// (500), because the cancellation remap is skipped when panicked is set.
+func TestHandler_Char_PanicBeatsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	h := charHandler(func(*Context) (any, error) { panic("boom") }, 0)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequestWithContext(ctx, http.MethodGet, "/", http.NoBody))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	//nolint:testifylint // exact bytes are the contract.
+	assert.Equal(t, "{\"error\":{\"message\":\"Internal Server Error\"}}\n", w.Body.String())
+}
+
+// TestHandler_Char_ContextDeadlinePropagation pins which context the user
+// handler actually receives on each path.
+func TestHandler_Char_ContextDeadlinePropagation(t *testing.T) {
+	t.Run("no-timeout-has-no-deadline", func(t *testing.T) {
+		var hasDeadline bool
+
+		charServe(t, charHandler(func(c *Context) (any, error) {
+			_, hasDeadline = c.Deadline()
+
+			return nil, nil
+		}, 0), http.MethodGet)
+
+		assert.False(t, hasDeadline)
+	})
+
+	t.Run("timeout-sets-deadline", func(t *testing.T) {
+		var (
+			hasDeadline bool
+			remaining   time.Duration
+		)
+
+		charServe(t, charHandler(func(c *Context) (any, error) {
+			var dl time.Time
+
+			dl, hasDeadline = c.Deadline()
+			remaining = time.Until(dl)
+
+			return nil, nil
+		}, time.Minute), http.MethodGet)
+
+		assert.True(t, hasDeadline)
+		// Normalized: only the ballpark is asserted, never the wall clock.
+		assert.Positive(t, remaining)
+		assert.LessOrEqual(t, remaining, time.Minute)
+	})
+}
+
+// TestHandler_Char_WebSocketBypassesTimeout pins that a WebSocket upgrade
+// request ignores requestTimeout entirely: the handler's context carries no
+// deadline and a handler slower than the configured timeout still returns its
+// own result rather than a 408.
+func TestHandler_Char_WebSocketBypassesTimeout(t *testing.T) {
+	var hasDeadline bool
+
+	h := charHandler(func(c *Context) (any, error) {
+		_, hasDeadline = c.Deadline()
+
+		time.Sleep(30 * time.Millisecond)
+
+		return "ws-ok", nil
+	}, 5*time.Millisecond)
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ws", http.NoBody)
+	r.Header.Set("Connection", "Upgrade")
+	r.Header.Set("Upgrade", "websocket")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.False(t, hasDeadline, "a WebSocket request must not inherit the request timeout")
+	assert.Equal(t, http.StatusOK, w.Code)
+	//nolint:testifylint // exact bytes are the contract.
+	assert.Equal(t, "{\"data\":\"ws-ok\"}\n", w.Body.String())
+}
+
+// TestHandler_Char_WebSocketStillWritesJSONEnvelope pins a sharp edge: despite
+// the "do not respond with HTTP headers since this is a WebSocket request"
+// comment in handleWebSocketUpgrade, the normal JSON envelope IS still written
+// for an upgrade request whose handler returns without hijacking the
+// connection. handleWebSocketUpgrade is a no-op in both of its branches.
+func TestHandler_Char_WebSocketStillWritesJSONEnvelope(t *testing.T) {
+	h := charHandler(func(*Context) (any, error) { return "ws", nil }, 0)
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ws", http.NoBody)
+	r.Header.Set("Connection", "Upgrade")
+	r.Header.Set("Upgrade", "websocket")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	//nolint:testifylint // exact bytes are the contract.
+	assert.Equal(t, "{\"data\":\"ws\"}\n", w.Body.String())
+}
+
+// TestHandler_Char_ResponseCustomHeaders pins that ServeHTTP applies
+// response.Response.Headers to the writer (Respond itself never does) and that
+// the headers do not appear in the JSON body.
+func TestHandler_Char_ResponseCustomHeaders(t *testing.T) {
+	for _, timeout := range []time.Duration{0, time.Minute} {
+		w := charServe(t, charHandler(func(*Context) (any, error) {
+			return response.Response{
+				Data:     map[string]string{"m": "hi"},
+				Metadata: map[string]any{"page": 1},
+				Headers:  map[string]string{"X-One": "1", "x-two": "2"},
+			}, nil
+		}, timeout), http.MethodGet)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "1", w.Header().Get("X-One"))
+		// Header keys are canonicalized by net/http.
+		assert.Equal(t, "2", w.Header().Get("X-Two"))
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+		//nolint:testifylint // exact bytes are the contract.
+		assert.Equal(t, "{\"metadata\":{\"page\":1},\"data\":{\"m\":\"hi\"}}\n", w.Body.String())
+	}
+}
+
+// TestHandler_Char_ResponseCustomHeadersCanOverrideContentType pins that a
+// handler-supplied Content-Type wins, because ServeHTTP sets the custom headers
+// before Respond decides whether to default it.
+func TestHandler_Char_ResponseCustomHeadersCanOverrideContentType(t *testing.T) {
+	w := charServe(t, charHandler(func(*Context) (any, error) {
+		return response.Response{
+			Data:    "x",
+			Headers: map[string]string{"Content-Type": "application/vnd.custom+json"},
+		}, nil
+	}, 0), http.MethodGet)
+
+	assert.Equal(t, "application/vnd.custom+json", w.Header().Get("Content-Type"))
+	//nolint:testifylint // exact bytes are the contract.
+	assert.Equal(t, "{\"data\":\"x\"}\n", w.Body.String())
+}
+
+// TestHandler_Char_ResponsePointerHeadersIgnored pins that returning a POINTER
+// to response.Response neither applies the custom headers nor takes the special
+// Response envelope path — the type assertion in ServeHTTP is by value.
+func TestHandler_Char_ResponsePointerHeadersIgnored(t *testing.T) {
+	w := charServe(t, charHandler(func(*Context) (any, error) {
+		return &response.Response{Data: "x", Headers: map[string]string{"X-One": "1"}}, nil
+	}, 0), http.MethodGet)
+
+	assert.Empty(t, w.Header().Get("X-One"), "custom headers are only applied for a value Response")
+	//nolint:testifylint // exact bytes are the contract.
+	assert.Equal(t, "{\"data\":{\"data\":\"x\"}}\n", w.Body.String())
+}
+
+// TestHandler_Char_SpecialResponseTypes pins that the special response types
+// survive the handler path unchanged.
+func TestHandler_Char_SpecialResponseTypes(t *testing.T) {
+	t.Run("file", func(t *testing.T) {
+		w := charServe(t, charHandler(func(*Context) (any, error) {
+			return response.File{Content: []byte("abc"), ContentType: "text/csv"}, nil
+		}, 0), http.MethodGet)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+		assert.Equal(t, "abc", w.Body.String())
+	})
+
+	t.Run("redirect-get", func(t *testing.T) {
+		w := charServe(t, charHandler(func(*Context) (any, error) {
+			return response.Redirect{URL: "/elsewhere"}, nil
+		}, 0), http.MethodGet)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		assert.Equal(t, "/elsewhere", w.Header().Get("Location"))
+		assert.Empty(t, w.Body.String())
+	})
+
+	t.Run("redirect-post", func(t *testing.T) {
+		w := charServe(t, charHandler(func(*Context) (any, error) {
+			return response.Redirect{URL: "/elsewhere"}, nil
+		}, time.Minute), http.MethodPost)
+
+		assert.Equal(t, http.StatusSeeOther, w.Code)
+		assert.Equal(t, "/elsewhere", w.Header().Get("Location"))
+	})
+
+	t.Run("raw", func(t *testing.T) {
+		w := charServe(t, charHandler(func(*Context) (any, error) {
+			return response.Raw{Data: map[string]string{"k": "v"}}, nil
+		}, 0), http.MethodGet)
+
+		//nolint:testifylint // exact bytes are the contract.
+		assert.Equal(t, "{\"k\":\"v\"}\n", w.Body.String())
+	})
+}
+
+// TestHandler_Char_ErrorLogging pins WHICH log level each error class is
+// emitted at by logError — the level is part of the operational contract even
+// though it never reaches the client.
+func TestHandler_Char_ErrorLogging(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantLevel string
+		// ERROR (and above) is written to stderr; everything else to stdout.
+		onStderr bool
+	}{
+		{"plain-error-is-ERROR", errTest, "ERROR", true},
+		{"entity-not-found-is-INFO", gofrHTTP.ErrorEntityNotFound{}, "INFO", false},
+		{"already-exists-is-WARN", gofrHTTP.ErrorEntityAlreadyExist{}, "WARN", false},
+		{"invalid-route-is-INFO", gofrHTTP.ErrorInvalidRoute{}, "INFO", false},
+		{"panic-recovery-is-ERROR", gofrHTTP.ErrorPanicRecovery{}, "ERROR", true},
+		{"too-many-requests-is-WARN", gofrHTTP.ErrorTooManyRequests{}, "WARN", false},
+		{"client-closed-is-DEBUG", gofrHTTP.ErrorClientClosedRequest{}, "DEBUG", false},
+		{"request-timeout-is-INFO", gofrHTTP.ErrorRequestTimeout{}, "INFO", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serve := func() {
+				h := handler{
+					function:  func(*Context) (any, error) { return nil, tc.err },
+					container: &container.Container{Logger: logging.NewLogger(logging.DEBUG)},
+				}
+
+				h.ServeHTTP(httptest.NewRecorder(),
+					httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody))
+			}
+
+			logs := testutil.StdoutOutputForFunc(serve)
+			if tc.onStderr {
+				logs = testutil.StderrOutputForFunc(serve)
+			}
+
+			assert.Contains(t, logs, tc.wantLevel)
+			assert.Contains(t, logs, tc.err.Error())
+		})
+	}
+}
+
+// TestHandler_Char_NoErrorNoLog pins that a successful handler logs nothing
+// from logError.
+func TestHandler_Char_NoErrorNoLog(t *testing.T) {
+	logs := testutil.StdoutOutputForFunc(func() {
+		h := handler{
+			function:  func(*Context) (any, error) { return "ok", nil },
+			container: &container.Container{Logger: logging.NewLogger(logging.DEBUG)},
+		}
+
+		h.ServeHTTP(httptest.NewRecorder(),
+			httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody))
+	})
+
+	assert.Empty(t, logs)
+}
+
+// TestErrorLogEntry_Char_PrettyPrint pins the exact bytes of the pretty-printed
+// error log line, ANSI color escapes included.
+func TestErrorLogEntry_Char_PrettyPrint(t *testing.T) {
+	var buf strings.Builder
+
+	(&ErrorLogEntry{TraceID: "abc123", Error: "went wrong"}).PrettyPrint(&buf)
+
+	assert.Equal(t, "\u001B[38;5;8mabc123 \u001B[38;5;202mwent wrong \n", buf.String())
+}

--- a/pkg/gofr/http/middleware/web_socket_test.go
+++ b/pkg/gofr/http/middleware/web_socket_test.go
@@ -82,3 +82,175 @@ func Test_WSConnectionCreate_Success(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
+
+// ---------------------------------------------------------------------------
+// Characterization suite for WSHandlerUpgrade.
+//
+// Pins the observable behavior of the middleware for both branches: a
+// non-upgrade request must pass through completely untouched, and an upgrade
+// request must be handed to the upgrader with the resulting connection
+// registered and its key placed in the request context.
+// ---------------------------------------------------------------------------
+
+// TestWSHandlerUpgrade_Char_NonUpgradePassesThrough pins that a request without
+// websocket upgrade headers reaches the inner handler unmodified: no upgrade is
+// attempted, the context carries no connection key, no connection is
+// registered, and the inner handler's status/headers/body are what the client
+// sees.
+func TestWSHandlerUpgrade_Char_NonUpgradePassesThrough(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{"no-headers", nil},
+		{"connection-only", map[string]string{"Connection": "upgrade"}},
+		{"upgrade-only", map[string]string{"Upgrade": "websocket"}},
+		{"wrong-upgrade-protocol", map[string]string{"Connection": "upgrade", "Upgrade": "h2c"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// No EXPECT() is registered on the mock upgrader: gomock fails the
+			// test if Upgrade is called at all on this path.
+			_, wsManager := initializeWebSocketMocks(t)
+			mockContainer, _ := container.NewMockContainer(t)
+
+			var (
+				called    bool
+				gotCtxVal any
+				gotMethod string
+				gotPath   string
+			)
+
+			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				gotCtxVal = r.Context().Value(gofrWebSocket.WSConnectionKey)
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+
+				w.Header().Set("X-Inner", "yes")
+				w.WriteHeader(http.StatusTeapot)
+				_, _ = w.Write([]byte("inner body"))
+			})
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/plain?a=b", http.NoBody)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+
+			WSHandlerUpgrade(mockContainer, wsManager)(inner).ServeHTTP(rec, req)
+
+			assert.True(t, called, "inner handler must be invoked")
+			assert.Nil(t, gotCtxVal, "no websocket key must be added to the context")
+			assert.Equal(t, http.MethodPost, gotMethod)
+			assert.Equal(t, "/plain", gotPath)
+
+			// The inner handler's response is passed through byte for byte.
+			assert.Equal(t, http.StatusTeapot, rec.Code)
+			assert.Equal(t, "yes", rec.Header().Get("X-Inner"))
+			assert.Equal(t, "inner body", rec.Body.String())
+
+			assert.Empty(t, wsManager.ListConnections(), "no connection must be registered")
+		})
+	}
+}
+
+// TestWSHandlerUpgrade_Char_UpgradeFailure pins the exact response written when
+// the upgrader fails: 400 with net/http's plain-text error envelope, and the
+// inner handler is NOT invoked.
+func TestWSHandlerUpgrade_Char_UpgradeFailure(t *testing.T) {
+	mockUpgrader, wsManager := initializeWebSocketMocks(t)
+	mockContainer, _ := container.NewMockContainer(t)
+
+	mockUpgrader.EXPECT().Upgrade(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errConnection).Times(1)
+
+	var called bool
+
+	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ws", http.NoBody)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+
+	rec := httptest.NewRecorder()
+
+	WSHandlerUpgrade(mockContainer, wsManager)(inner).ServeHTTP(rec, req)
+
+	assert.False(t, called, "inner handler must not run after a failed upgrade")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	// http.Error's exact wire shape: plain text, sniffing disabled, trailing \n.
+	assert.Equal(t, "text/plain; charset=utf-8", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "Could not open WebSocket connection\n", rec.Body.String())
+
+	assert.Empty(t, wsManager.ListConnections())
+}
+
+// TestWSHandlerUpgrade_Char_UpgradeSuccess pins the success branch: the
+// connection is registered under the Sec-WebSocket-Key, that key is placed in
+// the request context, and the inner handler still runs and owns the response.
+func TestWSHandlerUpgrade_Char_UpgradeSuccess(t *testing.T) {
+	mockUpgrader, wsManager := initializeWebSocketMocks(t)
+	mockContainer, _ := container.NewMockContainer(t)
+
+	conn := &websocket.Conn{}
+	mockUpgrader.EXPECT().Upgrade(gomock.Any(), gomock.Any(), gomock.Any()).Return(conn, nil).Times(1)
+
+	const key = "dGhlIHNhbXBsZSBub25jZQ=="
+
+	var gotCtxVal any
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCtxVal = r.Context().Value(gofrWebSocket.WSConnectionKey)
+
+		w.WriteHeader(http.StatusSwitchingProtocols)
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ws", http.NoBody)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Sec-WebSocket-Key", key)
+
+	rec := httptest.NewRecorder()
+
+	WSHandlerUpgrade(mockContainer, wsManager)(inner).ServeHTTP(rec, req)
+
+	assert.Equal(t, key, gotCtxVal, "the Sec-WebSocket-Key must be in the inner request's context")
+	assert.Equal(t, []string{key}, wsManager.ListConnections())
+
+	registered := wsManager.GetWebsocketConnection(key)
+	if assert.NotNil(t, registered) {
+		assert.Equal(t, conn, registered.Conn)
+	}
+
+	assert.Equal(t, http.StatusSwitchingProtocols, rec.Code)
+}
+
+// TestWSHandlerUpgrade_Char_MissingSecWebSocketKey pins that a successful
+// upgrade without a Sec-WebSocket-Key registers the connection under the EMPTY
+// string — so two such connections would overwrite one another. Reported, not
+// fixed.
+func TestWSHandlerUpgrade_Char_MissingSecWebSocketKey(t *testing.T) {
+	mockUpgrader, wsManager := initializeWebSocketMocks(t)
+	mockContainer, _ := container.NewMockContainer(t)
+
+	mockUpgrader.EXPECT().Upgrade(gomock.Any(), gomock.Any(), gomock.Any()).Return(&websocket.Conn{}, nil).Times(1)
+
+	var gotCtxVal any
+
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotCtxVal = r.Context().Value(gofrWebSocket.WSConnectionKey)
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ws", http.NoBody)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+
+	WSHandlerUpgrade(mockContainer, wsManager)(inner).ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.NotNil(t, gotCtxVal, "the key is present in the context, it is just empty")
+	assert.Empty(t, gotCtxVal)
+	assert.Equal(t, []string{""}, wsManager.ListConnections())
+}

--- a/pkg/gofr/http/request_test.go
+++ b/pkg/gofr/http/request_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -400,4 +401,568 @@ func TestContext_ReturnsRequestContext(t *testing.T) {
 	ctx := r.Context()
 
 	assert.Equal(t, httpReq.Context(), ctx)
+}
+
+// ---------------------------------------------------------------------------
+// Characterization suite.
+//
+// Pins the CURRENT param/binding contract of Request: exact return values and
+// exact error strings, including the sharp edges. Assertions are literal on
+// purpose — a refactor that changes any of these changes handler behavior.
+// ---------------------------------------------------------------------------
+
+// charBindTarget is the struct bound in the JSON characterization cases.
+type charBindTarget struct {
+	A string `json:"a"`
+	B int    `json:"b"`
+}
+
+func newCharRequest(t *testing.T, target, contentType, body string) *Request {
+	t.Helper()
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, target, strings.NewReader(body))
+	if contentType != "" {
+		r.Header.Set("Content-Type", contentType)
+	}
+
+	return NewRequest(r)
+}
+
+// TestRequest_Char_Param pins Param: it reads ONLY the URL query string (never
+// the body), returns the FIRST value for a repeated key, and returns "" for a
+// key that is absent or whose value is empty.
+func TestRequest_Char_Param(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		key    string
+		want   string
+	}{
+		{"single", "/x?a=b", "a", "b"},
+		{"absent", "/x?a=b", "zzz", ""},
+		{"no-query-string", "/x", "a", ""},
+		{"empty-value", "/x?a=", "a", ""},
+		{"bare-key", "/x?a", "a", ""},
+		// A repeated key yields only the first value.
+		{"repeated-returns-first", "/x?a=1&a=2&a=3", "a", "1"},
+		// Commas are NOT split by Param (unlike Params).
+		{"comma-not-split", "/x?a=1,2,3", "a", "1,2,3"},
+		{"url-decoded", "/x?a=hello%20world%26", "a", "hello world&"},
+		{"plus-is-space", "/x?a=hello+world", "a", "hello world"},
+		// Keys are case sensitive.
+		{"case-sensitive-key", "/x?Abc=1", "abc", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := NewRequest(httptest.NewRequestWithContext(t.Context(), http.MethodGet, tc.target, http.NoBody))
+
+			assert.Equal(t, tc.want, req.Param(tc.key))
+		})
+	}
+}
+
+// TestRequest_Char_Params pins Params: every value for the key, each further
+// split on commas. A missing key yields a nil slice (not an empty one).
+func TestRequest_Char_Params(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		key    string
+		want   []string
+	}{
+		{"single", "/x?a=b", "a", []string{"b"}},
+		{"repeated", "/x?a=1&a=2", "a", []string{"1", "2"}},
+		{"comma-split", "/x?a=1,2,3", "a", []string{"1", "2", "3"}},
+		{"repeated-and-comma-split", "/x?a=1,2&a=3", "a", []string{"1", "2", "3"}},
+		// An empty value still produces one empty element, because
+		// strings.Split("", ",") returns []string{""}.
+		{"empty-value-yields-empty-element", "/x?a=", "a", []string{""}},
+		{"bare-key-yields-empty-element", "/x?a", "a", []string{""}},
+		// Trailing/leading commas produce empty elements — no trimming.
+		{"leading-trailing-commas", "/x?a=,1,", "a", []string{"", "1", ""}},
+		{"absent-is-nil", "/x?a=b", "zzz", nil},
+		{"no-query-string-is-nil", "/x", "a", nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := NewRequest(httptest.NewRequestWithContext(t.Context(), http.MethodGet, tc.target, http.NoBody))
+
+			got := req.Params(tc.key)
+
+			assert.Equal(t, tc.want, got)
+
+			if tc.want == nil {
+				assert.Nil(t, got, "a missing key must yield nil, not an empty slice")
+			}
+		})
+	}
+}
+
+// TestRequest_Char_PathParam pins PathParam against gorilla/mux vars: present
+// keys return their value, everything else returns the empty string (never a
+// panic), and lookups are case sensitive.
+func TestRequest_Char_PathParam(t *testing.T) {
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/users/7", http.NoBody)
+	r = mux.SetURLVars(r, map[string]string{"id": "7", "Empty": "", "Mixed": "AbC"})
+
+	req := NewRequest(r)
+
+	assert.Equal(t, "7", req.PathParam("id"))
+	assert.Empty(t, req.PathParam("Empty"))
+	assert.Equal(t, "AbC", req.PathParam("Mixed"))
+	assert.Empty(t, req.PathParam("mixed"), "path params are case sensitive")
+	assert.Empty(t, req.PathParam("missing"))
+	assert.Empty(t, req.PathParam(""))
+}
+
+// TestRequest_Char_PathParamNoVars pins that a request never routed through mux
+// has a nil pathParams map and every lookup safely returns "".
+func TestRequest_Char_PathParamNoVars(t *testing.T) {
+	req := NewRequest(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody))
+
+	assert.Nil(t, req.pathParams)
+	assert.Empty(t, req.PathParam("anything"))
+}
+
+// TestRequest_Char_HostName pins HostName: "<proto>://<Host>", where proto is
+// X-Forwarded-Proto when set and "http" otherwise. The header value is trusted
+// and echoed verbatim — no allow-list, no validation.
+func TestRequest_Char_HostName(t *testing.T) {
+	tests := []struct {
+		name          string
+		host          string
+		forwardedProt string
+		want          string
+	}{
+		{"default-proto", "example.com", "", "http://example.com"},
+		{"forwarded-https", "example.com", "https", "https://example.com"},
+		{"host-with-port", "example.com:8080", "", "http://example.com:8080"},
+		// The proto header is echoed verbatim, whatever it says.
+		{"arbitrary-proto-echoed", "example.com", "gopher", "gopher://example.com"},
+		{"forwarded-proto-list-echoed", "example.com", "https, http", "https, http://example.com"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody)
+			r.Host = tc.host
+
+			if tc.forwardedProt != "" {
+				r.Header.Set("X-Forwarded-Proto", tc.forwardedProt)
+			}
+
+			assert.Equal(t, tc.want, NewRequest(r).HostName())
+		})
+	}
+}
+
+// TestRequest_Char_Context pins that Context returns the *same* context
+// instance carried by the underlying http.Request.
+func TestRequest_Char_Context(t *testing.T) {
+	type ctxKey struct{}
+
+	base := context.WithValue(t.Context(), ctxKey{}, "v")
+	r := httptest.NewRequestWithContext(base, http.MethodGet, "/x", http.NoBody)
+
+	got := NewRequest(r).Context()
+
+	assert.Equal(t, base, got)
+	assert.Equal(t, "v", got.Value(ctxKey{}))
+}
+
+// TestRequest_Char_BindJSON pins the JSON binding path, including the exact
+// error strings produced by encoding/json for malformed input.
+func TestRequest_Char_BindJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		wantErr     string
+		want        charBindTarget
+	}{
+		{"valid", "application/json", `{"a":"x","b":5}`, "", charBindTarget{A: "x", B: 5}},
+		// The content type is split on ";", so parameters are tolerated.
+		{"with-charset", "application/json; charset=utf-8", `{"a":"x"}`, "", charBindTarget{A: "x"}},
+		// SHARP EDGE (pinned as-is): the content type is split on ";" but never
+		// trimmed, so `application/json ; charset=utf-8` yields "application/json "
+		// (trailing space) which matches nothing — Bind silently does nothing.
+		{"with-space-before-semicolon-is-a-noop", "application/json ; charset=utf-8", `{"a":"x"}`, "", charBindTarget{}},
+		// Unknown JSON keys are silently ignored.
+		{"unknown-keys-ignored", "application/json", `{"a":"x","zz":1}`, "", charBindTarget{A: "x"}},
+		// Absent keys leave the target's existing (zero) value untouched.
+		{"partial-object", "application/json", `{"b":9}`, "", charBindTarget{B: 9}},
+		{"json-null", "application/json", `null`, "", charBindTarget{}},
+		{"empty-object", "application/json", `{}`, "", charBindTarget{}},
+
+		// --- malformed input -------------------------------------------------
+		{"empty-body", "application/json", ``, "unexpected end of JSON input", charBindTarget{}},
+		{"whitespace-only-body", "application/json", "   ", "unexpected end of JSON input", charBindTarget{}},
+		{"truncated", "application/json", `{"a":`, "unexpected end of JSON input", charBindTarget{}},
+		{
+			"not-json", "application/json", `hello`,
+			"invalid character 'h' looking for beginning of value", charBindTarget{},
+		},
+		{
+			"unquoted-key", "application/json", `{a:1}`,
+			"invalid character 'a' looking for beginning of object key string", charBindTarget{},
+		},
+		{
+			"trailing-garbage", "application/json", `{"a":"x"} junk`,
+			"invalid character 'j' after top-level value", charBindTarget{},
+		},
+
+		// --- type mismatches --------------------------------------------------
+		// NOTE: on a type mismatch encoding/json still populates the fields it
+		// COULD decode, so the target is left partially bound alongside the error.
+		{
+			"wrong-type-for-string", "application/json", `{"a":5}`,
+			"json: cannot unmarshal number into Go struct field charBindTarget.a of type string",
+			charBindTarget{},
+		},
+		{
+			"wrong-type-for-int", "application/json", `{"a":"x","b":"nope"}`,
+			"json: cannot unmarshal string into Go struct field charBindTarget.b of type int",
+			charBindTarget{A: "x"},
+		},
+		{
+			"array-instead-of-object", "application/json", `[1,2]`,
+			"json: cannot unmarshal array into Go value of type http.charBindTarget",
+			charBindTarget{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := newCharRequest(t, "/x", tc.contentType, tc.body)
+
+			var got charBindTarget
+
+			err := req.Bind(&got)
+
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+			}
+
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestRequest_Char_BindJSONNonPointerIsSilentNoOp pins a sharp edge: Bind takes
+// `any` and unmarshals into `&i`, so passing a non-pointer value binds into a
+// throwaway copy of the interface. No error is returned and the caller's value
+// is untouched — a typo like `c.Bind(target)` fails completely silently.
+func TestRequest_Char_BindJSONNonPointerIsSilentNoOp(t *testing.T) {
+	req := newCharRequest(t, "/x", "application/json", `{"a":"x","b":5}`)
+
+	target := charBindTarget{}
+
+	// Deliberately binding to a non-pointer to characterize the silent no-op.
+	err := req.Bind(target)
+
+	require.NoError(t, err, "no error is reported for a non-pointer target")
+	assert.Equal(t, charBindTarget{}, target, "the caller's value is left untouched")
+}
+
+// TestRequest_Char_BindJSONIntoNonStructTargets pins binding into the
+// non-struct pointer targets a handler may reasonably use.
+func TestRequest_Char_BindJSONIntoNonStructTargets(t *testing.T) {
+	t.Run("map", func(t *testing.T) {
+		req := newCharRequest(t, "/x", "application/json", `{"a":1,"b":"s"}`)
+
+		var got map[string]any
+
+		require.NoError(t, req.Bind(&got))
+		assert.Equal(t, map[string]any{"a": float64(1), "b": "s"}, got)
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		req := newCharRequest(t, "/x", "application/json", `[1,2,3]`)
+
+		var got []int
+
+		require.NoError(t, req.Bind(&got))
+		assert.Equal(t, []int{1, 2, 3}, got)
+	})
+
+	t.Run("string", func(t *testing.T) {
+		req := newCharRequest(t, "/x", "application/json", `"hello"`)
+
+		var got string
+
+		require.NoError(t, req.Bind(&got))
+		assert.Equal(t, "hello", got)
+	})
+
+	t.Run("any", func(t *testing.T) {
+		req := newCharRequest(t, "/x", "application/json", `{"a":1}`)
+
+		var got any
+
+		require.NoError(t, req.Bind(&got))
+		assert.Equal(t, map[string]any{"a": float64(1)}, got)
+	})
+}
+
+// TestRequest_Char_BindUnhandledContentTypes pins that Bind is a NO-OP that
+// returns nil for any content type it does not recognize — including a missing
+// header and a differently-cased one. A handler that ignores Bind's error sees
+// an all-zero struct rather than a failure.
+func TestRequest_Char_BindUnhandledContentTypes(t *testing.T) {
+	for _, ct := range []string{
+		"",
+		"text/plain",
+		"application/xml",
+		"application/JSON",  // matching is case SENSITIVE
+		"Application/json",  // ...in both halves
+		"application/json ", // a trailing space is not trimmed
+		" application/json", // nor a leading one
+		"application/jsonx", // no prefix matching
+		"text/json",
+		"application/x-www-form-urlencoded ", // trailing space again defeats the match
+	} {
+		t.Run("ct="+ct, func(t *testing.T) {
+			req := newCharRequest(t, "/x", ct, `{"a":"x","b":5}`)
+
+			var got charBindTarget
+
+			err := req.Bind(&got)
+
+			require.NoError(t, err, "unhandled content types must not error")
+			assert.Equal(t, charBindTarget{}, got, "unhandled content types must not bind")
+		})
+	}
+}
+
+// TestRequest_Char_BindFormURLEncoded pins the form-urlencoded path, including
+// the exact sentinel errors.
+func TestRequest_Char_BindFormURLEncoded(t *testing.T) {
+	type target struct {
+		Name string
+		Age  int
+		OK   bool
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		req := newCharRequest(t, "/x",
+			"application/x-www-form-urlencoded", "Name=alice&Age=30&OK=true")
+
+		var got target
+
+		require.NoError(t, req.Bind(&got))
+		assert.Equal(t, target{Name: "alice", Age: 30, OK: true}, got)
+	})
+
+	// Top-level form keys are matched against the exact Go field name (or the
+	// `form`/`file` tag) — the match is CASE SENSITIVE, unlike the nested
+	// struct-string parser in setStructValue.
+	t.Run("field-names-are-case-sensitive", func(t *testing.T) {
+		req := newCharRequest(t, "/x",
+			"application/x-www-form-urlencoded", "name=alice&AGE=30")
+
+		var got target
+
+		require.ErrorIs(t, req.Bind(&got), errFieldsNotSet)
+		assert.Equal(t, target{}, got)
+	})
+
+	t.Run("form-tag-overrides-field-name", func(t *testing.T) {
+		type tagged struct {
+			Name string `form:"user_name"`
+		}
+
+		req := newCharRequest(t, "/x",
+			"application/x-www-form-urlencoded", "user_name=alice&Name=bob")
+
+		var got tagged
+
+		require.NoError(t, req.Bind(&got))
+		assert.Equal(t, tagged{Name: "alice"}, got)
+	})
+
+	t.Run("no-matching-field-returns-errFieldsNotSet", func(t *testing.T) {
+		req := newCharRequest(t, "/x",
+			"application/x-www-form-urlencoded", "unknown=1")
+
+		var got target
+
+		err := req.Bind(&got)
+
+		require.ErrorIs(t, err, errFieldsNotSet)
+		assert.Equal(t, target{}, got)
+	})
+
+	t.Run("empty-body-returns-errFieldsNotSet", func(t *testing.T) {
+		req := newCharRequest(t, "/x", "application/x-www-form-urlencoded", "")
+
+		var got target
+
+		require.ErrorIs(t, req.Bind(&got), errFieldsNotSet)
+	})
+}
+
+// TestRequest_Char_BindFormURLEncodedErrors pins the form-urlencoded failure
+// modes and the query-string leak.
+func TestRequest_Char_BindFormURLEncodedErrors(t *testing.T) {
+	type target struct {
+		Name string
+		Age  int
+		OK   bool
+	}
+
+	t.Run("non-pointer-target-returns-errNonPointerBind", func(t *testing.T) {
+		req := newCharRequest(t, "/x",
+			"application/x-www-form-urlencoded", "Name=alice")
+
+		err := req.Bind(target{})
+
+		require.ErrorIs(t, err, errNonPointerBind)
+		assert.Equal(t, "bind error, cannot bind to a non pointer type", err.Error())
+	})
+
+	t.Run("malformed-escape-returns-parse-error", func(t *testing.T) {
+		req := newCharRequest(t, "/x",
+			"application/x-www-form-urlencoded", "Name=%zz")
+
+		var got target
+
+		err := req.Bind(&got)
+
+		require.Error(t, err)
+		assert.Equal(t, `invalid URL escape "%zz"`, err.Error())
+	})
+
+	// SHARP EDGE (pinned as-is): ParseForm merges the URL query into r.Form, so
+	// a query parameter can populate a body-bound field. A client can therefore
+	// set form fields via the URL even when the body does not mention them.
+	t.Run("query-string-leaks-into-form-binding", func(t *testing.T) {
+		req := newCharRequest(t, "/x?Age=99",
+			"application/x-www-form-urlencoded", "Name=alice")
+
+		var got target
+
+		require.NoError(t, req.Bind(&got))
+		assert.Equal(t, target{Name: "alice", Age: 99}, got)
+	})
+
+	// The raw strconv error is surfaced verbatim to the handler: it names no
+	// field, so the caller cannot tell WHICH input was bad.
+	t.Run("type-mismatch-surfaces-raw-strconv-error", func(t *testing.T) {
+		req := newCharRequest(t, "/x",
+			"application/x-www-form-urlencoded", "Name=alice&Age=notanumber")
+
+		var got target
+
+		err := req.Bind(&got)
+
+		require.Error(t, err)
+		assert.Equal(t, `strconv.ParseInt: parsing "notanumber": invalid syntax`, err.Error())
+	})
+}
+
+// TestRequest_Char_BindMultipartErrors pins the multipart failure modes.
+func TestRequest_Char_BindMultipartErrors(t *testing.T) {
+	type target struct {
+		Name string
+	}
+
+	t.Run("non-pointer-target-returns-errNonPointerBind", func(t *testing.T) {
+		req := newCharRequest(t, "/x", "multipart/form-data; boundary=xx", "")
+
+		require.ErrorIs(t, req.Bind(target{}), errNonPointerBind)
+	})
+
+	t.Run("missing-boundary-returns-parse-error", func(t *testing.T) {
+		req := newCharRequest(t, "/x", "multipart/form-data", "")
+
+		var got target
+
+		err := req.Bind(&got)
+
+		require.Error(t, err)
+		assert.Equal(t, "no multipart boundary param in Content-Type", err.Error())
+	})
+
+	t.Run("no-matching-field-returns-errNoFileFound", func(t *testing.T) {
+		body := "--xx\r\nContent-Disposition: form-data; name=\"other\"\r\n\r\nv\r\n--xx--\r\n"
+		req := newCharRequest(t, "/x", "multipart/form-data; boundary=xx", body)
+
+		var got target
+
+		err := req.Bind(&got)
+
+		require.ErrorIs(t, err, errNoFileFound)
+		assert.Equal(t, "no files were bounded", err.Error())
+	})
+
+	t.Run("valid-text-field-binds", func(t *testing.T) {
+		body := "--xx\r\nContent-Disposition: form-data; name=\"Name\"\r\n\r\nalice\r\n--xx--\r\n"
+		req := newCharRequest(t, "/x", "multipart/form-data; boundary=xx", body)
+
+		var got target
+
+		require.NoError(t, req.Bind(&got))
+		assert.Equal(t, target{Name: "alice"}, got)
+	})
+}
+
+// TestRequest_Char_BindBinary pins the binary/octet-stream path and its exact
+// error for a target that is not a *[]byte.
+func TestRequest_Char_BindBinary(t *testing.T) {
+	t.Run("binds-raw-bytes", func(t *testing.T) {
+		req := newCharRequest(t, "/x", "binary/octet-stream", "\x00\x01raw")
+
+		var got []byte
+
+		require.NoError(t, req.Bind(&got))
+		assert.Equal(t, []byte("\x00\x01raw"), got)
+	})
+
+	t.Run("empty-body-binds-empty-slice", func(t *testing.T) {
+		req := newCharRequest(t, "/x", "binary/octet-stream", "")
+
+		var got []byte
+
+		require.NoError(t, req.Bind(&got))
+		assert.Empty(t, got)
+	})
+
+	t.Run("wrong-target-type-error-message", func(t *testing.T) {
+		req := newCharRequest(t, "/x", "binary/octet-stream", "raw")
+
+		var got string
+
+		err := req.Bind(&got)
+
+		require.ErrorIs(t, err, errNonSliceBind)
+		// The message interpolates the target with %v, which for a pointer is a
+		// non-deterministic address — so only the stable prefix is pinned.
+		assert.True(t, strings.HasPrefix(err.Error(),
+			"bind error: input is not a pointer to a byte slice: 0x"), err.Error())
+	})
+}
+
+// TestRequest_Char_BodyIsReplayable pins that body() restores r.Body, so Bind
+// can be called more than once and downstream readers still see the payload.
+func TestRequest_Char_BodyIsReplayable(t *testing.T) {
+	req := newCharRequest(t, "/x", "application/json", `{"a":"x","b":5}`)
+
+	var first, second charBindTarget
+
+	require.NoError(t, req.Bind(&first))
+	require.NoError(t, req.Bind(&second))
+
+	assert.Equal(t, charBindTarget{A: "x", B: 5}, first)
+	assert.Equal(t, charBindTarget{A: "x", B: 5}, second)
+
+	// The raw body is still readable afterwards.
+	rest, err := io.ReadAll(req.req.Body)
+	require.NoError(t, err)
+	//nolint:testifylint // exact bytes are the contract.
+	assert.Equal(t, `{"a":"x","b":5}`, string(rest))
 }

--- a/pkg/gofr/http/responder_test.go
+++ b/pkg/gofr/http/responder_test.go
@@ -896,3 +896,862 @@ func BenchmarkResponderRespond(b *testing.B) {
 		r.Respond(data, nil)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Characterization suite.
+//
+// Everything below pins the CURRENT observable wire contract of Responder:
+// exact status code, exact Content-Type, exact body bytes. It is deliberately
+// exhaustive and deliberately literal — no Contains, no "not empty". A refactor
+// that changes any byte a client sees must fail here.
+// ---------------------------------------------------------------------------
+
+var (
+	errCharPlain = errors.New("plain failure")
+)
+
+// charError is an error carrying an arbitrary status code, used to pin the
+// StatusCodeResponder branch without depending on a concrete GoFr error type.
+type charError struct {
+	msg  string
+	code int
+}
+
+func (e charError) Error() string   { return e.msg }
+func (e charError) StatusCode() int { return e.code }
+
+// charMarshallerError implements both StatusCodeResponder and ResponseMarshaller
+// so the merge behavior of createErrorResponse is pinned by value type (the
+// existing CustomError is a pointer type).
+type charMarshallerError struct{}
+
+func (charMarshallerError) Error() string   { return "validation failed" }
+func (charMarshallerError) StatusCode() int { return http.StatusBadRequest }
+func (charMarshallerError) Response() map[string]any {
+	return map[string]any{"field": "email", "reason": "bad format"}
+}
+
+type charStruct struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type charOmit struct {
+	ID   int    `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// respondCase is one exact-bytes expectation for Respond.
+type respondCase struct {
+	name       string
+	method     string
+	data       any
+	err        error
+	wantStatus int
+	wantCType  string
+	wantBody   string
+}
+
+func runRespondCases(t *testing.T, cases []respondCase) {
+	t.Helper()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			NewResponder(w, tc.method).Respond(tc.data, tc.err)
+
+			assert.Equal(t, tc.wantStatus, w.Code, "status code")
+			assert.Equal(t, tc.wantCType, w.Header().Get("Content-Type"), "Content-Type")
+			assert.Equal(t, tc.wantBody, w.Body.String(), "body bytes")
+		})
+	}
+}
+
+// TestResponder_Char_SuccessEnvelope pins the success-path envelope for every
+// shape of data GoFr allows a handler to return, across every HTTP method whose
+// status mapping differs.
+func TestResponder_Char_SuccessEnvelope(t *testing.T) {
+	runRespondCases(t, []respondCase{
+		// --- nil data, per method -------------------------------------------
+		{"nil-get", http.MethodGet, nil, nil, http.StatusOK, "application/json", "{}\n"},
+		{"nil-post", http.MethodPost, nil, nil, http.StatusAccepted, "application/json", "{}\n"},
+		{"nil-put", http.MethodPut, nil, nil, http.StatusOK, "application/json", "{}\n"},
+		{"nil-patch", http.MethodPatch, nil, nil, http.StatusOK, "application/json", "{}\n"},
+		{"nil-delete", http.MethodDelete, nil, nil, http.StatusNoContent, "application/json", "{}\n"},
+		{"nil-head", http.MethodHead, nil, nil, http.StatusOK, "application/json", "{}\n"},
+		{"nil-options", http.MethodOptions, nil, nil, http.StatusOK, "application/json", "{}\n"},
+		{"nil-empty-method", "", nil, nil, http.StatusOK, "application/json", "{}\n"},
+
+		// --- primitives ------------------------------------------------------
+		{"string", http.MethodGet, "hello", nil, http.StatusOK, "application/json", "{\"data\":\"hello\"}\n"},
+		// NOTE: `data` carries `omitempty`, but its Go type is `any`, so only a
+		// nil INTERFACE is omitted. A zero-valued primitive is still emitted.
+		{"empty-string", http.MethodGet, "", nil, http.StatusOK, "application/json", "{\"data\":\"\"}\n"},
+		{"int", http.MethodGet, 42, nil, http.StatusOK, "application/json", "{\"data\":42}\n"},
+		{"zero-int", http.MethodGet, 0, nil, http.StatusOK, "application/json", "{\"data\":0}\n"},
+		{"negative-int", http.MethodGet, -7, nil, http.StatusOK, "application/json", "{\"data\":-7}\n"},
+		{"float", http.MethodGet, 3.5, nil, http.StatusOK, "application/json", "{\"data\":3.5}\n"},
+		{"bool-true", http.MethodGet, true, nil, http.StatusOK, "application/json", "{\"data\":true}\n"},
+		{"bool-false", http.MethodGet, false, nil, http.StatusOK, "application/json", "{\"data\":false}\n"},
+
+		// --- structs ----------------------------------------------------------
+		{
+			"struct", http.MethodGet, charStruct{ID: 1, Name: "a"}, nil,
+			http.StatusOK, "application/json", "{\"data\":{\"id\":1,\"name\":\"a\"}}\n",
+		},
+		{
+			"zero-struct-no-omitempty", http.MethodGet, charStruct{}, nil,
+			http.StatusOK, "application/json", "{\"data\":{\"id\":0,\"name\":\"\"}}\n",
+		},
+		{
+			"zero-struct-all-omitempty", http.MethodGet, charOmit{}, nil,
+			http.StatusOK, "application/json", "{\"data\":{}}\n",
+		},
+		{
+			"pointer-to-struct", http.MethodGet, &charStruct{ID: 2, Name: "b"}, nil,
+			http.StatusOK, "application/json", "{\"data\":{\"id\":2,\"name\":\"b\"}}\n",
+		},
+		// A typed nil pointer inside the interface: isNil() collapses it to nil
+		// for the BODY, but handleSuccess sees a non-nil interface, so a POST
+		// still reports 201 Created rather than 202 Accepted.
+		{"typed-nil-ptr-get", http.MethodGet, newNilTemp(), nil, http.StatusOK, "application/json", "{}\n"},
+		{"typed-nil-ptr-post", http.MethodPost, newNilTemp(), nil, http.StatusCreated, "application/json", "{}\n"},
+
+		// --- slices / arrays / maps -------------------------------------------
+		{"slice-of-int", http.MethodGet, []int{1, 2, 3}, nil, http.StatusOK, "application/json", "{\"data\":[1,2,3]}\n"},
+		{"empty-slice", http.MethodGet, []int{}, nil, http.StatusOK, "application/json", "{\"data\":[]}\n"},
+		// A nil SLICE is a non-nil interface, so it survives omitempty and the
+		// client sees an explicit `null` — unlike a nil POINTER, which isNil()
+		// collapses to an absent `data` key. Two ways to say "nothing".
+		{"nil-slice", http.MethodGet, []int(nil), nil, http.StatusOK, "application/json", "{\"data\":null}\n"},
+		{
+			"slice-of-struct", http.MethodGet, []charStruct{{ID: 1, Name: "a"}, {ID: 2, Name: "b"}}, nil,
+			http.StatusOK, "application/json", "{\"data\":[{\"id\":1,\"name\":\"a\"},{\"id\":2,\"name\":\"b\"}]}\n",
+		},
+		{"array", http.MethodGet, [2]int{9, 8}, nil, http.StatusOK, "application/json", "{\"data\":[9,8]}\n"},
+		{
+			"map-string-string", http.MethodGet, map[string]string{"k": "v"}, nil,
+			http.StatusOK, "application/json", "{\"data\":{\"k\":\"v\"}}\n",
+		},
+		{"empty-map", http.MethodGet, map[string]string{}, nil, http.StatusOK, "application/json", "{\"data\":{}}\n"},
+		{"nil-map", http.MethodGet, map[string]string(nil), nil, http.StatusOK, "application/json", "{\"data\":null}\n"},
+		// Map keys are emitted in sorted order by encoding/json, so this is
+		// deterministic despite Go's randomized map iteration.
+		{
+			"map-key-ordering", http.MethodGet, map[string]int{"z": 1, "a": 2, "m": 3}, nil,
+			http.StatusOK, "application/json", "{\"data\":{\"a\":2,\"m\":3,\"z\":1}}\n",
+		},
+	})
+}
+
+// TestResponder_Char_RawEnvelope pins resTypes.Raw: the envelope is bypassed
+// entirely and Data is written as the whole body.
+func TestResponder_Char_RawEnvelope(t *testing.T) {
+	runRespondCases(t, []respondCase{
+		{
+			"raw-map", http.MethodGet, resTypes.Raw{Data: map[string]string{"k": "v"}}, nil,
+			http.StatusOK, "application/json", "{\"k\":\"v\"}\n",
+		},
+		{"raw-string", http.MethodGet, resTypes.Raw{Data: "plain"}, nil, http.StatusOK, "application/json", "\"plain\"\n"},
+		{
+			"raw-slice", http.MethodGet, resTypes.Raw{Data: []int{1, 2}}, nil,
+			http.StatusOK, "application/json", "[1,2]\n",
+		},
+		// Raw{} is a zero struct, so a POST sees non-nil data and reports 201.
+		{"raw-nil-data-get", http.MethodGet, resTypes.Raw{}, nil, http.StatusOK, "application/json", "null\n"},
+		{"raw-nil-data-post", http.MethodPost, resTypes.Raw{Data: "x"}, nil, http.StatusCreated, "application/json", "\"x\"\n"},
+
+		// LATENT BUG (pinned as-is): when a handler returns a Raw alongside an
+		// error, the status becomes 206 Partial Content but the error object is
+		// silently DROPPED from the body — the client gets only Raw.Data and no
+		// indication of what failed.
+		{
+			"raw-with-error-drops-error", http.MethodGet, resTypes.Raw{Data: "partial"}, errCharPlain,
+			http.StatusPartialContent, "application/json", "\"partial\"\n",
+		},
+		// LATENT BUG (pinned as-is): Raw{} is an empty struct, so isEmptyStruct
+		// fires and the status becomes 500 with errEmptyResponse — but the body
+		// is still the raw `null`, not the error envelope.
+		{
+			"raw-empty-with-error", http.MethodGet, resTypes.Raw{}, errCharPlain,
+			http.StatusInternalServerError, "application/json", "null\n",
+		},
+	})
+}
+
+// TestResponder_Char_ResponseEnvelope pins resTypes.Response, including the
+// Metadata field and the fixed JSON field ordering (error, metadata, data).
+func TestResponder_Char_ResponseEnvelope(t *testing.T) {
+	runRespondCases(t, []respondCase{
+		{
+			"response-data-only", http.MethodGet,
+			resTypes.Response{Data: map[string]string{"k": "v"}}, nil,
+			http.StatusOK, "application/json", "{\"data\":{\"k\":\"v\"}}\n",
+		},
+		{
+			"response-with-metadata", http.MethodGet,
+			resTypes.Response{Data: "d", Metadata: map[string]any{"page": 1}}, nil,
+			http.StatusOK, "application/json", "{\"metadata\":{\"page\":1},\"data\":\"d\"}\n",
+		},
+		// Field order in the envelope is error, then metadata, then data.
+		{
+			"response-metadata-and-error-ordering", http.MethodGet,
+			resTypes.Response{Data: "d", Metadata: map[string]any{"page": 1}}, errCharPlain,
+			http.StatusPartialContent, "application/json",
+			"{\"error\":{\"message\":\"plain failure\"},\"metadata\":{\"page\":1},\"data\":\"d\"}\n",
+		},
+		{
+			"response-empty-metadata-omitted", http.MethodGet,
+			resTypes.Response{Data: "d", Metadata: map[string]any{}}, nil,
+			http.StatusOK, "application/json", "{\"data\":\"d\"}\n",
+		},
+		// Headers are declared `json:"-"` and are applied by the caller
+		// (handler.ServeHTTP), never by Respond.
+		{
+			"response-headers-not-serialized", http.MethodGet,
+			resTypes.Response{Data: "d", Headers: map[string]string{"X-A": "b"}}, nil,
+			http.StatusOK, "application/json", "{\"data\":\"d\"}\n",
+		},
+		// LATENT QUIRK (pinned as-is): resTypes.Response{} is a zero struct, so
+		// isEmptyStruct fires: the status becomes 500 AND the caller's real
+		// error is replaced by the generic "internal server error".
+		{
+			"response-empty-with-error", http.MethodGet,
+			resTypes.Response{}, errCharPlain,
+			http.StatusInternalServerError, "application/json", "{\"error\":{\"message\":\"internal server error\"}}\n",
+		},
+	})
+}
+
+// TestResponder_Char_ResponseHeadersNotApplied pins that Respond does NOT apply
+// resTypes.Response.Headers to the writer — that is handler.ServeHTTP's job.
+func TestResponder_Char_ResponseHeadersNotApplied(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	NewResponder(w, http.MethodGet).Respond(resTypes.Response{
+		Data:    "d",
+		Headers: map[string]string{"X-Custom": "v"},
+	}, nil)
+
+	assert.Empty(t, w.Header().Get("X-Custom"), "Respond must not set Response.Headers")
+}
+
+// TestResponder_Char_ErrorEnvelope pins the exact `{"error":{...}}` envelope and
+// status code for every error type GoFr maps, plus the generic branches.
+func TestResponder_Char_ErrorEnvelope(t *testing.T) {
+	runRespondCases(t, []respondCase{
+		// --- plain error (no StatusCodeResponder) -> 500 ----------------------
+		{
+			"plain-error", http.MethodGet, nil, errCharPlain,
+			http.StatusInternalServerError, "application/json", "{\"error\":{\"message\":\"plain failure\"}}\n",
+		},
+		// The method-based success mapping is NOT consulted on the error path:
+		// a failed DELETE is 500, not 204.
+		{
+			"plain-error-delete", http.MethodDelete, nil, errCharPlain,
+			http.StatusInternalServerError, "application/json", "{\"error\":{\"message\":\"plain failure\"}}\n",
+		},
+		{
+			"plain-error-post", http.MethodPost, nil, errCharPlain,
+			http.StatusInternalServerError, "application/json", "{\"error\":{\"message\":\"plain failure\"}}\n",
+		},
+
+		// --- GoFr status-coded errors ----------------------------------------
+		{
+			"entity-not-found", http.MethodGet, nil, ErrorEntityNotFound{Name: "id", Value: "2"},
+			http.StatusNotFound, "application/json", "{\"error\":{\"message\":\"No entity found with id: 2\"}}\n",
+		},
+		{
+			"entity-not-found-zero", http.MethodGet, nil, ErrorEntityNotFound{},
+			http.StatusNotFound, "application/json", "{\"error\":{\"message\":\"No entity found with : \"}}\n",
+		},
+		{
+			"entity-already-exists", http.MethodGet, nil, ErrorEntityAlreadyExist{},
+			http.StatusConflict, "application/json", "{\"error\":{\"message\":\"entity already exists\"}}\n",
+		},
+		// NOTE: ErrorInvalidParam has a `json:"param,omitempty"` tag, but it does
+		// NOT implement ResponseMarshaller, so the param list never reaches the
+		// wire — the client only ever sees the rendered message string.
+		{
+			"invalid-param", http.MethodGet, nil, ErrorInvalidParam{Params: []string{"a", "b"}},
+			http.StatusBadRequest, "application/json", "{\"error\":{\"message\":\"'2' invalid parameter(s): a, b\"}}\n",
+		},
+		{
+			"invalid-param-empty", http.MethodGet, nil, ErrorInvalidParam{},
+			http.StatusBadRequest, "application/json", "{\"error\":{\"message\":\"'0' invalid parameter(s): \"}}\n",
+		},
+		{
+			"missing-param", http.MethodGet, nil, ErrorMissingParam{Params: []string{"id"}},
+			http.StatusBadRequest, "application/json", "{\"error\":{\"message\":\"'1' missing parameter(s): id\"}}\n",
+		},
+		{
+			"invalid-route", http.MethodGet, nil, ErrorInvalidRoute{},
+			http.StatusNotFound, "application/json", "{\"error\":{\"message\":\"route not registered\"}}\n",
+		},
+		{
+			"request-timeout", http.MethodGet, nil, ErrorRequestTimeout{},
+			http.StatusRequestTimeout, "application/json", "{\"error\":{\"message\":\"request timed out\"}}\n",
+		},
+		{
+			"client-closed-request", http.MethodGet, nil, ErrorClientClosedRequest{},
+			StatusClientClosedRequest, "application/json", "{\"error\":{\"message\":\"client closed request\"}}\n",
+		},
+		{
+			"panic-recovery", http.MethodGet, nil, ErrorPanicRecovery{},
+			http.StatusInternalServerError, "application/json", "{\"error\":{\"message\":\"Internal Server Error\"}}\n",
+		},
+		{
+			"too-many-requests", http.MethodGet, nil, ErrorTooManyRequests{},
+			http.StatusTooManyRequests, "application/json", "{\"error\":{\"message\":\"rate limit exceeded\"}}\n",
+		},
+		{
+			"service-unavailable-bare", http.MethodGet, nil, ErrorServiceUnavailable{},
+			http.StatusServiceUnavailable, "application/json", "{\"error\":{\"message\":\"Service Unavailable\"}}\n",
+		},
+		{
+			"service-unavailable-detailed", http.MethodGet, nil,
+			ErrorServiceUnavailable{Dependency: "redis", ErrorMessage: "dial fail"},
+			http.StatusServiceUnavailable, "application/json",
+			"{\"error\":{\"message\":\"Service unavailable due to error: dial fail from dependency redis\"}}\n",
+		},
+	})
+}
+
+// TestResponder_Char_ErrorEnvelopeEdges pins the remaining error-path branches:
+// arbitrary status codes, the ResponseMarshaller merge, the 206 partial-content
+// rule and the empty-struct short circuit.
+func TestResponder_Char_ErrorEnvelopeEdges(t *testing.T) {
+	runRespondCases(t, []respondCase{
+		// --- arbitrary status-coded error ------------------------------------
+		{
+			"custom-status-code", http.MethodGet, nil, charError{msg: "teapot", code: http.StatusTeapot},
+			http.StatusTeapot, "application/json", "{\"error\":{\"message\":\"teapot\"}}\n",
+		},
+		// A StatusCodeResponder reporting 0 is normalized to 500 by
+		// determineResponse.
+		{
+			"zero-status-code-normalized-to-500", http.MethodGet, nil, charError{msg: "zero", code: 0},
+			http.StatusInternalServerError, "application/json", "{\"error\":{\"message\":\"zero\"}}\n",
+		},
+
+		// --- ResponseMarshaller merge ----------------------------------------
+		// Extra fields are merged in alongside "message"; keys are emitted in
+		// sorted order because the error object is a map.
+		{
+			"response-marshaller-merge", http.MethodGet, nil, charMarshallerError{},
+			http.StatusBadRequest, "application/json",
+			"{\"error\":{\"field\":\"email\",\"message\":\"validation failed\",\"reason\":\"bad format\"}}\n",
+		},
+
+		// --- data + error -> 206 Partial Content ------------------------------
+		// NOTE: the error's own StatusCode() is ignored entirely when data is
+		// non-nil; a 404 alongside partial data is reported as 206.
+		{
+			"data-plus-statuscoded-error-is-206", http.MethodGet, map[string]string{"k": "v"},
+			ErrorEntityNotFound{Name: "id", Value: "9"},
+			http.StatusPartialContent, "application/json",
+			"{\"error\":{\"message\":\"No entity found with id: 9\"},\"data\":{\"k\":\"v\"}}\n",
+		},
+		// A typed nil pointer counts as nil here, so the error's status wins.
+		{
+			"typed-nil-data-plus-error-uses-error-status", http.MethodGet, newNilTemp(), ErrorEntityNotFound{},
+			http.StatusNotFound, "application/json", "{\"error\":{\"message\":\"No entity found with : \"}}\n",
+		},
+
+		// --- empty-struct short circuit ---------------------------------------
+		// LATENT QUIRK (pinned as-is): when data is a zero-valued struct AND an
+		// error is present, determineResponse replaces the status with 500 and
+		// the error object with the generic "internal server error" — the real
+		// error is lost. The zero struct is still serialized into `data`.
+		{
+			"empty-struct-plus-error", http.MethodGet, charStruct{}, ErrorEntityNotFound{Name: "id", Value: "1"},
+			http.StatusInternalServerError, "application/json",
+			"{\"error\":{\"message\":\"internal server error\"},\"data\":{\"id\":0,\"name\":\"\"}}\n",
+		},
+		// ...but a POINTER to a zero struct escapes the short circuit, because
+		// isEmptyStruct dereferences for the Kind check yet compares the
+		// original pointer against a zero STRUCT. Different behavior for
+		// semantically identical data.
+		{
+			"pointer-to-empty-struct-plus-error", http.MethodGet, &charStruct{}, ErrorEntityNotFound{Name: "id", Value: "1"},
+			http.StatusPartialContent, "application/json",
+			"{\"error\":{\"message\":\"No entity found with id: 1\"},\"data\":{\"id\":0,\"name\":\"\"}}\n",
+		},
+		// A zero struct whose fields are all omitempty still serializes as `{}`
+		// under `data`, so the client cannot distinguish it from "no data".
+		{
+			"empty-omitempty-struct-plus-error", http.MethodGet, charOmit{}, errCharPlain,
+			http.StatusInternalServerError, "application/json",
+			"{\"error\":{\"message\":\"internal server error\"},\"data\":{}}\n",
+		},
+	})
+}
+
+// TestResponder_Char_JSONEscaping pins encoding/json's default HTML escaping.
+// GoFr uses json.Encoder without SetEscapeHTML(false), so <, > and & become
+// \u003c, \u003e and \u0026 on the wire, and U+2028/U+2029 are escaped too.
+func TestResponder_Char_JSONEscaping(t *testing.T) {
+	runRespondCases(t, []respondCase{
+		{
+			"html-angle-brackets", http.MethodGet, "<script>alert(1)</script>", nil,
+			http.StatusOK, "application/json",
+			"{\"data\":\"\\u003cscript\\u003ealert(1)\\u003c/script\\u003e\"}\n",
+		},
+		{
+			"ampersand", http.MethodGet, "a & b", nil,
+			http.StatusOK, "application/json", "{\"data\":\"a \\u0026 b\"}\n",
+		},
+		{
+			"double-quote-and-backslash", http.MethodGet, `he said "hi" \ bye`, nil,
+			http.StatusOK, "application/json", "{\"data\":\"he said \\\"hi\\\" \\\\ bye\"}\n",
+		},
+		{
+			"control-chars", http.MethodGet, "line1\nline2\ttab", nil,
+			http.StatusOK, "application/json", "{\"data\":\"line1\\nline2\\ttab\"}\n",
+		},
+		// Non-ASCII is emitted as raw UTF-8, not \u escapes.
+		{
+			"unicode-passthrough", http.MethodGet, "héllo 世界 🚀", nil,
+			http.StatusOK, "application/json", "{\"data\":\"héllo 世界 🚀\"}\n",
+		},
+		// U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR are escaped so the
+		// body is safe to embed in a <script> tag.
+		{
+			"line-separator-escaped", http.MethodGet, "a\u2028b\u2029c", nil,
+			http.StatusOK, "application/json", "{\"data\":\"a\\u2028b\\u2029c\"}\n",
+		},
+		// Escaping applies to map KEYS too.
+		{
+			"escaped-map-key", http.MethodGet, map[string]string{"<k>": "&v"}, nil,
+			http.StatusOK, "application/json", "{\"data\":{\"\\u003ck\\u003e\":\"\\u0026v\"}}\n",
+		},
+		// ...and to the error message.
+		{
+			//nolint:err113 // characterizing a caller-supplied ad-hoc error.
+			"escaped-error-message", http.MethodGet, nil, errors.New("bad <input> & stuff"),
+			http.StatusInternalServerError, "application/json",
+			"{\"error\":{\"message\":\"bad \\u003cinput\\u003e \\u0026 stuff\"}}\n",
+		},
+		// Raw bypasses the envelope but NOT the escaping.
+		{
+			"raw-is-still-escaped", http.MethodGet, resTypes.Raw{Data: "<b>"}, nil,
+			http.StatusOK, "application/json", "\"\\u003cb\\u003e\"\n",
+		},
+	})
+}
+
+// TestResponder_Char_ContentTypeNotOverwritten pins that a Content-Type already
+// set on the writer is preserved — Respond only defaults it when unset.
+func TestResponder_Char_ContentTypeNotOverwritten(t *testing.T) {
+	tests := []struct {
+		name    string
+		preset  string
+		wantCTy string
+	}{
+		{"unset-defaults-to-json", "", "application/json"},
+		{"preset-preserved", "application/vnd.api+json", "application/vnd.api+json"},
+		{"preset-text-preserved", "text/plain", "text/plain"},
+		{"preset-with-charset-preserved", "application/json; charset=utf-8", "application/json; charset=utf-8"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			if tc.preset != "" {
+				w.Header().Set("Content-Type", tc.preset)
+			}
+
+			NewResponder(w, http.MethodGet).Respond("x", nil)
+
+			assert.Equal(t, tc.wantCTy, w.Header().Get("Content-Type"))
+			// The body is unaffected by the Content-Type; it is always JSON.
+			assert.JSONEq(t, `{"data":"x"}`, w.Body.String())
+		})
+	}
+}
+
+// TestResponder_Char_EncodeFailure pins the fallback written when the payload
+// cannot be JSON-encoded. Note the body has a space after "message": and the
+// status is written AFTER Content-Type has already been set to application/json.
+func TestResponder_Char_EncodeFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		data any
+	}{
+		{"channel", make(chan int)},
+		{"func", func() {}},
+		{"nan", math.NaN()},
+		{"inf", math.Inf(1)},
+		{"map-with-unencodable-value", map[string]any{"c": make(chan int)}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			NewResponder(w, http.MethodGet).Respond(tc.data, nil)
+
+			assert.Equal(t, http.StatusInternalServerError, w.Code)
+			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			//nolint:testifylint // exact bytes are the contract: note the space after the colon.
+			assert.Equal(t, "{\"error\":{\"message\": \"failed to encode response as JSON\"}}\n", w.Body.String())
+		})
+	}
+}
+
+// TestResponder_Char_File pins the File special response type.
+func TestResponder_Char_File(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		file       resTypes.File
+		err        error
+		wantStatus int
+		wantCType  string
+		wantBody   string
+	}{
+		{
+			"png-get", http.MethodGet,
+			resTypes.File{Content: []byte{0x89, 'P', 'N', 'G'}, ContentType: "image/png"}, nil,
+			http.StatusOK, "image/png", "\x89PNG",
+		},
+		{
+			"post-is-201", http.MethodPost,
+			resTypes.File{Content: []byte("x"), ContentType: "text/csv"}, nil,
+			http.StatusCreated, "text/csv", "x",
+		},
+		{
+			"delete-is-204", http.MethodDelete,
+			resTypes.File{Content: []byte("x"), ContentType: "text/csv"}, nil,
+			http.StatusNoContent, "text/csv", "x",
+		},
+		// Empty ContentType is written verbatim as an empty header value rather
+		// than being defaulted or sniffed.
+		{
+			"empty-content-type", http.MethodGet,
+			resTypes.File{Content: []byte("x")}, nil,
+			http.StatusOK, "", "x",
+		},
+		{
+			"empty-content", http.MethodGet,
+			resTypes.File{ContentType: "text/plain"}, nil,
+			http.StatusOK, "text/plain", "",
+		},
+		// With an error the status comes from the error, NOT 206 — and the body
+		// is still the file bytes, so the client gets no error detail at all.
+		{
+			"with-status-coded-error", http.MethodGet,
+			resTypes.File{Content: []byte("x"), ContentType: "text/plain"}, ErrorEntityNotFound{Name: "id", Value: "1"},
+			http.StatusNotFound, "text/plain", "x",
+		},
+		{
+			"with-plain-error", http.MethodGet,
+			resTypes.File{Content: []byte("x"), ContentType: "text/plain"}, errCharPlain,
+			http.StatusInternalServerError, "text/plain", "x",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			NewResponder(w, tc.method).Respond(tc.file, tc.err)
+
+			assert.Equal(t, tc.wantStatus, w.Code, "status code")
+			assert.Equal(t, tc.wantCType, w.Header().Get("Content-Type"), "Content-Type")
+			assert.Equal(t, tc.wantBody, w.Body.String(), "body bytes")
+		})
+	}
+}
+
+// TestResponder_Char_XML pins the XML special response type, including the
+// application/xml default and the "no write for empty content" branch.
+func TestResponder_Char_XML(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		xml        resTypes.XML
+		err        error
+		wantStatus int
+		wantCType  string
+		wantBody   string
+	}{
+		{
+			"default-content-type", http.MethodGet,
+			resTypes.XML{Content: []byte("<a>1</a>")}, nil,
+			http.StatusOK, "application/xml", "<a>1</a>",
+		},
+		{
+			"explicit-content-type", http.MethodGet,
+			resTypes.XML{Content: []byte("<a/>"), ContentType: "application/rss+xml"}, nil,
+			http.StatusOK, "application/rss+xml", "<a/>",
+		},
+		{
+			"empty-content-writes-nothing", http.MethodGet,
+			resTypes.XML{}, nil,
+			http.StatusOK, "application/xml", "",
+		},
+		{
+			"post-is-201", http.MethodPost,
+			resTypes.XML{Content: []byte("<a/>")}, nil,
+			http.StatusCreated, "application/xml", "<a/>",
+		},
+		{
+			"delete-is-204", http.MethodDelete,
+			resTypes.XML{Content: []byte("<a/>")}, nil,
+			http.StatusNoContent, "application/xml", "<a/>",
+		},
+		// XML content is written verbatim — no escaping, no envelope.
+		{
+			"content-written-verbatim", http.MethodGet,
+			resTypes.XML{Content: []byte("<a>&amp; \"x\" <b/></a>")}, nil,
+			http.StatusOK, "application/xml", "<a>&amp; \"x\" <b/></a>",
+		},
+		{
+			"with-status-coded-error", http.MethodGet,
+			resTypes.XML{Content: []byte("<a/>")}, ErrorInvalidParam{Params: []string{"p"}},
+			http.StatusBadRequest, "application/xml", "<a/>",
+		},
+		{
+			"with-plain-error", http.MethodGet,
+			resTypes.XML{Content: []byte("<a/>")}, errCharPlain,
+			http.StatusInternalServerError, "application/xml", "<a/>",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			NewResponder(w, tc.method).Respond(tc.xml, tc.err)
+
+			assert.Equal(t, tc.wantStatus, w.Code, "status code")
+			assert.Equal(t, tc.wantCType, w.Header().Get("Content-Type"), "Content-Type")
+			assert.Equal(t, tc.wantBody, w.Body.String(), "body bytes")
+		})
+	}
+}
+
+// TestResponder_Char_Redirect pins the Redirect special response type. The
+// status depends ONLY on the HTTP method, never on the error, and no body is
+// written.
+func TestResponder_Char_Redirect(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		url        string
+		err        error
+		wantStatus int
+	}{
+		{"get-is-302", http.MethodGet, "/target", nil, http.StatusFound},
+		{"head-is-302", http.MethodHead, "/target", nil, http.StatusFound},
+		{"delete-is-302", http.MethodDelete, "/target", nil, http.StatusFound},
+		{"options-is-302", http.MethodOptions, "/target", nil, http.StatusFound},
+		{"post-is-303", http.MethodPost, "/target", nil, http.StatusSeeOther},
+		{"put-is-303", http.MethodPut, "/target", nil, http.StatusSeeOther},
+		{"patch-is-303", http.MethodPatch, "/target", nil, http.StatusSeeOther},
+		// The error is ignored completely for redirects.
+		{"get-with-error-still-302", http.MethodGet, "/target", ErrorEntityNotFound{}, http.StatusFound},
+		{"post-with-error-still-303", http.MethodPost, "/target", errCharPlain, http.StatusSeeOther},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			NewResponder(w, tc.method).Respond(resTypes.Redirect{URL: tc.url}, tc.err)
+
+			assert.Equal(t, tc.wantStatus, w.Code, "status code")
+			assert.Equal(t, tc.url, w.Header().Get("Location"), "Location")
+			assert.Empty(t, w.Body.String(), "redirect must write no body")
+			// Content-Type is never set for a redirect.
+			assert.Empty(t, w.Header().Get("Content-Type"), "Content-Type")
+		})
+	}
+}
+
+// TestResponder_Char_RedirectURLVerbatim pins that the Location header is the
+// URL string exactly as given — no normalization, no escaping, no validation.
+func TestResponder_Char_RedirectURLVerbatim(t *testing.T) {
+	for _, url := range []string{
+		"",
+		"https://example.com/a?b=c&d=e#frag",
+		"/relative path with spaces",
+		"javascript:alert(1)",
+	} {
+		w := httptest.NewRecorder()
+
+		NewResponder(w, http.MethodGet).Respond(resTypes.Redirect{URL: url}, nil)
+
+		assert.Equal(t, url, w.Header().Get("Location"))
+	}
+}
+
+// TestResponder_Char_Template pins the Template special response type: the
+// Content-Type is always text/html (never charset-qualified) and the rendered
+// bytes are html/template output with its own contextual escaping.
+func TestResponder_Char_Template(t *testing.T) {
+	createTemplateFile(t, "./templates/char.html", "<h1>{{.Title}}</h1>")
+
+	defer removeTemplateDir(t)
+
+	tests := []struct {
+		name       string
+		method     string
+		data       any
+		err        error
+		wantStatus int
+		wantBody   string
+	}{
+		{"get-is-200", http.MethodGet, map[string]string{"Title": "Hi"}, nil, http.StatusOK, "<h1>Hi</h1>"},
+		{"post-is-201", http.MethodPost, map[string]string{"Title": "Hi"}, nil, http.StatusCreated, "<h1>Hi</h1>"},
+		// LATENT BUG (pinned as-is): a Template returned from a DELETE handler
+		// gets status 204, and the HTTP layer rejects a body on a 204. Because
+		// html/template writes incrementally and Render discards Execute's
+		// error, the client receives a TRUNCATED page (only the first text
+		// node) rather than either the full page or an error.
+		{"delete-is-204", http.MethodDelete, map[string]string{"Title": "Hi"}, nil, http.StatusNoContent, "<h1>"},
+		{
+			"with-status-coded-error", http.MethodGet, map[string]string{"Title": "Hi"},
+			ErrorEntityNotFound{}, http.StatusNotFound, "<h1>Hi</h1>",
+		},
+		{
+			"with-plain-error", http.MethodGet, map[string]string{"Title": "Hi"},
+			errCharPlain, http.StatusInternalServerError, "<h1>Hi</h1>",
+		},
+		// html/template applies contextual escaping of its own — this is NOT the
+		// JSON \u003c escaping used by the envelope path.
+		{
+			"html-escaped-by-html-template", http.MethodGet, map[string]string{"Title": "<b>&x</b>"},
+			nil, http.StatusOK, "<h1>&lt;b&gt;&amp;x&lt;/b&gt;</h1>",
+		},
+		// A missing field renders as the literal Go zero-value marker.
+		{"missing-field", http.MethodGet, map[string]string{}, nil, http.StatusOK, "<h1></h1>"},
+		{"nil-data", http.MethodGet, nil, nil, http.StatusOK, "<h1></h1>"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			NewResponder(w, tc.method).Respond(resTypes.Template{Name: "char.html", Data: tc.data}, tc.err)
+
+			assert.Equal(t, tc.wantStatus, w.Code, "status code")
+			assert.Equal(t, "text/html", w.Header().Get("Content-Type"), "Content-Type")
+			assert.Equal(t, tc.wantBody, w.Body.String(), "body bytes")
+		})
+	}
+}
+
+// TestResponder_Char_TemplatePointerIsNotSpecial pins a sharp edge: the type
+// switch matches resTypes.Template by VALUE, so returning *resTypes.Template
+// falls through to the JSON envelope instead of rendering. Reported, not fixed.
+func TestResponder_Char_TemplatePointerIsNotSpecial(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	NewResponder(w, http.MethodGet).Respond(&resTypes.Template{Name: "char.html", Data: "x"}, nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	//nolint:testifylint // exact bytes are the contract.
+	assert.Equal(t, "{\"data\":{\"Data\":\"x\",\"Name\":\"char.html\"}}\n", w.Body.String())
+}
+
+// TestResponder_Char_SpecialTypePointersFallThrough pins that every special
+// response type is matched by value only; a pointer to one is JSON-encoded.
+func TestResponder_Char_SpecialTypePointersFallThrough(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     any
+		wantBody string
+	}{
+		{"file-ptr", &resTypes.File{Content: []byte("ab"), ContentType: "text/plain"},
+			"{\"data\":{\"Content\":\"YWI=\",\"ContentType\":\"text/plain\"}}\n"},
+		{"xml-ptr", &resTypes.XML{Content: []byte("<a/>")},
+			"{\"data\":{\"Content\":\"PGEvPg==\",\"ContentType\":\"\"}}\n"},
+		{"redirect-ptr", &resTypes.Redirect{URL: "/x"}, "{\"data\":{\"URL\":\"/x\"}}\n"},
+		{"raw-ptr", &resTypes.Raw{Data: "x"}, "{\"data\":{\"Data\":\"x\"}}\n"},
+		{"response-ptr", &resTypes.Response{Data: "x"}, "{\"data\":{\"data\":\"x\"}}\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			NewResponder(w, http.MethodGet).Respond(tc.data, nil)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			assert.Equal(t, tc.wantBody, w.Body.String())
+		})
+	}
+}
+
+// TestResponder_Char_StreamHeaders pins the full header set and status of a
+// Stream response, and that an error returned alongside a Stream is ignored.
+func TestResponder_Char_StreamHeaders(t *testing.T) {
+	t.Run("sse", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		NewResponder(w, http.MethodPost).
+			Respond(resTypes.Stream{Source: &sliceSource{items: []any{"a"}}}, ErrorEntityNotFound{})
+
+		// Always 200, even for POST and even with an error present.
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+		assert.Equal(t, "no-cache", w.Header().Get("Cache-Control"))
+		assert.Equal(t, "keep-alive", w.Header().Get("Connection"))
+		assert.Equal(t, "data: \"a\"\n\ndata: [DONE]\n\n", w.Body.String())
+	})
+
+	t.Run("ndjson", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		NewResponder(w, http.MethodGet).
+			Respond(resTypes.Stream{Source: &sliceSource{items: []any{"a"}}, Format: resTypes.NDJSON}, nil)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/x-ndjson", w.Header().Get("Content-Type"))
+		// NDJSON does NOT set Cache-Control / Connection.
+		assert.Empty(t, w.Header().Get("Cache-Control"))
+		assert.Empty(t, w.Header().Get("Connection"))
+		// NDJSON has no [DONE] terminator.
+		assert.Equal(t, "\"a\"\n", w.Body.String())
+	})
+
+	t.Run("nil-source", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		NewResponder(w, http.MethodGet).Respond(resTypes.Stream{}, nil)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		// No Content-Type is set on the nil-source path.
+		assert.Empty(t, w.Header().Get("Content-Type"))
+		//nolint:testifylint // exact bytes are the contract.
+		assert.Equal(t, "{\"error\":{\"message\":\"stream source is nil\"}}\n", w.Body.String())
+	})
+}
+
+// TestResponder_Char_NoBodyForDeleteIsStillWritten pins that GoFr writes a JSON
+// body even with 204 No Content, which is a protocol violation net/http will
+// suppress on a real connection but which the responder itself does emit.
+func TestResponder_Char_NoBodyForDeleteIsStillWritten(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	NewResponder(w, http.MethodDelete).Respond(map[string]string{"k": "v"}, nil)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	//nolint:testifylint // exact bytes are the contract.
+	assert.Equal(t, "{\"data\":{\"k\":\"v\"}}\n", w.Body.String())
+}
+
+// TestResponder_Char_MethodCaseSensitivity pins that method matching is exact —
+// a lowercase "post" does not get the 201 mapping.
+func TestResponder_Char_MethodCaseSensitivity(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	NewResponder(w, "post").Respond("x", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}


### PR DESCRIPTION
## Summary

Companion to #3766, covering the rest of what a request touches: the responder, request binding, the handler execution paths, and the WebSocket upgrade. Tests only — no production line is modified (`4 files changed, 2114 insertions(+)`, zero deletions).

Same rationale: coverage of these files was already high, but almost nothing asserted the observable result, so a refactor could change a status code, a `Content-Type` or the JSON envelope and every test would still pass. Every assertion is literal — exact status, exact `Content-Type`, exact body bytes including the trailing newline.

~297 cases.

## What's pinned

- **responder** — the success envelope across methods × nil/primitive/struct/pointer/typed-nil/slice/map; `Raw` and `Response` (incl. `Metadata` and field order); the full error matrix for every GoFr error type plus plain errors and custom status responders; 206 partial content; JSON HTML escaping; the `Content-Type` default-vs-preserve rule; the encode-failure fallback; and the special types (`File`, `XML`, `Redirect`, `Template`, `Stream`).
- **request** — `Param` / `Params` / `PathParam` / `HostName` / `Context`, and `Bind` for JSON, form-urlencoded, multipart and binary, with the exact stdlib and sentinel error strings for malformed bodies, wrong content types and type mismatches.
- **handler** — `serveInline` and `serveWithGoroutine` asserted against the **same** expectations so the two paths cannot drift; panic recovery on both, with explicit assertions that the panic value and stack never leak to the client; the 408 timeout; 499 client cancellation; and the WebSocket bypass.
- **web_socket** — non-upgrade passthrough byte-identical to the inner handler, upgrade-failure wire shape, and upgrade-success registration.

## Behaviour found and characterized, not fixed

Recording current behaviour surfaced several defects, pinned as-is here and addressed separately:

- `Respond(Raw{...}, err)` returns 206 and **drops the error entirely** — no error field at all.
- A zero-valued struct plus an error is forced to 500 with the caller's error **replaced** by a generic `"internal server error"`, while a *pointer* to the same zero struct returns 206 with the real message. `isEmptyStruct` dereferences for the `Kind()` check but then compares the original pointer against a zero struct.
- All special response types match **by value only**, so `*Redirect` / `*Template` / `*File` / `*XML` fall through to the JSON envelope — a `*Redirect` returns 200 with a JSON body and no `Location` header.
- `Bind` to a non-pointer is a silent no-op; `Content-Type` matching is case-sensitive and untrimmed, so `Application/json` binds nothing without error; `ParseForm` merges the query string into body binding.

## Tests

`go test -race ./pkg/gofr/http/...` green. `golangci-lint --new-from-rev` reports 0 issues. (`go test ./pkg/gofr/` fails on a metrics port bind that reproduces identically on unmodified `development`.)
