### PR TITLE
fix: data race on server shutdown + de-flake cron/file-token unit tests

### DIFF
--- a/pkg/gofr/cron_test.go
+++ b/pkg/gofr/cron_test.go
@@ -214,7 +214,16 @@ func TestCronTab_AddJob(t *testing.T) {
 	mocks.Metrics.EXPECT().NewCounter("app_cron_job_success", gomock.Any()).AnyTimes()
 	mocks.Metrics.EXPECT().NewCounter("app_cron_job_failures", gomock.Any()).AnyTimes()
 
+	// The "* * * * *" job fires at second 0 of every minute. If the package run
+	// crosses a minute boundary while the ticker goroutine is alive, the job runs
+	// and records runtime metrics, so allow those calls any number of times.
+	mocks.Metrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mocks.Metrics.EXPECT().RecordHistogram(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
 	c := NewCron(mockContainer)
+	// Stop the background ticker so a leaked goroutine cannot fire "test-job"
+	// after the test completes and panic via t.Fatalf on the mock controller.
+	defer c.Stop()
 
 	for _, tc := range testCases {
 		err := c.AddJob(tc.schedule, "test-job", fn)
@@ -253,6 +262,7 @@ func TestCronTab_runScheduled(t *testing.T) {
 	mocks.Metrics.EXPECT().RecordHistogram(gomock.Any(), "app_cron_job_duration", gomock.Any(), "job", "test-job").Times(1)
 
 	c := NewCron(mockContainer)
+	defer c.Stop()
 
 	// Populate the job array for cron table
 	c.jobs = []*job{j}
@@ -700,6 +710,7 @@ func TestCronTab_runScheduled_Panic(t *testing.T) {
 				var c *Crontab
 				if tc.expectMetricsCalls {
 					c = NewCron(cntnr)
+					defer c.Stop()
 					c.jobs = []*job{j}
 				} else {
 					c = &Crontab{

--- a/pkg/gofr/cron_test.go
+++ b/pkg/gofr/cron_test.go
@@ -214,15 +214,19 @@ func TestCronTab_AddJob(t *testing.T) {
 	mocks.Metrics.EXPECT().NewCounter("app_cron_job_success", gomock.Any()).AnyTimes()
 	mocks.Metrics.EXPECT().NewCounter("app_cron_job_failures", gomock.Any()).AnyTimes()
 
-	// The "* * * * *" job fires at second 0 of every minute. If the package run
-	// crosses a minute boundary while the ticker goroutine is alive, the job runs
-	// and records runtime metrics, so allow those calls any number of times.
+	// These AnyTimes() runtime expectations are load-bearing, not merely
+	// defensive: Stop() below halts only *future* ticks, it does not join a job
+	// goroutine that a tick already dispatched (Crontab fires `go j.run(...)` with
+	// no WaitGroup). The "* * * * *" job fires at second 0 of every minute, so a
+	// job dispatched just before Stop can still call the metrics mock after the
+	// test returns; without these expectations that call is gomock's
+	// t.Fatalf-on-finished-test -> panic. `defer c.Stop()` narrows the window but
+	// cannot close it — deterministic joining needs a framework change to Stop
+	// (tracked in gofr-dev/gofr#3801). Do not remove these believing Stop covers it.
 	mocks.Metrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	mocks.Metrics.EXPECT().RecordHistogram(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	c := NewCron(mockContainer)
-	// Stop the background ticker so a leaked goroutine cannot fire "test-job"
-	// after the test completes and panic via t.Fatalf on the mock controller.
 	defer c.Stop()
 
 	for _, tc := range testCases {

--- a/pkg/gofr/http_server.go
+++ b/pkg/gofr/http_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"gofr.dev/pkg/gofr/container"
@@ -18,6 +19,7 @@ type httpServer struct {
 	router      *gofrHTTP.Router
 	port        int
 	ws          *websocket.Manager
+	srvMu       sync.Mutex // guards srv, which run() writes on the serve goroutine and Shutdown() reads on the caller goroutine
 	srv         *http.Server
 	certFile    string
 	keyFile     string
@@ -58,18 +60,27 @@ func (s *httpServer) run(c *container.Container) {
 		middleware.WSHandlerUpgrade(c, s.ws),
 	)
 
+	s.srvMu.Lock()
+
 	if s.srv != nil {
+		s.srvMu.Unlock()
 		c.Logf("Server already running on port: %d", s.port)
+
 		return
 	}
 
 	c.Logf("Starting server on port: %d", s.port)
 
-	s.srv = &http.Server{
+	// Assign under the lock, then operate on the local copy so the blocking
+	// ListenAndServe call below never holds it. Shutdown reads srv under the
+	// same lock, so the two goroutines no longer race on the field.
+	srv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", s.port),
 		Handler:           s.router,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
+	s.srv = srv
+	s.srvMu.Unlock()
 
 	// If both certFile and keyFile are provided, validate and run HTTPS server
 	if s.certFile != "" && s.keyFile != "" {
@@ -79,7 +90,7 @@ func (s *httpServer) run(c *container.Container) {
 		}
 
 		// Start HTTPS server with TLS
-		if err := s.srv.ListenAndServeTLS(s.certFile, s.keyFile); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := srv.ListenAndServeTLS(s.certFile, s.keyFile); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			c.Errorf("error while listening to https server, err: %v", err)
 		}
 
@@ -87,24 +98,24 @@ func (s *httpServer) run(c *container.Container) {
 	}
 
 	// If no certFile/keyFile is provided, run the HTTP server
-	if err := s.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		c.Errorf("error while listening to http server, err: %v", err)
 	}
 }
 
 func (s *httpServer) Shutdown(ctx context.Context) error {
-	if s.srv == nil {
+	s.srvMu.Lock()
+	srv := s.srv
+	s.srvMu.Unlock()
+
+	if srv == nil {
 		return nil
 	}
 
 	return ShutdownWithContext(ctx, func(ctx context.Context) error {
-		return s.srv.Shutdown(ctx)
+		return srv.Shutdown(ctx)
 	}, func() error {
-		if err := s.srv.Close(); err != nil {
-			return err
-		}
-
-		return nil
+		return srv.Close()
 	})
 }
 

--- a/pkg/gofr/mcp.go
+++ b/pkg/gofr/mcp.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"gofr.dev/pkg/gofr/ai/mcp"
@@ -74,6 +75,7 @@ func (a *App) mcpPort() (int, bool) {
 type mcpServer struct {
 	port    int
 	handler http.Handler
+	srvMu   sync.Mutex // guards srv, written by Run on the serve goroutine and read by Shutdown on the caller goroutine
 	srv     *http.Server
 }
 
@@ -86,23 +88,33 @@ func (m *mcpServer) Run(c *container.Container) {
 
 	// Bind to loopback: the MCP transport authenticates only by passing through per-handler auth,
 	// so it must not become a second network-reachable ingress to the service's handlers.
-	m.srv = &http.Server{
+	// Assign under the lock, then serve on the local copy so the blocking
+	// ListenAndServe call never holds it while Shutdown reads srv.
+	srv := &http.Server{
 		Addr:              fmt.Sprintf("127.0.0.1:%d", m.port),
 		Handler:           m.handler,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	if err := m.srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+	m.srvMu.Lock()
+	m.srv = srv
+	m.srvMu.Unlock()
+
+	if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 		c.Errorf("error while listening to MCP server, err: %v", err)
 	}
 }
 
 func (m *mcpServer) Shutdown(ctx context.Context) error {
-	if m.srv == nil {
+	m.srvMu.Lock()
+	srv := m.srv
+	m.srvMu.Unlock()
+
+	if srv == nil {
 		return nil
 	}
 
 	return ShutdownWithContext(ctx, func(ctx context.Context) error {
-		return m.srv.Shutdown(ctx)
+		return srv.Shutdown(ctx)
 	}, nil)
 }

--- a/pkg/gofr/metrics_server.go
+++ b/pkg/gofr/metrics_server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"gofr.dev/pkg/gofr/container"
@@ -12,8 +13,9 @@ import (
 )
 
 type metricServer struct {
-	port int
-	srv  *http.Server
+	port  int
+	srvMu sync.Mutex // guards srv, written by Run on the serve goroutine and read by Shutdown on the caller goroutine
+	srv   *http.Server
 }
 
 func newMetricServer(port int) *metricServer {
@@ -24,13 +26,19 @@ func (m *metricServer) Run(c *container.Container) {
 	if m != nil {
 		c.Logf("Starting metrics server on port: %d", m.port)
 
-		m.srv = &http.Server{
+		// Assign under the lock, then serve on the local copy so the blocking
+		// ListenAndServe call never holds it while Shutdown reads srv.
+		srv := &http.Server{
 			Addr:              fmt.Sprintf(":%d", m.port),
 			Handler:           metrics.GetHandler(c.Metrics()),
 			ReadHeaderTimeout: 5 * time.Second,
 		}
 
-		err := m.srv.ListenAndServe()
+		m.srvMu.Lock()
+		m.srv = srv
+		m.srvMu.Unlock()
+
+		err := srv.ListenAndServe()
 
 		if !errors.Is(err, http.ErrServerClosed) {
 			c.Errorf("error while listening to metrics server, err: %v", err)
@@ -39,11 +47,15 @@ func (m *metricServer) Run(c *container.Container) {
 }
 
 func (m *metricServer) Shutdown(ctx context.Context) error {
-	if m.srv == nil {
+	m.srvMu.Lock()
+	srv := m.srv
+	m.srvMu.Unlock()
+
+	if srv == nil {
 		return nil
 	}
 
 	return ShutdownWithContext(ctx, func(ctx context.Context) error {
-		return m.srv.Shutdown(ctx)
+		return srv.Shutdown(ctx)
 	}, nil)
 }

--- a/pkg/gofr/service/file_token_auth_test.go
+++ b/pkg/gofr/service/file_token_auth_test.go
@@ -281,10 +281,10 @@ func TestFileTokenAuthConfig_RefreshFailureLogsWarning(t *testing.T) {
 	// Remove the token file so the next refresh tick fails to read it.
 	require.NoError(t, os.Remove(path))
 
-	// Cached token must remain available despite refresh failures.
+	// Before any refresh runs, the eagerly-read cached token is available.
 	tok, tokErr := cfg.currentToken()
 	require.NoError(t, tokErr)
-	assert.Equal(t, "token-v1", tok)
+	require.Equal(t, "token-v1", tok)
 
 	// Wait until a refresh failure is actually logged. This passes the moment the
 	// warning appears and only fails if it never appears within the ceiling, so a
@@ -292,6 +292,12 @@ func TestFileTokenAuthConfig_RefreshFailureLogsWarning(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return strings.Contains(logs.String(), "failed to refresh token")
 	}, 2*time.Second, 10*time.Millisecond)
+
+	// After repeated failed refreshes, the cached token must still be served —
+	// a vanished token file must not clear what was already loaded.
+	tok, tokErr = cfg.currentToken()
+	require.NoError(t, tokErr)
+	assert.Equal(t, "token-v1", tok)
 }
 
 // TestFileTokenAuthConfig_ObservableInjectionViaNewHTTPService verifies that

--- a/pkg/gofr/service/file_token_auth_test.go
+++ b/pkg/gofr/service/file_token_auth_test.go
@@ -1,11 +1,14 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"gofr.dev/pkg/gofr/logging"
-	"gofr.dev/pkg/gofr/testutil"
 )
 
 func testLogger() logging.Logger {
@@ -27,6 +29,63 @@ func writeTokenFile(t *testing.T, content string) string {
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 
 	return path
+}
+
+// stdoutCapture redirects os.Stdout to a pipe and drains it in a background
+// goroutine, so callers can poll String() while a concurrent writer is still
+// emitting — unlike testutil.StdoutOutputForFunc, which only returns the output
+// after the function under test has fully returned.
+type stdoutCapture struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func newConcurrentStdoutCapture(t *testing.T) *stdoutCapture {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	old := os.Stdout
+	os.Stdout = w
+
+	c := &stdoutCapture{}
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		b := make([]byte, 1024)
+
+		for {
+			n, readErr := r.Read(b)
+			if n > 0 {
+				c.mu.Lock()
+				c.buf.Write(b[:n])
+				c.mu.Unlock()
+			}
+
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	t.Cleanup(func() {
+		os.Stdout = old
+		_ = w.Close()
+		<-done
+		_ = r.Close()
+	})
+
+	return c
+}
+
+func (c *stdoutCapture) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.buf.String()
 }
 
 func TestNewFileTokenAuthConfig(t *testing.T) {
@@ -204,29 +263,33 @@ func TestFileTokenAuthConfig_InjectsBearerHeaderAllVerbs(t *testing.T) {
 func TestFileTokenAuthConfig_RefreshFailureLogsWarning(t *testing.T) {
 	path := writeTokenFile(t, "token-v1")
 
-	out := testutil.StdoutOutputForFunc(func() {
-		cfg, err := NewFileTokenAuthConfig(WithTokenFilePath(path), WithRefreshInterval(20*time.Millisecond))
-		require.NoError(t, err)
+	// Capture stdout concurrently so we can wait until the warning is actually
+	// observed rather than sleeping a fixed interval and hoping the background
+	// refresh goroutine was scheduled in time (which is only heuristic).
+	logs := newConcurrentStdoutCapture(t)
 
-		t.Cleanup(func() { _ = cfg.Close() })
+	cfg, err := NewFileTokenAuthConfig(WithTokenFilePath(path), WithRefreshInterval(10*time.Millisecond))
+	require.NoError(t, err)
 
-		// Inject the logger the way NewHTTPService would via the Observable hook.
-		cfg.SetLogger(logging.NewMockLogger(logging.WARN))
+	t.Cleanup(func() { _ = cfg.Close() })
 
-		// Remove the token file so the next refresh tick fails to read it.
-		require.NoError(t, os.Remove(path))
+	// Inject the logger the way NewHTTPService would via the Observable hook.
+	cfg.SetLogger(logging.NewMockLogger(logging.WARN))
 
-		assert.Eventually(t, func() bool {
-			// Cached token must remain available despite refresh failures.
-			tok, tokErr := cfg.currentToken()
-			return tokErr == nil && tok == "token-v1"
-		}, time.Second, 20*time.Millisecond)
+	// Remove the token file so the next refresh tick fails to read it.
+	require.NoError(t, os.Remove(path))
 
-		// Give the refresh loop time to log at least one warning.
-		time.Sleep(100 * time.Millisecond)
-	})
+	// Cached token must remain available despite refresh failures.
+	tok, tokErr := cfg.currentToken()
+	require.NoError(t, tokErr)
+	assert.Equal(t, "token-v1", tok)
 
-	assert.Contains(t, out, "failed to refresh token")
+	// Wait until a refresh failure is actually logged. This passes the moment the
+	// warning appears and only fails if it never appears within the ceiling, so a
+	// briefly-starved goroutine no longer flakes the test.
+	assert.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "failed to refresh token")
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 // TestFileTokenAuthConfig_ObservableInjectionViaNewHTTPService verifies that
@@ -235,22 +298,24 @@ func TestFileTokenAuthConfig_RefreshFailureLogsWarning(t *testing.T) {
 func TestFileTokenAuthConfig_ObservableInjectionViaNewHTTPService(t *testing.T) {
 	path := writeTokenFile(t, "token-v1")
 
-	out := testutil.StdoutOutputForFunc(func() {
-		cfg, err := NewFileTokenAuthConfig(WithTokenFilePath(path), WithRefreshInterval(20*time.Millisecond))
-		require.NoError(t, err)
+	logs := newConcurrentStdoutCapture(t)
 
-		t.Cleanup(func() { _ = cfg.Close() })
+	cfg, err := NewFileTokenAuthConfig(WithTokenFilePath(path), WithRefreshInterval(10*time.Millisecond))
+	require.NoError(t, err)
 
-		// Registering the option through NewHTTPService is what should inject
-		// the logger — no explicit SetLogger call here.
-		_ = NewHTTPService("http://example.invalid", logging.NewMockLogger(logging.WARN), nil, cfg)
+	t.Cleanup(func() { _ = cfg.Close() })
 
-		require.NoError(t, os.Remove(path))
+	// Registering the option through NewHTTPService is what should inject
+	// the logger — no explicit SetLogger call here.
+	_ = NewHTTPService("http://example.invalid", logging.NewMockLogger(logging.WARN), nil, cfg)
 
-		time.Sleep(100 * time.Millisecond)
-	})
+	require.NoError(t, os.Remove(path))
 
-	assert.Contains(t, out, "failed to refresh token")
+	// Wait until the auto-injected logger actually surfaces a refresh failure,
+	// rather than sleeping a fixed interval and hoping the goroutine was scheduled.
+	assert.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "failed to refresh token")
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 // TestFileTokenAuthConfig_WorksWithConnectionPoolConfig locks in the regression

--- a/pkg/gofr/service/file_token_auth_test.go
+++ b/pkg/gofr/service/file_token_auth_test.go
@@ -74,7 +74,9 @@ func newConcurrentStdoutCapture(t *testing.T) *stdoutCapture {
 	t.Cleanup(func() {
 		os.Stdout = old
 		_ = w.Close()
+
 		<-done
+
 		_ = r.Close()
 	})
 


### PR DESCRIPTION
## Description

Fixes flaky `PKG Unit Testing` failures on `development`: a **data race** on server shutdown plus two time-dependent tests. All reproduce only under the full-package run / `-race` / loaded CI runner, not in isolation.

## 1. Data race on `srv` in server shutdown — `Fixes #3762`

`httpServer.run()` **wrote** `s.srv` on the serve goroutine while `App.Shutdown()` **read** it on the caller goroutine, with no synchronization — `Test_Shutdown` failed intermittently under `-race`. The identical write-in-`Run` / read-in-`Shutdown` pattern existed in `metricServer` and `mcpServer` (both surfaced once the httpServer read was fixed).

**Fix:** guard `srv` with a `sync.Mutex` in each server. The lock is held only around the assignment (in `Run`) and the read (in `Shutdown`), **never** across the blocking `ListenAndServe` / `srv.Shutdown`; `Run` serves on a local copy published under the lock.

- `pkg/gofr/http_server.go`
- `pkg/gofr/metrics_server.go`
- `pkg/gofr/mcp.go`

**Scope — this closes the `-race`-visible memory hazard only.** It does *not* fix the separate ordering bug where a signal arriving before the server assigns `srv` makes `Shutdown` see `srv == nil`, report success, and let the listener come up afterwards (the nil check carries no happens-before edge, and `-race` can't see it). That, plus the analogous cron `Stop()`-without-job-join, is tracked in **#3801**. Also out of scope and pre-existing on `development`: a race on `grpcServer.server` (different field, created at registration with a `Fatalf` path) and a `pkg/gofr/websocket` race.

## 2. Flaky unit tests — `Fixes #3799`

### `TestCronTab_AddJob` — `panic: Fail in goroutine after TestCronTab_AddJob has completed` (`pkg/gofr`)

`NewCron` starts a per-second ticker goroutine the test never stopped. Its `* * * * *` job (`"test-job"`) only had *registration* mock expectations. The leaked goroutine outlived the test and, when the run crossed a wall-clock minute boundary (`Starting cron job: test-job` at `…:33:00.000`), fired the job → unexpected `IncrementCounter`/`RecordHistogram` on the mock → gomock called `t.Fatalf` on the finished test → panic.

**Fix:** `defer c.Stop()` in every test that builds a `Crontab` via `NewCron`, plus `AnyTimes()` runtime-metric expectations in `AddJob`. Note `Stop()` only halts future ticks — it cannot join an already-dispatched `go j.run(...)`, so `AnyTimes()` is load-bearing here, not merely defensive; deterministic joining needs the context-aware `Stop()` tracked in #3801.

### `TestFileTokenAuthConfig_RefreshFailureLogsWarning` / `…_ObservableInjectionViaNewHTTPService` (`pkg/gofr/service`)

Asserted a background refresh-failure warning after a fixed `time.Sleep` and a one-shot stdout read (`testutil.StdoutOutputForFunc` only returns after the func exits, so the test could not poll). Under load the refresh goroutine could be starved → empty output → `"" does not contain "failed to refresh token"`.

**Fix:** a small concurrent `stdoutCapture` helper drains stdout in the background so the test can `assert.Eventually(... contains "failed to refresh token", 2s, 10ms)` — bounded-wait instead of a heuristic sleep. The "cached token remains available across failed refreshes" assertion is retained.

## Verification

- `Test_Shutdown` — pass, `-race -count=15` (was flaky/red before)
- `TestCronTab*` — pass, `-count=5`
- `TestFileTokenAuthConfig_RefreshFailureLogsWarning` + `…_ObservableInjectionViaNewHTTPService` — pass, `-race -count=15`
- `go build` + `go vet ./pkg/gofr/ ./pkg/gofr/service/` + `golangci-lint` — clean
