### PR TITLE
fix(http): stop dropping errors and honour pointers to response types

### DIFF
--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -90,9 +90,15 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		result, err = h.serveWithGoroutine(c, traceID, r)
 	}
 
-	// Handle custom headers if 'result' is a 'Response'.
-	if resp, ok := result.(response.Response); ok {
+	// Handle custom headers if 'result' is a 'Response'. A pointer is handled
+	// equivalently to the value form, otherwise its Headers are silently dropped.
+	switch resp := result.(type) {
+	case response.Response:
 		resp.SetCustomHeaders(w)
+	case *response.Response:
+		if resp != nil {
+			resp.SetCustomHeaders(w)
+		}
 	}
 
 	c.responder.Respond(result, err)

--- a/pkg/gofr/handler_test.go
+++ b/pkg/gofr/handler_test.go
@@ -906,17 +906,19 @@ func TestHandler_Char_ResponseCustomHeadersCanOverrideContentType(t *testing.T) 
 	assert.Equal(t, "{\"data\":\"x\"}\n", w.Body.String())
 }
 
-// TestHandler_Char_ResponsePointerHeadersIgnored pins that returning a POINTER
-// to response.Response neither applies the custom headers nor takes the special
-// Response envelope path — the type assertion in ServeHTTP is by value.
-func TestHandler_Char_ResponsePointerHeadersIgnored(t *testing.T) {
+// TestHandler_Char_ResponsePointerHeadersApplied pins the fix: returning a
+// POINTER to response.Response now applies the custom headers and takes the
+// Response envelope path, exactly like the value form. Previously the type
+// assertion in ServeHTTP was by value, so the headers were silently dropped and
+// the struct was serialized as ordinary data. WIRE-FORMAT CHANGE.
+func TestHandler_Char_ResponsePointerHeadersApplied(t *testing.T) {
 	w := charServe(t, charHandler(func(*Context) (any, error) {
 		return &response.Response{Data: "x", Headers: map[string]string{"X-One": "1"}}, nil
 	}, 0), http.MethodGet)
 
-	assert.Empty(t, w.Header().Get("X-One"), "custom headers are only applied for a value Response")
+	assert.Equal(t, "1", w.Header().Get("X-One"), "custom headers apply to a *Response too")
 	//nolint:testifylint // exact bytes are the contract.
-	assert.Equal(t, "{\"data\":{\"data\":\"x\"}}\n", w.Body.String())
+	assert.Equal(t, "{\"data\":\"x\"}\n", w.Body.String())
 }
 
 // TestHandler_Char_SpecialResponseTypes pins that the special response types

--- a/pkg/gofr/http/request.go
+++ b/pkg/gofr/http/request.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"reflect"
 	"strings"
@@ -56,8 +57,14 @@ func (r *Request) PathParam(key string) string {
 
 // Bind parses the request body and binds it to the provided interface.
 func (r *Request) Bind(i any) error {
-	v := r.req.Header.Get("Content-Type")
-	contentType := strings.Split(v, ";")[0]
+	// Binding into a non-pointer would unmarshal into a throwaway copy and leave
+	// the caller's value untouched, so reject it up front instead of silently
+	// doing nothing.
+	if rv := reflect.ValueOf(i); rv.Kind() != reflect.Pointer {
+		return errNonPointerBind
+	}
+
+	contentType := mediaType(r.req.Header.Get("Content-Type"))
 
 	switch contentType {
 	case "application/json":
@@ -76,6 +83,21 @@ func (r *Request) Bind(i any) error {
 	}
 
 	return nil
+}
+
+// mediaType extracts the bare media type from a Content-Type header value.
+// Per RFC 9110 the media type is case-insensitive and may be followed by
+// parameters and arbitrary optional whitespace, so `Application/JSON` and
+// `application/json ; charset=utf-8` must both resolve to `application/json`.
+func mediaType(header string) string {
+	parsed, _, err := mime.ParseMediaType(header)
+	if err != nil && parsed == "" {
+		// The header is malformed beyond a bad parameter list; fall back to a
+		// best-effort parse rather than losing an otherwise usable media type.
+		return strings.ToLower(strings.TrimSpace(strings.Split(header, ";")[0]))
+	}
+
+	return parsed
 }
 
 // HostName retrieves the hostname from the request.

--- a/pkg/gofr/http/request_test.go
+++ b/pkg/gofr/http/request_test.go
@@ -309,14 +309,24 @@ func TestBind_BinaryOctetStream_NotPointerToByteSlice(t *testing.T) {
 	}
 	req.req.Header.Set("Content-Type", "binary/octet-stream")
 
-	err := req.Bind("invalid input")
+	// A non-pointer target is now rejected up front by Bind with errNonPointerBind
+	// rather than reaching bindBinary — binding into a value could never have
+	// worked, and it used to be silent for every other content type.
+	if err := req.Bind("invalid input"); !errors.Is(err, errNonPointerBind) {
+		t.Fatalf("Expected error: %v, got: %v", errNonPointerBind, err)
+	}
+
+	// A pointer to something that is not a []byte still reaches bindBinary.
+	var notBytes string
+
+	err := req.Bind(&notBytes)
 
 	if !errors.Is(err, errNonSliceBind) {
 		t.Fatalf("Expected error: %v, got: %v", errNonSliceBind, err)
 	}
 
-	if !strings.Contains(err.Error(), "input is not a pointer to a byte slice: invalid input") {
-		t.Errorf("Expected error to contain: input is not a pointer to a byte slice: invalid input, got: %v", err)
+	if !strings.Contains(err.Error(), "input is not a pointer to a byte slice") {
+		t.Errorf("Expected error to contain: input is not a pointer to a byte slice, got: %v", err)
 	}
 }
 
@@ -585,10 +595,10 @@ func TestRequest_Char_BindJSON(t *testing.T) {
 		{"valid", "application/json", `{"a":"x","b":5}`, "", charBindTarget{A: "x", B: 5}},
 		// The content type is split on ";", so parameters are tolerated.
 		{"with-charset", "application/json; charset=utf-8", `{"a":"x"}`, "", charBindTarget{A: "x"}},
-		// SHARP EDGE (pinned as-is): the content type is split on ";" but never
-		// trimmed, so `application/json ; charset=utf-8` yields "application/json "
-		// (trailing space) which matches nothing — Bind silently does nothing.
-		{"with-space-before-semicolon-is-a-noop", "application/json ; charset=utf-8", `{"a":"x"}`, "", charBindTarget{}},
+		// FIXED (was a silent no-op): the header used to be split on ";" without
+		// trimming, so `application/json ; charset=utf-8` yielded "application/json "
+		// and matched nothing. mime.ParseMediaType now handles the whitespace.
+		{"with-space-before-semicolon", "application/json ; charset=utf-8", `{"a":"x"}`, "", charBindTarget{A: "x"}},
 		// Unknown JSON keys are silently ignored.
 		{"unknown-keys-ignored", "application/json", `{"a":"x","zz":1}`, "", charBindTarget{A: "x"}},
 		// Absent keys leave the target's existing (zero) value untouched.
@@ -653,20 +663,25 @@ func TestRequest_Char_BindJSON(t *testing.T) {
 	}
 }
 
-// TestRequest_Char_BindJSONNonPointerIsSilentNoOp pins a sharp edge: Bind takes
-// `any` and unmarshals into `&i`, so passing a non-pointer value binds into a
-// throwaway copy of the interface. No error is returned and the caller's value
-// is untouched — a typo like `c.Bind(target)` fails completely silently.
-func TestRequest_Char_BindJSONNonPointerIsSilentNoOp(t *testing.T) {
-	req := newCharRequest(t, "/x", "application/json", `{"a":"x","b":5}`)
+// TestRequest_Char_BindNonPointerErrors pins the fix for a sharp edge: Bind
+// takes `any` and used to unmarshal into `&i`, so a non-pointer target bound
+// into a throwaway copy of the interface and a typo like `c.Bind(target)` failed
+// completely silently. It now reports errNonPointerBind for every content type,
+// matching what the form/multipart paths already did.
+func TestRequest_Char_BindNonPointerErrors(t *testing.T) {
+	for _, ct := range []string{"application/json", "binary/octet-stream", "text/plain", ""} {
+		t.Run("ct="+ct, func(t *testing.T) {
+			req := newCharRequest(t, "/x", ct, `{"a":"x","b":5}`)
 
-	target := charBindTarget{}
+			target := charBindTarget{}
 
-	// Deliberately binding to a non-pointer to characterize the silent no-op.
-	err := req.Bind(target)
+			err := req.Bind(target)
 
-	require.NoError(t, err, "no error is reported for a non-pointer target")
-	assert.Equal(t, charBindTarget{}, target, "the caller's value is left untouched")
+			require.ErrorIs(t, err, errNonPointerBind)
+			assert.Equal(t, "bind error, cannot bind to a non pointer type", err.Error())
+			assert.Equal(t, charBindTarget{}, target, "the caller's value is still left untouched")
+		})
+	}
 }
 
 // TestRequest_Char_BindJSONIntoNonStructTargets pins binding into the
@@ -710,21 +725,15 @@ func TestRequest_Char_BindJSONIntoNonStructTargets(t *testing.T) {
 }
 
 // TestRequest_Char_BindUnhandledContentTypes pins that Bind is a NO-OP that
-// returns nil for any content type it does not recognize — including a missing
-// header and a differently-cased one. A handler that ignores Bind's error sees
-// an all-zero struct rather than a failure.
+// returns nil for any content type it does not recognize. A handler that ignores
+// Bind's error sees an all-zero struct rather than a failure.
 func TestRequest_Char_BindUnhandledContentTypes(t *testing.T) {
 	for _, ct := range []string{
 		"",
 		"text/plain",
 		"application/xml",
-		"application/JSON",  // matching is case SENSITIVE
-		"Application/json",  // ...in both halves
-		"application/json ", // a trailing space is not trimmed
-		" application/json", // nor a leading one
 		"application/jsonx", // no prefix matching
 		"text/json",
-		"application/x-www-form-urlencoded ", // trailing space again defeats the match
 	} {
 		t.Run("ct="+ct, func(t *testing.T) {
 			req := newCharRequest(t, "/x", ct, `{"a":"x","b":5}`)
@@ -737,6 +746,44 @@ func TestRequest_Char_BindUnhandledContentTypes(t *testing.T) {
 			assert.Equal(t, charBindTarget{}, got, "unhandled content types must not bind")
 		})
 	}
+}
+
+// TestRequest_Char_BindContentTypeIsNormalized pins the fix for case-sensitive,
+// untrimmed content-type matching. Every spelling below used to fall through to
+// the unhandled branch and silently leave the target all-zero; the media type is
+// now parsed per RFC 9110, so case and surrounding whitespace are irrelevant.
+func TestRequest_Char_BindContentTypeIsNormalized(t *testing.T) {
+	for _, ct := range []string{
+		"application/json",
+		"application/JSON",
+		"Application/json",
+		"APPLICATION/JSON",
+		"application/json ",
+		" application/json",
+		"application/json;charset=utf-8",
+		"application/json ; charset=UTF-8",
+	} {
+		t.Run("ct="+ct, func(t *testing.T) {
+			req := newCharRequest(t, "/x", ct, `{"a":"x","b":5}`)
+
+			var got charBindTarget
+
+			require.NoError(t, req.Bind(&got))
+			assert.Equal(t, charBindTarget{A: "x", B: 5}, got)
+		})
+	}
+
+	// The same normalization applies to the form path.
+	t.Run("form-urlencoded-trailing-space", func(t *testing.T) {
+		type target struct{ Name string }
+
+		req := newCharRequest(t, "/x", "application/x-www-form-urlencoded ", "Name=alice")
+
+		var got target
+
+		require.NoError(t, req.Bind(&got))
+		assert.Equal(t, target{Name: "alice"}, got)
+	})
 }
 
 // TestRequest_Char_BindFormURLEncoded pins the form-urlencoded path, including

--- a/pkg/gofr/http/responder.go
+++ b/pkg/gofr/http/responder.go
@@ -3,16 +3,11 @@ package http
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"reflect"
 	"sync"
 
 	resTypes "gofr.dev/pkg/gofr/http/response"
-)
-
-var (
-	errEmptyResponse = errors.New("internal server error")
 )
 
 // maxRespPooledBuf caps the capacity of a response buffer returned to the pool
@@ -49,6 +44,10 @@ type Responder struct {
 // Respond sends a response with the given data and handles potential errors, setting appropriate
 // status codes and formatting responses as JSON or raw data as needed.
 func (r Responder) Respond(data any, err error) {
+	// A pointer to a special response type must behave exactly like its value form,
+	// otherwise it silently falls through to the JSON envelope below.
+	data = derefSpecialResponse(data)
+
 	if r.handleSpecialResponseTypes(data, err) {
 		return
 	}
@@ -59,7 +58,14 @@ func (r Responder) Respond(data any, err error) {
 
 	switch v := data.(type) {
 	case resTypes.Raw:
-		resp = v.Data
+		// Raw normally bypasses the envelope, but an error must never be dropped:
+		// when one is present we fall back to the standard envelope so the client
+		// is told what failed instead of receiving a bare partial payload.
+		if errorObj != nil {
+			resp = response{Data: v.Data, Error: errorObj}
+		} else {
+			resp = v.Data
+		}
 	case resTypes.Response:
 		resp = response{Data: v.Data, Metadata: v.Metadata, Error: errorObj}
 	default:
@@ -114,6 +120,42 @@ func putRespBuf(buf *bytes.Buffer) {
 	if buf.Cap() <= maxRespPooledBuf {
 		respBufPool.Put(buf)
 	}
+}
+
+// derefSpecialResponse unwraps a pointer to one of the special response types
+// into its value form, so *resTypes.Redirect is redirected, *resTypes.Template
+// is rendered and so on, exactly like their value counterparts. Anything else —
+// including a nil pointer — is returned untouched.
+func derefSpecialResponse(data any) any {
+	switch v := data.(type) {
+	case *resTypes.Stream:
+		return derefResponseValue(v)
+	case *resTypes.File:
+		return derefResponseValue(v)
+	case *resTypes.Template:
+		return derefResponseValue(v)
+	case *resTypes.XML:
+		return derefResponseValue(v)
+	case *resTypes.Redirect:
+		return derefResponseValue(v)
+	case *resTypes.Raw:
+		return derefResponseValue(v)
+	case *resTypes.Response:
+		return derefResponseValue(v)
+	}
+
+	return data
+}
+
+// derefResponseValue returns the value p points to. A nil pointer is returned
+// as-is — still typed, so the existing typed-nil handling in isNil and the
+// method-based status mapping behave exactly as they did before.
+func derefResponseValue[T any](p *T) any {
+	if p != nil {
+		return *p
+	}
+
+	return p
 }
 
 // handleSpecialResponseTypes handles special response types that bypass JSON encoding.
@@ -209,9 +251,12 @@ func handleSuccessStatusCode(method string, data any) int {
 }
 
 func (r Responder) determineResponse(data any, err error) (statusCode int, errObj any) {
-	// Handle empty struct case first
+	// A zero-valued struct carries no information, so alongside an error it is
+	// treated as absent data: the error's own status code wins over 206 Partial
+	// Content. The caller's error is always reported as-is — it is never replaced
+	// by a generic one.
 	if err != nil && isEmptyStruct(data) {
-		return http.StatusInternalServerError, createErrorResponse(errEmptyResponse)
+		data = nil
 	}
 
 	statusCode, errorObj := getStatusCode(r.method, data, err)
@@ -245,10 +290,12 @@ func isEmptyStruct(data any) bool {
 		return false
 	}
 
-	// Compare against a zero value of the same type
+	// Compare against a zero value of the same type. The comparison must use the
+	// dereferenced value v, not the original data: comparing a pointer against a
+	// zero struct is never equal, which made *T and T diverge.
 	zero := reflect.Zero(v.Type()).Interface()
 
-	return reflect.DeepEqual(data, zero)
+	return reflect.DeepEqual(v.Interface(), zero)
 }
 
 // getStatusCode returns corresponding HTTP status codes.

--- a/pkg/gofr/http/responder_test.go
+++ b/pkg/gofr/http/responder_test.go
@@ -1062,20 +1062,22 @@ func TestResponder_Char_RawEnvelope(t *testing.T) {
 		{"raw-nil-data-get", http.MethodGet, resTypes.Raw{}, nil, http.StatusOK, "application/json", "null\n"},
 		{"raw-nil-data-post", http.MethodPost, resTypes.Raw{Data: "x"}, nil, http.StatusCreated, "application/json", "\"x\"\n"},
 
-		// LATENT BUG (pinned as-is): when a handler returns a Raw alongside an
-		// error, the status becomes 206 Partial Content but the error object is
-		// silently DROPPED from the body — the client gets only Raw.Data and no
-		// indication of what failed.
+		// FIXED (was: 206 with the error silently DROPPED, body just `"partial"`).
+		// Raw bypasses the envelope only on the success path; when an error is
+		// present Respond falls back to the standard envelope so the client is
+		// actually told what failed. WIRE-FORMAT CHANGE for Raw-plus-error.
 		{
-			"raw-with-error-drops-error", http.MethodGet, resTypes.Raw{Data: "partial"}, errCharPlain,
-			http.StatusPartialContent, "application/json", "\"partial\"\n",
+			"raw-with-error-uses-envelope", http.MethodGet, resTypes.Raw{Data: "partial"}, errCharPlain,
+			http.StatusPartialContent, "application/json",
+			"{\"error\":{\"message\":\"plain failure\"},\"data\":\"partial\"}\n",
 		},
-		// LATENT BUG (pinned as-is): Raw{} is an empty struct, so isEmptyStruct
-		// fires and the status becomes 500 with errEmptyResponse — but the body
-		// is still the raw `null`, not the error envelope.
+		// FIXED (was: 500 with body `null`, no error at all). Raw{} is a zero
+		// struct, so it is treated as absent data: the error's own status applies
+		// (500 here, the plain-error default) and the caller's real error — not a
+		// generic "internal server error" — is reported.
 		{
 			"raw-empty-with-error", http.MethodGet, resTypes.Raw{}, errCharPlain,
-			http.StatusInternalServerError, "application/json", "null\n",
+			http.StatusInternalServerError, "application/json", "{\"error\":{\"message\":\"plain failure\"}}\n",
 		},
 	})
 }
@@ -1113,13 +1115,14 @@ func TestResponder_Char_ResponseEnvelope(t *testing.T) {
 			resTypes.Response{Data: "d", Headers: map[string]string{"X-A": "b"}}, nil,
 			http.StatusOK, "application/json", "{\"data\":\"d\"}\n",
 		},
-		// LATENT QUIRK (pinned as-is): resTypes.Response{} is a zero struct, so
-		// isEmptyStruct fires: the status becomes 500 AND the caller's real
-		// error is replaced by the generic "internal server error".
+		// FIXED (was: the caller's error replaced by "internal server error").
+		// resTypes.Response{} is a zero struct and so counts as absent data, but
+		// the caller's real error is now reported verbatim. The status is still
+		// 500 because a plain error carries no status code of its own.
 		{
 			"response-empty-with-error", http.MethodGet,
 			resTypes.Response{}, errCharPlain,
-			http.StatusInternalServerError, "application/json", "{\"error\":{\"message\":\"internal server error\"}}\n",
+			http.StatusInternalServerError, "application/json", "{\"error\":{\"message\":\"plain failure\"}}\n",
 		},
 	})
 }
@@ -1260,30 +1263,33 @@ func TestResponder_Char_ErrorEnvelopeEdges(t *testing.T) {
 		},
 
 		// --- empty-struct short circuit ---------------------------------------
-		// LATENT QUIRK (pinned as-is): when data is a zero-valued struct AND an
-		// error is present, determineResponse replaces the status with 500 and
-		// the error object with the generic "internal server error" — the real
-		// error is lost. The zero struct is still serialized into `data`.
+		// FIXED (was: 500 with the generic "internal server error", the caller's
+		// real error lost). A zero-valued struct carries no information, so it is
+		// treated as absent data and the ERROR's own status code applies — 404
+		// here — while the caller's error is reported verbatim. The zero struct is
+		// still serialized into `data`.
 		{
 			"empty-struct-plus-error", http.MethodGet, charStruct{}, ErrorEntityNotFound{Name: "id", Value: "1"},
-			http.StatusInternalServerError, "application/json",
-			"{\"error\":{\"message\":\"internal server error\"},\"data\":{\"id\":0,\"name\":\"\"}}\n",
+			http.StatusNotFound, "application/json",
+			"{\"error\":{\"message\":\"No entity found with id: 1\"},\"data\":{\"id\":0,\"name\":\"\"}}\n",
 		},
-		// ...but a POINTER to a zero struct escapes the short circuit, because
-		// isEmptyStruct dereferences for the Kind check yet compares the
-		// original pointer against a zero STRUCT. Different behavior for
-		// semantically identical data.
+		// FIXED (was: 206, because isEmptyStruct dereferenced for the Kind check
+		// but compared the original POINTER against a zero struct, so *T never
+		// matched). A pointer to a zero struct is now byte-for-byte identical to
+		// the value form above.
 		{
 			"pointer-to-empty-struct-plus-error", http.MethodGet, &charStruct{}, ErrorEntityNotFound{Name: "id", Value: "1"},
-			http.StatusPartialContent, "application/json",
+			http.StatusNotFound, "application/json",
 			"{\"error\":{\"message\":\"No entity found with id: 1\"},\"data\":{\"id\":0,\"name\":\"\"}}\n",
 		},
 		// A zero struct whose fields are all omitempty still serializes as `{}`
 		// under `data`, so the client cannot distinguish it from "no data".
+		// FIXED: the caller's error is no longer replaced by a generic one; the
+		// status stays 500 only because a plain error has no status of its own.
 		{
 			"empty-omitempty-struct-plus-error", http.MethodGet, charOmit{}, errCharPlain,
 			http.StatusInternalServerError, "application/json",
-			"{\"error\":{\"message\":\"internal server error\"},\"data\":{}}\n",
+			"{\"error\":{\"message\":\"plain failure\"},\"data\":{}}\n",
 		},
 	})
 }
@@ -1644,35 +1650,51 @@ func TestResponder_Char_Template(t *testing.T) {
 	}
 }
 
-// TestResponder_Char_TemplatePointerIsNotSpecial pins a sharp edge: the type
-// switch matches resTypes.Template by VALUE, so returning *resTypes.Template
-// falls through to the JSON envelope instead of rendering. Reported, not fixed.
-func TestResponder_Char_TemplatePointerIsNotSpecial(t *testing.T) {
+// TestResponder_Char_TemplatePointerIsRendered pins the fix for a sharp edge:
+// the type switch used to match resTypes.Template by VALUE only, so a
+// *resTypes.Template was JSON-serialized instead of rendered. It is now
+// dereferenced first and renders exactly like the value form.
+func TestResponder_Char_TemplatePointerIsRendered(t *testing.T) {
+	createTemplateFile(t, "./templates/char.html", "<h1>{{.Title}}</h1>")
+
+	defer removeTemplateDir(t)
+
 	w := httptest.NewRecorder()
 
-	NewResponder(w, http.MethodGet).Respond(&resTypes.Template{Name: "char.html", Data: "x"}, nil)
+	NewResponder(w, http.MethodGet).Respond(&resTypes.Template{
+		Name: "char.html", Data: map[string]string{"Title": "Hi"},
+	}, nil)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-	//nolint:testifylint // exact bytes are the contract.
-	assert.Equal(t, "{\"data\":{\"Data\":\"x\",\"Name\":\"char.html\"}}\n", w.Body.String())
+	assert.Equal(t, "text/html", w.Header().Get("Content-Type"))
+	assert.Equal(t, "<h1>Hi</h1>", w.Body.String())
 }
 
-// TestResponder_Char_SpecialTypePointersFallThrough pins that every special
-// response type is matched by value only; a pointer to one is JSON-encoded.
-func TestResponder_Char_SpecialTypePointersFallThrough(t *testing.T) {
+// TestResponder_Char_SpecialTypePointersAreDereferenced pins the fix: every
+// special response type is now matched through a pointer too, so *T behaves
+// byte-for-byte like T. Previously each of these fell through to the JSON
+// envelope — a redirect returned 200 with a serialized struct and no Location
+// header, a file was base64-encoded, and so on. WIRE-FORMAT CHANGE for anyone
+// who returned a pointer to a special response type.
+func TestResponder_Char_SpecialTypePointersAreDereferenced(t *testing.T) {
 	tests := []struct {
-		name     string
-		data     any
-		wantBody string
+		name       string
+		data       any
+		wantStatus int
+		wantCType  string
+		wantBody   string
+		wantLoc    string
 	}{
 		{"file-ptr", &resTypes.File{Content: []byte("ab"), ContentType: "text/plain"},
-			"{\"data\":{\"Content\":\"YWI=\",\"ContentType\":\"text/plain\"}}\n"},
+			http.StatusOK, "text/plain", "ab", ""},
 		{"xml-ptr", &resTypes.XML{Content: []byte("<a/>")},
-			"{\"data\":{\"Content\":\"PGEvPg==\",\"ContentType\":\"\"}}\n"},
-		{"redirect-ptr", &resTypes.Redirect{URL: "/x"}, "{\"data\":{\"URL\":\"/x\"}}\n"},
-		{"raw-ptr", &resTypes.Raw{Data: "x"}, "{\"data\":{\"Data\":\"x\"}}\n"},
-		{"response-ptr", &resTypes.Response{Data: "x"}, "{\"data\":{\"data\":\"x\"}}\n"},
+			http.StatusOK, "application/xml", "<a/>", ""},
+		{"redirect-ptr", &resTypes.Redirect{URL: "/x"},
+			http.StatusFound, "", "", "/x"},
+		{"raw-ptr", &resTypes.Raw{Data: "x"},
+			http.StatusOK, "application/json", "\"x\"\n", ""},
+		{"response-ptr", &resTypes.Response{Data: "x"},
+			http.StatusOK, "application/json", "{\"data\":\"x\"}\n", ""},
 	}
 
 	for _, tc := range tests {
@@ -1681,10 +1703,29 @@ func TestResponder_Char_SpecialTypePointersFallThrough(t *testing.T) {
 
 			NewResponder(w, http.MethodGet).Respond(tc.data, nil)
 
-			assert.Equal(t, http.StatusOK, w.Code)
-			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			assert.Equal(t, tc.wantStatus, w.Code)
+			assert.Equal(t, tc.wantCType, w.Header().Get("Content-Type"))
 			assert.Equal(t, tc.wantBody, w.Body.String())
+			assert.Equal(t, tc.wantLoc, w.Header().Get("Location"))
 		})
+	}
+}
+
+// TestResponder_Char_SpecialTypeNilPointers pins that a typed NIL pointer to a
+// special response type is still not dereferenced — it collapses to the ordinary
+// empty JSON envelope rather than panicking.
+func TestResponder_Char_SpecialTypeNilPointers(t *testing.T) {
+	for _, data := range []any{
+		(*resTypes.File)(nil), (*resTypes.XML)(nil), (*resTypes.Redirect)(nil),
+		(*resTypes.Raw)(nil), (*resTypes.Response)(nil), (*resTypes.Template)(nil),
+		(*resTypes.Stream)(nil),
+	} {
+		w := httptest.NewRecorder()
+
+		NewResponder(w, http.MethodGet).Respond(data, nil)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "{}\n", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
> Stacked on #3767 — the characterization suite lands first, then this changes behaviour against it. Review after that merges.

## Summary

Fixes five defects surfaced by the characterization suite in #3767. Each was pinned there by a test recording the broken result; those tests now assert the corrected one. No exported signature changes.

## Fixes

**An error passed alongside a `Raw` response was discarded entirely.** The client received `206 Partial Content` with the payload and *no indication anything had failed*. `Raw` now carries the standard error envelope when an error is present. `Raw` without an error is byte-identical to before.

**A zero-valued struct plus an error replaced the caller's error** with a generic `"internal server error"` and forced 500 — while a **pointer** to the same zero struct returned 206 with the real message. Same data, two different contracts. `isEmptyStruct` dereferenced a pointer for its `Kind()` check but then compared the *original pointer* against a zero struct, so the pointer form never matched. Both forms now behave identically, and neither swallows the caller's error.

**Pointers to the special response types fell through to the JSON envelope.** A `*Redirect` returned `200` with `{"data":{"URL":"/there"}}` and no `Location` header instead of redirecting; a `*Template` was serialised instead of rendered; a `*Response`'s custom `Headers` were ignored. Pointer forms are now handled equivalently to values — via an explicit type switch, not reflection, so the response hot path is unaffected. Typed nil pointers keep their existing collapse behaviour.

**`Bind` to a non-pointer silently did nothing** — the body was unmarshalled into a throwaway copy and `nil` returned, leaving the caller's struct zeroed with no error. It now returns `errNonPointerBind`, consistently for every content type rather than only the form paths.

**`Content-Type` matching was case-sensitive and untrimmed**, so `Application/json` or `application/json ; charset=utf-8` fell through to the unhandled branch and bound nothing without error. Media types are now parsed per RFC 9110.

## Behaviour changes to be aware of

| Case | Before | After |
|---|---|---|
| `Respond(Raw{...}, err)` | `206`, naked payload, error lost | `206`, error envelope |
| `Respond(S{}, err)` | `500`, `"internal server error"` | error's own status + real message |
| `Respond(&S{}, err)` | `206` | identical to the value form |
| `Respond(&Redirect{...}, nil)` | `200` + JSON body | `302` + `Location` |
| `Bind(target)` (missing `&`) | `nil`, struct untouched | returns an error |
| `Application/json` | bound nothing, no error | binds |

The `Bind` change is the most likely source of user-visible churn: it can turn a silently-passing handler into a 500 — which is the point, but worth calling out. The `Content-Type` change is purely additive; no request that bound successfully before behaves differently.

## Deliberately left alone

`File`/`XML`/`Template`/`Redirect` still discard an accompanying error body (same class as the `Raw` bug, but fixing it means choosing an error representation per content type). The unhandled-content-type branch still returns `nil` rather than erroring — a much larger blast radius. `ParseForm` merging the query string into form binding. All remain pinned by their characterization tests.

## Tests

`go test -race ./pkg/gofr/http/...` and `-run 'TestHandler|TestErrorLogEntry' ./pkg/gofr/` green. `golangci-lint --new-from-rev` reports 0 issues.
