### PR TITLE
fix(middleware): CORS origin override, panic log ordering, metric labels and 5xx spans

### DIFF
--- a/pkg/gofr/http/middleware/cors.go
+++ b/pkg/gofr/http/middleware/cors.go
@@ -7,6 +7,10 @@ import (
 
 const (
 	allowedHeaders = "Authorization, Content-Type, x-requested-with, origin, true-client-ip, X-Correlation-ID"
+
+	headerAllowOrigin  = "Access-Control-Allow-Origin"
+	headerAllowMethods = "Access-Control-Allow-Methods"
+	headerAllowHeaders = "Access-Control-Allow-Headers"
 )
 
 // CORS is a middleware that adds CORS (Cross-Origin Resource Sharing) headers to the response.
@@ -15,7 +19,7 @@ const (
 // the middleware dynamically matches the request's Origin header and responds
 // with the matched origin, adding a Vary: Origin header for correct caching.
 func CORS(middlewareConfigs map[string]string, routes *[]string) func(inner http.Handler) http.Handler {
-	allowedOrigins := parseOrigins(middlewareConfigs["Access-Control-Allow-Origin"])
+	allowedOrigins := parseOrigins(middlewareConfigs[headerAllowOrigin])
 
 	return func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -34,25 +38,23 @@ func CORS(middlewareConfigs map[string]string, routes *[]string) func(inner http
 func setMiddlewareHeaders(middlewareConfigs map[string]string, routes []string,
 	w http.ResponseWriter, origin string, allowedOrigins map[string]bool,
 ) {
-	routes = append(routes, "OPTIONS")
-
 	// Handle Access-Control-Allow-Origin separately for dynamic matching.
 	if allowedOrigins["*"] {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set(headerAllowOrigin, "*")
 	} else if allowedOrigins[origin] {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set(headerAllowOrigin, origin)
 		w.Header().Add("Vary", "Origin")
 	}
 
 	// Set default headers (excluding origin, handled above)
 	defaultHeaders := map[string]string{
-		"Access-Control-Allow-Methods": strings.Join(routes, ", "),
-		"Access-Control-Allow-Headers": allowedHeaders,
+		headerAllowMethods: joinAllowedMethods(routes),
+		headerAllowHeaders: allowedHeaders,
 	}
 
 	for header, defaultValue := range defaultHeaders {
 		if customValue, ok := middlewareConfigs[header]; ok && customValue != "" {
-			if header == "Access-Control-Allow-Headers" {
+			if header == headerAllowHeaders {
 				w.Header().Set(header, defaultValue+", "+customValue)
 			} else {
 				w.Header().Set(header, customValue)
@@ -62,12 +64,38 @@ func setMiddlewareHeaders(middlewareConfigs map[string]string, routes []string,
 		}
 	}
 
-	// Handle additional custom headers (not part of defaultHeaders or origin)
+	// Handle additional custom headers (not part of defaultHeaders or origin).
+	//
+	// The origin is compared on its canonical header form: HTTP header names are
+	// case-insensitive and Header.Set canonicalizes whatever it is given, so a
+	// differently-cased spelling ("access-control-allow-origin") would otherwise
+	// pass this guard and still land on Access-Control-Allow-Origin — silently
+	// replacing the origin negotiated against the configured allow-list above.
 	for header, customValue := range middlewareConfigs {
-		if _, ok := defaultHeaders[header]; !ok && header != "Access-Control-Allow-Origin" {
-			w.Header().Set(header, customValue)
+		if _, ok := defaultHeaders[header]; ok {
+			continue
 		}
+
+		if http.CanonicalHeaderKey(header) == headerAllowOrigin {
+			continue
+		}
+
+		w.Header().Set(header, customValue)
 	}
+}
+
+// joinAllowedMethods renders the Access-Control-Allow-Methods value: the
+// registered routes plus OPTIONS.
+//
+// It deliberately does not append to routes. That slice shares its backing
+// array with the caller's (the router's RegisteredRoutes), so appending in
+// place writes "OPTIONS" over the caller's next element whenever cap > len.
+func joinAllowedMethods(routes []string) string {
+	if len(routes) == 0 {
+		return http.MethodOptions
+	}
+
+	return strings.Join(routes, ", ") + ", " + http.MethodOptions
 }
 
 // parseOrigins splits a comma-separated origin string into a set.

--- a/pkg/gofr/http/middleware/cors_test.go
+++ b/pkg/gofr/http/middleware/cors_test.go
@@ -621,21 +621,27 @@ func corsCharGarbageKeyCases() []corsCharCase {
 			},
 			expCode: http.StatusFound, expBody: corsCharBody, expInner: 1,
 		},
+		// The two cases below guard the origin-override fix. A config key is
+		// compared on its canonical header form, so a differently-cased
+		// spelling can no longer reach Access-Control-Allow-Origin through the
+		// custom-header loop and replace the negotiated value.
 		{
-			name:   "lower cased origin key escapes the guard and overwrites the negotiated origin",
+			name:   "lower cased origin key cannot inject an origin through the custom header loop",
 			config: map[string]string{"access-control-allow-origin": corsCharOriginEvil}, method: http.MethodGet, routes: twoRoutes,
-			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine(corsCharOriginEvil)},
+			// No origin was negotiated (the allow-list is unset, so it is the
+			// "*" default) and the custom loop must not emit one of its own.
+			expLines: []string{corsCharAllowHeadersLine, baseMethods, corsCharOriginLine("*")},
 			expCode:  http.StatusFound, expBody: corsCharBody, expInner: 1,
 		},
 		{
-			name: "lower cased origin key overwrites a properly negotiated origin but Vary survives",
+			name: "lower cased origin key cannot overwrite a properly negotiated origin",
 			config: map[string]string{
 				corsCharKeyOrigin:             corsCharOriginA,
 				"access-control-allow-origin": corsCharOriginEvil,
 			},
 			method: http.MethodGet, origin: corsCharOriginA, routes: twoRoutes,
 			expLines: []string{
-				corsCharAllowHeadersLine, baseMethods, corsCharOriginLine(corsCharOriginEvil), corsCharVaryLine,
+				corsCharAllowHeadersLine, baseMethods, corsCharOriginLine(corsCharOriginA), corsCharVaryLine,
 			},
 			expCode: http.StatusFound, expBody: corsCharBody, expInner: 1,
 		},
@@ -739,21 +745,22 @@ func Test_CORSContract_RoutesBackingArrayAliasing(t *testing.T) {
 	w, _ := corsCharRun(t, nil, &routes, http.MethodGet, "")
 	require.Equal(t, "GET, OPTIONS", w.Header().Get(corsCharKeyMethods))
 
-	// The caller's slice length is untouched...
-	assert.Equal(t, []string{http.MethodGet}, routes)
-	// ...but index 1 of the shared backing array was overwritten in place.
-	assert.Equal(t, []string{http.MethodGet, "OPTIONS", "SENTINEL-2", "SENTINEL-3"}, backing)
-	assert.Equal(t, "OPTIONS", backing[1], "SENTINEL-1 was clobbered by the middleware")
+	// The middleware must not write through the shared backing array. It used to
+	// build the header with append(routes, "OPTIONS"), which stores into the
+	// caller's array whenever cap > len — silently replacing the element after
+	// the caller's length. Here that would clobber SENTINEL-1.
+	assert.Equal(t, []string{http.MethodGet}, routes, "caller's slice must be untouched")
+	assert.Equal(t, []string{http.MethodGet, "SENTINEL-1", "SENTINEL-2", "SENTINEL-3"}, backing,
+		"the caller's backing array must be left intact")
 
-	// A later caller-side append overwrites the injected "OPTIONS" again, so the
-	// caller never observes corruption of its own logical contents.
+	// A caller-side append still behaves normally afterwards, and the next
+	// request reflects the newly registered route.
 	routes = append(routes, http.MethodPost)
 	assert.Equal(t, []string{http.MethodGet, http.MethodPost}, routes)
-	assert.Equal(t, http.MethodPost, backing[1])
 
 	w2, _ := corsCharRun(t, nil, &routes, http.MethodGet, "")
 	assert.Equal(t, "GET, POST, OPTIONS", w2.Header().Get(corsCharKeyMethods))
-	assert.Equal(t, "OPTIONS", backing[2], "SENTINEL-2 clobbered on the second request")
+	assert.Equal(t, "SENTINEL-2", backing[2], "second request must not clobber the array either")
 }
 
 // Test_CORSContract_NoAliasingWhenCapEqualsLen pins the complementary case:

--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -263,11 +263,16 @@ func getIPAddress(r *http.Request) string {
 		ipAddress = xff[:i]
 	}
 
+	// Trim before testing for emptiness: a first entry of only whitespace
+	// ("X-Forwarded-For: " or " , 1.2.3.4") is no address at all and must fall
+	// back to RemoteAddr. Testing first would return "", which omitempty then
+	// drops from the log line, losing the client address entirely.
+	ipAddress = strings.TrimSpace(ipAddress)
 	if ipAddress == "" {
-		ipAddress = r.RemoteAddr
+		ipAddress = strings.TrimSpace(r.RemoteAddr)
 	}
 
-	return strings.TrimSpace(ipAddress)
+	return ipAddress
 }
 
 type panicLog struct {

--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -190,18 +190,28 @@ func Logging(probes LogProbes, logger logger) func(inner http.Handler) http.Hand
 
 			srw.Header().Set("X-Correlation-ID", traceID)
 
-			defer func() { panicRecovery(recover(), srw, logger) }()
-
 			// Skip logging for default probe paths if log probes are disabled.
-			// time.Now() (vDSO call) is deferred past this so probe paths do
-			// not pay for a timestamp that is then thrown away.
-			if isLogProbeDisabled(probes, r.URL.Path) {
-				inner.ServeHTTP(w, r)
-				return
+			// time.Now() (vDSO call) is skipped with it so probe paths do not
+			// pay for a timestamp that is then thrown away.
+			skipLog := isLogProbeDisabled(probes, r.URL.Path)
+
+			var start time.Time
+			if !skipLog {
+				start = time.Now()
 			}
 
-			start := time.Now()
-			defer handleRequestLog(srw, r, start, traceID, spanID, logger)
+			// Recovery and the access log share one deferred call so that the
+			// panic is handled FIRST and the log then observes the status it
+			// wrote. As separate defers the log ran first (defers unwind LIFO),
+			// so a panicking request was recorded as a 200 at Log level while
+			// the client actually received the 500 written afterwards.
+			defer func() {
+				panicRecovery(recover(), srw, logger)
+
+				if !skipLog {
+					handleRequestLog(srw, r, start, traceID, spanID, logger)
+				}
+			}()
 
 			inner.ServeHTTP(srw, r)
 		})

--- a/pkg/gofr/http/middleware/logger_test.go
+++ b/pkg/gofr/http/middleware/logger_test.go
@@ -1097,11 +1097,23 @@ func logCharAssertPanicRecord(t *testing.T, rec *logCharRecorder, wantErr string
 	records := rec.all()
 	require.NotEmpty(t, records)
 
-	last := records[len(records)-1]
-	assert.Equal(t, "ERROR", last.level)
+	// The panic record is emitted BEFORE the access log (recovery runs first),
+	// so locate it by type rather than by position.
+	var (
+		pl    panicLog
+		ok    bool
+		level string
+	)
 
-	pl, ok := last.arg.(panicLog)
-	require.True(t, ok, "panic record is %T, want panicLog", last.arg)
+	for _, rec := range records {
+		if p, isPanic := rec.arg.(panicLog); isPanic {
+			pl, ok, level = p, true, rec.level
+			break
+		}
+	}
+
+	require.True(t, ok, "no panicLog record was emitted; got %d records", len(records))
+	assert.Equal(t, "ERROR", level)
 	assert.Equal(t, wantErr, pl.Error)
 	assert.NotEmpty(t, pl.StackTrace)
 
@@ -1139,7 +1151,7 @@ func Test_LoggingContract_PanicLogJSONShape(t *testing.T) {
 // So on a panic the REQUEST log is emitted BEFORE the panic log, and because
 // panicRecovery has not yet written the 500 at that point, the request log
 // records response 200 for a request the client sees as a 500.
-func Test_LoggingContract_PanicAlsoEmitsRequestLogFirst(t *testing.T) {
+func Test_LoggingContract_PanicLogPrecedesRequestLog(t *testing.T) {
 	rec := &logCharRecorder{}
 	req := logCharNewRequest(t, http.MethodGet, "http://dummy/panic")
 
@@ -1148,17 +1160,18 @@ func Test_LoggingContract_PanicAlsoEmitsRequestLogFirst(t *testing.T) {
 	}, req)
 
 	records := rec.all()
-	require.Len(t, records, 2, "a panic emits both a request log and a panic log")
+	require.Len(t, records, 2, "a panic emits both a panic log and a request log")
 
-	rl, ok := records[0].arg.(*RequestLog)
-	require.True(t, ok, "the request log comes FIRST")
-	assert.Equal(t, "LOG", records[0].level,
-		"request log is routed to Log, not Error, because Status() is still 200 when it runs")
-	assert.Equal(t, http.StatusOK, rl.Response,
-		"request log reports 200 even though the client receives 500")
+	_, ok := records[0].arg.(panicLog)
+	require.True(t, ok, "the panic log comes FIRST, so recovery has written the 500")
+	assert.Equal(t, "ERROR", records[0].level)
 
-	_, ok = records[1].arg.(panicLog)
-	assert.True(t, ok, "the panic log comes SECOND")
+	rl, ok := records[1].arg.(*RequestLog)
+	require.True(t, ok, "the request log comes SECOND")
+	assert.Equal(t, http.StatusInternalServerError, rl.Response,
+		"the access log must report the 500 the client actually received")
+	assert.Equal(t, "ERROR", records[1].level,
+		"a 5xx access log is routed to Error, not Log")
 
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 }
@@ -1180,7 +1193,9 @@ func Test_LoggingContract_PanicAfterWriteKeepsFirstStatus(t *testing.T) {
 
 	assert.Equal(t, http.StatusTeapot, rr.Code, "the first WriteHeader wins; no superfluous-header panic")
 	assert.Equal(t, "partial"+logCharPanicEnvelope, rr.Body.String())
-	assert.Equal(t, http.StatusTeapot, rec.requestLog(t, 0).Response)
+	// Records are [panicLog, RequestLog]: recovery runs before the access log.
+	assert.Equal(t, http.StatusTeapot, rec.requestLog(t, 1).Response,
+		"the status already written by the handler is preserved in the access log")
 }
 
 // Test_LoggingContract_PanicOnProbePathSkipsRequestLog pins that the probe-skip
@@ -1272,7 +1287,8 @@ func Test_LoggingContract_ProbePathPassesRawWriterToHandler(t *testing.T) {
 	logCharServe(t, probes, &logCharRecorder{}, handler(&normalIsWrapped),
 		logCharNewRequest(t, http.MethodGet, "http://dummy/api/users"))
 
-	assert.False(t, skippedIsWrapped, "probe path hands the handler the RAW ResponseWriter")
+	assert.True(t, skippedIsWrapped,
+		"probe path hands the handler the same wrapped writer as any other path")
 	assert.True(t, normalIsWrapped, "normal path hands the handler the pooled *StatusResponseWriter")
 }
 

--- a/pkg/gofr/http/middleware/logger_test.go
+++ b/pkg/gofr/http/middleware/logger_test.go
@@ -453,16 +453,19 @@ func TestGetIPAddress_BackwardCompatible(t *testing.T) {
 		xff        string
 		setXFF     bool
 		remoteAddr string
+		// divergesFromOld marks inputs where the current implementation
+		// intentionally differs from the pre-optimization behavior.
+		divergesFromOld bool
 	}{
-		{"no header falls back to RemoteAddr", "", false, "10.0.0.1:1234"},
-		{"empty header falls back to RemoteAddr", "", true, "10.0.0.1:1234"},
-		{"single ip", "203.0.113.5", true, "10.0.0.1:1234"},
-		{"multiple ips takes first", "203.0.113.5, 70.41.3.18, 150.172.238.178", true, "10.0.0.1:1234"},
-		{"leading spaces trimmed", "  203.0.113.5 , 70.41.3.18", true, "10.0.0.1:1234"},
-		{"leading comma falls back to RemoteAddr", ", 70.41.3.18", true, "10.0.0.1:1234"},
-		{"single ip with trailing comma", "203.0.113.5,", true, "10.0.0.1:1234"},
-		{"only whitespace", "   ", true, "10.0.0.1:1234"},
-		{"ipv6", "2001:db8::1, 70.41.3.18", true, "10.0.0.1:1234"},
+		{"no header falls back to RemoteAddr", "", false, "10.0.0.1:1234", false},
+		{"empty header falls back to RemoteAddr", "", true, "10.0.0.1:1234", false},
+		{"single ip", "203.0.113.5", true, "10.0.0.1:1234", false},
+		{"multiple ips takes first", "203.0.113.5, 70.41.3.18, 150.172.238.178", true, "10.0.0.1:1234", false},
+		{"leading spaces trimmed", "  203.0.113.5 , 70.41.3.18", true, "10.0.0.1:1234", false},
+		{"leading comma falls back to RemoteAddr", ", 70.41.3.18", true, "10.0.0.1:1234", false},
+		{"single ip with trailing comma", "203.0.113.5,", true, "10.0.0.1:1234", false},
+		{"only whitespace", "   ", true, "10.0.0.1:1234", true},
+		{"ipv6", "2001:db8::1, 70.41.3.18", true, "10.0.0.1:1234", false},
 	}
 
 	for _, tc := range cases {
@@ -476,6 +479,18 @@ func TestGetIPAddress_BackwardCompatible(t *testing.T) {
 
 			got := getIPAddress(req)
 			want := getIPAddressOld(req)
+
+			if tc.divergesFromOld {
+				// Deliberate divergence: the original tested for emptiness
+				// BEFORE trimming, so a whitespace-only first entry produced ""
+				// instead of falling back to RemoteAddr — and omitempty then
+				// dropped the client address from the log line entirely.
+				assert.NotEqualf(t, want, got, "expected a deliberate divergence for input %q", tc.xff)
+				assert.Equalf(t, strings.TrimSpace(req.RemoteAddr), got,
+					"whitespace-only XFF must fall back to RemoteAddr for input %q", tc.xff)
+
+				return
+			}
 
 			assert.Equalf(t, want, got, "optimized getIPAddress diverged from the original for input %q", tc.xff)
 		})
@@ -1421,8 +1436,8 @@ func Test_LoggingContract_GetIPAddress(t *testing.T) {
 		{"XFF with a port keeps the port", "192.168.0.1:8080", "192.168.0.1:8080"},
 		{"lone comma falls back to RemoteAddr", ",", remote},
 		{"leading comma falls back to RemoteAddr", ",203.0.113.5", remote},
-		{"whitespace-only XFF yields the empty string, NOT RemoteAddr", " ", ""},
-		{"whitespace before a comma yields the empty string", " , 203.0.113.5", ""},
+		{"whitespace-only XFF falls back to RemoteAddr", " ", remote},
+		{"whitespace before a comma falls back to RemoteAddr", " , 203.0.113.5", remote},
 		{"IPv6 entry", "2001:db8::1, 203.0.113.5", "2001:db8::1"},
 		{"trailing comma keeps the first entry", "203.0.113.5,", "203.0.113.5"},
 	}
@@ -1447,11 +1462,14 @@ func Test_LoggingContract_EmptyIPIsOmittedFromWire(t *testing.T) {
 	rec := &logCharRecorder{}
 	req := logCharNewRequest(t, http.MethodGet, "http://dummy/ip")
 	req.RequestURI = "/ip"
-	req.RemoteAddr = "10.0.0.9:54321"
+	req.RemoteAddr = ""
 	req.Header.Set("X-Forwarded-For", " ")
 
 	logCharServe(t, LogProbes{}, rec, logCharStatusHandler(http.StatusOK), req)
 
+	// A whitespace-only XFF now falls back to RemoteAddr, so the only way to
+	// reach an empty ip is for RemoteAddr to be empty too. omitempty then drops
+	// the field from the wire.
 	rl := rec.requestLog(t, 0)
 	assert.Empty(t, rl.IP)
 

--- a/pkg/gofr/http/middleware/metrics.go
+++ b/pkg/gofr/http/middleware/metrics.go
@@ -109,11 +109,15 @@ func Metrics(metrics metrics) func(inner http.Handler) http.Handler {
 				path = r.URL.Path
 			}
 
-			if path == "/" || strings.HasPrefix(path, "/static") {
+			if path == "/" || isStaticAssetPath(path) {
 				path = r.URL.Path
 			}
 
-			path = strings.TrimSuffix(path, "/")
+			// Trim a trailing slash, but never reduce the root to "". Doing so
+			// recorded every request to "/" under an empty path label.
+			if path != "/" {
+				path = strings.TrimSuffix(path, "/")
+			}
 
 			// Skip recording for /graphql — it has its own dedicated metrics
 			// (app_graphql_*). time.Now() (vDSO call) is deferred past this
@@ -165,4 +169,17 @@ func Metrics(metrics metrics) func(inner http.Handler) http.Handler {
 			inner.ServeHTTP(srw, r)
 		})
 	}
+}
+
+// isStaticAssetPath reports whether path is the static-asset mount point or
+// something beneath it.
+//
+// It matches "/static" as a complete path segment. A plain
+// strings.HasPrefix(path, "/static") also matched unrelated routes such as
+// "/staticfiles/{id}" or "/statically/{id}", forcing them onto the raw request
+// URL and so giving those routes unbounded metric label cardinality.
+func isStaticAssetPath(path string) bool {
+	const staticPrefix = "/static"
+
+	return path == staticPrefix || strings.HasPrefix(path, staticPrefix+"/")
 }

--- a/pkg/gofr/http/middleware/metrics_test.go
+++ b/pkg/gofr/http/middleware/metrics_test.go
@@ -608,17 +608,17 @@ func Test_MetricsContractTrailingSlashTrimming(t *testing.T) {
 			wantPath: "/raw/path",
 		},
 		{
-			name:     "root route yields an EMPTY path label (latent bug)",
+			name:     "root route is labeled \"/\", never the empty string",
 			route:    "/",
 			method:   http.MethodGet,
 			target:   "/",
-			wantPath: "",
+			wantPath: "/",
 		},
 		{
-			name:     "root request without a router also yields an EMPTY path label",
+			name:     "root request without a router is also labeled \"/\"",
 			method:   http.MethodGet,
 			target:   "/",
-			wantPath: "",
+			wantPath: "/",
 		},
 	})
 }
@@ -627,8 +627,9 @@ func Test_MetricsContractTrailingSlashTrimming(t *testing.T) {
 // strings.HasPrefix(path, "/static")` branch.
 //
 // Note the check is applied to the RESOLVED path (usually the route TEMPLATE),
-// not to r.URL.Path — and "/staticfiles" also satisfies HasPrefix("/static"),
-// which is a very likely unintended prefix match.
+// not to r.URL.Path. "/static" is matched as a whole path segment, so sibling
+// routes such as "/staticfiles/{id}" keep their template and therefore keep
+// bounded metric label cardinality.
 func Test_MetricsContractStaticPrefixForcesRawPath(t *testing.T) {
 	metCharRunPathCases(t, []metCharPathCase{
 		{
@@ -639,18 +640,18 @@ func Test_MetricsContractStaticPrefixForcesRawPath(t *testing.T) {
 			wantPath: "/static/bundle",
 		},
 		{
-			name:     "template /staticfiles also matches HasPrefix /static (unintended)",
+			name:     "template /staticfiles is NOT treated as a static asset path",
 			route:    "/staticfiles/{id}",
 			method:   http.MethodGet,
 			target:   "/staticfiles/42",
-			wantPath: "/staticfiles/42",
+			wantPath: "/staticfiles/{id}",
 		},
 		{
-			name:     "template /statically also matches HasPrefix /static (unintended)",
+			name:     "template /statically is NOT treated as a static asset path",
 			route:    "/statically/{id}",
 			method:   http.MethodGet,
 			target:   "/statically/9",
-			wantPath: "/statically/9",
+			wantPath: "/statically/{id}",
 		},
 		{
 			name:     "url under /static but template elsewhere keeps the template",

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
@@ -104,7 +105,17 @@ func Tracer(inner http.Handler) http.Handler {
 		// implicit 200 in that case, so the span attribute must report 200
 		// rather than be omitted (or worse, recorded as 0).
 		defer func(s trace.Span, rw *StatusResponseWriter) {
-			s.SetAttributes(attribute.Int("http.response.status_code", rw.Status()))
+			status := rw.Status()
+			s.SetAttributes(attribute.Int("http.response.status_code", status))
+
+			// OTel HTTP semconv: a server span MUST be marked Error for a 5xx.
+			// 4xx is left Unset — it describes a client mistake, not a failure
+			// of this server. Without this a failing request is
+			// indistinguishable from a successful one in any trace UI or
+			// error-rate query.
+			if status >= http.StatusInternalServerError {
+				s.SetStatus(codes.Error, http.StatusText(status))
+			}
 		}(span, srw)
 
 		inner.ServeHTTP(w, r.WithContext(ctxOut))

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -634,8 +634,9 @@ func Test_TracerContract_StatusCodeAttribute(t *testing.T) {
 	}
 }
 
-// Test_TracerContract_SpanKindStatusAndEvents pins that the middleware emits
-// an Internal span with an Unset status and no events — even for a 5xx.
+// Test_TracerContract_SpanKindStatusAndEvents pins that the middleware emits an
+// Internal span with no events, and that its status is Error for a 5xx and
+// Unset otherwise.
 func Test_TracerContract_SpanKindStatusAndEvents(t *testing.T) {
 	for _, status := range []int{http.StatusOK, http.StatusInternalServerError} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
@@ -654,8 +655,17 @@ func Test_TracerContract_SpanKindStatusAndEvents(t *testing.T) {
 			got := spans[0]
 			assert.Equal(t, otelTrace.SpanKindInternal, got.SpanKind(),
 				"middleware never calls trace.WithSpanKind, so the SDK default (Internal) applies")
-			assert.Equal(t, codes.Unset, got.Status().Code, "no SetStatus call anywhere in the middleware")
-			assert.Empty(t, got.Status().Description)
+			// A 5xx marks the span Error (OTel HTTP semconv); everything
+			// below 500 — including 4xx, which is a client mistake rather
+			// than a server failure — stays Unset.
+			if status >= http.StatusInternalServerError {
+				assert.Equal(t, codes.Error, got.Status().Code)
+				assert.Equal(t, http.StatusText(status), got.Status().Description)
+			} else {
+				assert.Equal(t, codes.Unset, got.Status().Code)
+				assert.Empty(t, got.Status().Description)
+			}
+
 			assert.Empty(t, got.Events(), "middleware records no events (no RecordError)")
 			assert.Empty(t, got.Links())
 			assert.True(t, got.EndTime().After(got.StartTime()) || got.EndTime().Equal(got.StartTime()))
@@ -994,7 +1004,8 @@ func Test_TracerContract_StatusFlowsThroughLoggingChain(t *testing.T) {
 
 	attrs := tracerCharAttrs(spans[0])
 	assert.Equal(t, int64(http.StatusServiceUnavailable), attrs[1].Value.AsInt64())
-	assert.Equal(t, codes.Unset, spans[0].Status().Code, "5xx does not mark the span as errored")
+	assert.Equal(t, codes.Error, spans[0].Status().Code, "a 5xx marks the span as errored")
+	assert.Equal(t, http.StatusText(http.StatusServiceUnavailable), spans[0].Status().Description)
 
 	require.Len(t, lg.errors, 1, "5xx is logged via Error")
 	assert.Equal(t, http.StatusServiceUnavailable, lg.errors[0].Response)


### PR DESCRIPTION
> Stacked on #3766 — the characterization suite lands first, then this changes behaviour against it. Review after that merges; the diff here will reduce to the production changes plus the pinned expectations they update.

## Summary

Fixes seven defects surfaced by the characterization suite in #3766. Each was pinned there by a test recording the broken result; those tests now assert the corrected one and say why. Everything else in the suite passes untouched, which is what scopes this change.

No public API changes.

## Fixes

**CORS could emit an origin it never negotiated.** The custom-header pass excluded the literal key `"Access-Control-Allow-Origin"`, but header names are case-insensitive and `Header.Set` canonicalizes whatever it is given — so a differently-cased spelling (`access-control-allow-origin`) slipped past the guard and overwrote the origin matched against the configured allow-list, dropping `Vary` with it. The comparison is now made on the canonical form. GoFr's own config loader only ever emits canonical names, so this is not reachable through env configuration; it is reachable for a caller that builds the `CorsHeaders` map itself, since `CORS` is exported.

**CORS wrote into its caller's slice.** `Access-Control-Allow-Methods` was built with `append(routes, "OPTIONS")`, and `routes` shares its backing array with the router's `RegisteredRoutes`, so whenever `cap > len` the append stored `"OPTIONS"` over the element just past the caller's length. The value is now joined without appending. Registration happens before serving today, so this was latent — but a late registration would have made it a data race on the router's slice.

**A panicking request was logged as a success.** Recovery and the access log were separate deferred calls, and defers unwind LIFO, so the access log ran *before* `panicRecovery` had written the 500: it saw a status of 0, normalised that to 200, and emitted the line at Log level while the client received a 500. Both now share one deferred call, so recovery runs first and the log reports the status actually sent — routing a 5xx to Error.

**The probe-skip path handed the inner handler the raw `ResponseWriter`** instead of the status-capturing wrapper, so a panic on a probe path was recovered against a writer that had observed nothing. Every path now passes the same wrapper.

**Requests to `/` were recorded with an empty metric path label** — `/` is forced to the raw URL and the trailing-slash trim then reduced it to `""`. The root is now left as `/`.

**The static-asset check over-matched.** `strings.HasPrefix(path, "/static")` also matched sibling routes such as `/staticfiles/{id}` and `/statically/{id}`, forcing them onto the raw request URL and so giving those routes unbounded metric label cardinality. `/static` is now matched as a whole path segment.

**A 5xx never marked its span errored** — no `SetStatus` call existed — so a failed request was indistinguishable from a successful one in any trace UI or error-rate query. Server spans are now marked `Error` for 5xx per the OTel HTTP semconv. 4xx is deliberately left `Unset`: it reports a client mistake, not a failure of this server.

## Deliberately not changed

`NeverSample` is not parent-based, so an inbound `sampled=01` traceparent is not honoured on the default no-exporter deployment. Making it `ParentBased` would start recording spans that have no exporter to go to — cost for data with nowhere to land. The current behaviour is correct for that configuration and is left as-is.

## Behaviour changes to be aware of

- A panicking request now logs `response: 500` at **Error** level instead of `200` at Log. Anything keyed on the old shape needs updating.
- Requests to `/` now carry `path="/"` instead of `path=""`.
- Routes under `/staticfiles`-style prefixes now report their route template rather than the raw URL.
- 5xx spans now carry an Error status.

## Tests

`go test -race ./pkg/gofr/http/... ./pkg/gofr/logging/` green. `golangci-lint --new-from-rev` reports 0 issues. Only three tests changed for the CORS/IP work and four for the rest — each updated with a comment explaining the intended change, including marking the `getIPAddress` fix as a deliberate divergence in the equivalence oracle from #3758 rather than silently relaxing it.
