### PR TITLE
fix(cron): join in-flight jobs on Stop and skip jobs with no logger

### DIFF
--- a/docs/guides/graceful-shutdown/page.md
+++ b/docs/guides/graceful-shutdown/page.md
@@ -9,7 +9,7 @@ nextjs:
 # Graceful Shutdown
 
 {% answer %}
-GoFr listens for `SIGINT` and `SIGTERM` and, on either signal, runs `App.Shutdown` which calls `Shutdown` on the HTTP, gRPC, and metrics servers and `Close` on the container's datasource connections. The shutdown is bounded by `SHUTDOWN_GRACE_PERIOD` (default `30s`); if it expires the process exits with whatever connections remain. Pair this with Kubernetes' `terminationGracePeriodSeconds` and a small `preStop` sleep to avoid losing in-flight requests during rolling restarts.
+GoFr listens for `SIGINT` and `SIGTERM` and, on either signal, runs `App.Shutdown` which calls `Shutdown` on the HTTP, gRPC, and metrics servers, stops the cron scheduler and waits for jobs already running, then calls `Close` on the container's datasource connections. The shutdown is bounded by `SHUTDOWN_GRACE_PERIOD` (default `30s`); if it expires the process exits with whatever connections remain. Pair this with Kubernetes' `terminationGracePeriodSeconds` and a small `preStop` sleep to avoid losing in-flight requests during rolling restarts.
 {% /answer %}
 
 ## When to use
@@ -24,15 +24,17 @@ Every production GoFr deployment on Kubernetes should be configured for graceful
 ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 ```
 
-When that context is canceled, a goroutine creates a timeout context using `SHUTDOWN_GRACE_PERIOD` (default `30s`) and calls `App.Shutdown`. The order is fixed by the framework — see [`pkg/gofr/gofr.go:96-114`](https://github.com/gofr-dev/gofr/blob/main/pkg/gofr/gofr.go) — and `Shutdown` joins errors from each step:
+When that context is canceled, a goroutine creates a timeout context using `SHUTDOWN_GRACE_PERIOD` (default `30s`) and calls `App.Shutdown`. The order is fixed by the framework — see [`pkg/gofr/gofr.go`](https://github.com/gofr-dev/gofr/blob/main/pkg/gofr/gofr.go) — and `Shutdown` joins errors from each step:
 
 1. `httpServer.Shutdown(ctx)` — stops accepting new connections, waits for in-flight handlers
 2. `grpcServer.Shutdown(ctx)` — drains active streams
-3. `container.Close()` — closes SQL pools, Redis clients, Pub/Sub consumers, and other registered datasources
+3. Cron stop — halts the scheduler and waits for jobs already running, bounded by the shutdown deadline
 4. `metricServer.Shutdown(ctx)` — stops `/metrics`
-5. Logger close — if the logger implements `io.Closer`, its `Close()` is called last
+5. `mcpServer.Shutdown(ctx)` — stops the MCP server
+6. `container.ShutdownMetrics(ctx)` and `container.Close()` — closes SQL pools, Redis clients, Pub/Sub consumers, and other registered datasources
+7. Logger close — if the logger implements `io.Closer`, its `Close()` is called last
 
-The container's `Close` is what commits Pub/Sub offsets and lets SQL drivers finish in-progress queries. Application code does not need to coordinate this order.
+The container's `Close` is what commits Pub/Sub offsets and lets SQL drivers finish in-progress queries. It runs second-to-last on purpose: every producer of datasource traffic — handlers, streams, cron jobs — is drained before the connections they use are torn down. Application code does not need to coordinate this order.
 
 ## OnStart hooks vs shutdown hooks
 
@@ -87,7 +89,7 @@ For a service with 2s P99, that's 5s + 30s + 10s = 45–60s.
 - **SQL.** `database/sql` waits for active queries to finish on `Close()`. Long-running transactions can extend shutdown — keep request timeouts shorter than `SHUTDOWN_GRACE_PERIOD`.
 - **Redis / NoSQL.** Clients close idle connections immediately and wait for in-flight commands.
 - **Pub/Sub.** GoFr's subscription manager respects the shutdown context — consumers stop polling and commit current offsets where the broker supports it (Kafka, NATS JetStream).
-- **Cron jobs.** GoFr's `App.Shutdown` drains HTTP, gRPC, and metrics servers and closes datasource connections — it does **not** stop the cron scheduler or wait for in-flight cron tasks. Cron jobs run with `context.Background()`, so they continue past SIGTERM and may be cut off when the container is killed at `terminationGracePeriodSeconds`. If you have long-running cron work that must finish, run it as a separate Kubernetes `Job` triggered by a `CronJob` resource instead of inside the same pod, so the pod's lifecycle doesn't interrupt it.
+- **Cron jobs.** `App.Shutdown` stops the cron scheduler and waits for jobs that are already running before it closes datasource connections, so a job mid-write is not cut off by `container.Close()`. The wait is bounded by the shutdown deadline (`SHUTDOWN_GRACE_PERIOD`): if a job is still running when that expires, `Shutdown` returns and the job is abandoned. The jobs themselves run with `context.Background()`, so a job's own `ctx` is never cancelled — anything that needs to be interruptible has to watch something else. For cron work that routinely outlasts `SHUTDOWN_GRACE_PERIOD`, run it as a Kubernetes `CronJob` in its own pod rather than inside the service.
 
 ## Verification
 

--- a/pkg/gofr/cron.go
+++ b/pkg/gofr/cron.go
@@ -35,6 +35,14 @@ type Crontab struct {
 	container *container.Container
 
 	mu sync.RWMutex
+	// stopped is set under mu before done is closed, so a tick that is already
+	// inside runScheduled cannot dispatch a new job goroutine after Stop has
+	// begun waiting for the in-flight ones.
+	stopped bool
+	// wg tracks the job goroutines dispatched by runScheduled so Stop can join
+	// them instead of leaving them to log/record metrics after their owner
+	// (an App, or a test's container) has been torn down.
+	wg sync.WaitGroup
 
 	done chan struct{}
 	once sync.Once
@@ -86,30 +94,78 @@ func NewCron(cntnr *container.Container) *Crontab {
 	return c
 }
 
+// Stop halts the scheduler and blocks until every job goroutine it already
+// dispatched has returned. Joining matters as much as halting: a job that fired
+// on the tick just before Stop keeps logging and recording metrics against a
+// container that the caller is about to tear down.
 func (c *Crontab) Stop() {
+	c.stop(nil)
+}
+
+// stop is Stop with an optional abort channel for the join, so an application
+// shutdown is never held open past its own deadline by a long-running job.
+func (c *Crontab) stop(abort <-chan struct{}) {
 	c.once.Do(func() {
 		c.ticker.Stop()
+
+		c.mu.Lock()
+		c.stopped = true
+		c.mu.Unlock()
+
 		close(c.done)
 	})
+
+	joined := make(chan struct{})
+
+	go func() {
+		c.wg.Wait()
+		close(joined)
+	}()
+
+	select {
+	case <-joined:
+	case <-abort:
+	}
 }
 
 func (c *Crontab) runScheduled(t time.Time) {
+	// The lock is held across dispatch so that Stop cannot slip between the
+	// stopped check and wg.Add. Dispatch only spawns goroutines, and a job that
+	// calls back into AddJob does so from its own goroutine, so this cannot
+	// deadlock.
 	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	n := len(c.jobs)
-	jb := make([]*job, n)
-	copy(jb, c.jobs)
+	if c.stopped {
+		return
+	}
 
-	c.mu.Unlock()
+	tk := getTick(t)
 
-	for _, j := range jb {
-		if j.tick(getTick(t)) {
-			go j.run(c.container)
+	for _, j := range c.jobs {
+		if !j.tick(tk) {
+			continue
 		}
+
+		c.wg.Add(1)
+
+		go func(j *job) {
+			defer c.wg.Done()
+
+			j.run(c.container)
+		}(j)
 	}
 }
 
 func (j *job) run(cntnr *container.Container) {
+	// A job runs on its own goroutine, detached from whoever scheduled it, so a
+	// container that is nil or half-built (no logger) has to be handled here
+	// rather than assumed away — every log below would otherwise nil-panic on a
+	// background goroutine and take the whole process down.
+	if cntnr == nil || cntnr.Logger == nil {
+		return
+	}
+
 	ctx, span := otel.GetTracerProvider().Tracer("gofr-"+version.Framework).
 		Start(context.Background(), j.name)
 	defer span.End()

--- a/pkg/gofr/cron_test.go
+++ b/pkg/gofr/cron_test.go
@@ -2,6 +2,7 @@ package gofr
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -771,7 +772,8 @@ func TestCronTab_runScheduled_NilLoggerAndContainer(t *testing.T) {
 
 func TestCrontab_Stop_JoinsInFlightJobs(t *testing.T) {
 	release := make(chan struct{})
-	finished := make(chan struct{})
+
+	var runs atomic.Int64
 
 	c := &Crontab{
 		ticker:    time.NewTicker(time.Second),
@@ -786,8 +788,8 @@ func TestCrontab_Stop_JoinsInFlightJobs(t *testing.T) {
 			dayOfWeek: map[int]struct{}{1: {}},
 			name:      "slow-job",
 			fn: func(*Context) {
+				runs.Add(1)
 				<-release
-				close(finished)
 			},
 		}},
 	}
@@ -811,14 +813,18 @@ func TestCrontab_Stop_JoinsInFlightJobs(t *testing.T) {
 
 	select {
 	case <-stopped:
-		<-finished
 	case <-time.After(time.Second):
 		t.Fatal("Stop did not return after the job finished")
 	}
 
-	// A tick that lands after Stop must not dispatch anything more.
+	require.Equal(t, int64(1), runs.Load(), "Stop must return only after the dispatched job has run")
+
+	// A tick that lands after Stop must not dispatch anything more. The second Stop joins
+	// whatever that tick dispatched, so the count below is read after any such job has finished.
 	c.runScheduled(time.Date(2024, 1, 1, 1, 1, 1, 1, time.Local))
 	c.Stop()
+
+	require.Equal(t, int64(1), runs.Load(), "a tick after Stop must not dispatch a job")
 }
 
 func TestCrontab_Stop(t *testing.T) {

--- a/pkg/gofr/cron_test.go
+++ b/pkg/gofr/cron_test.go
@@ -214,15 +214,10 @@ func TestCronTab_AddJob(t *testing.T) {
 	mocks.Metrics.EXPECT().NewCounter("app_cron_job_success", gomock.Any()).AnyTimes()
 	mocks.Metrics.EXPECT().NewCounter("app_cron_job_failures", gomock.Any()).AnyTimes()
 
-	// These AnyTimes() runtime expectations are load-bearing, not merely
-	// defensive: Stop() below halts only *future* ticks, it does not join a job
-	// goroutine that a tick already dispatched (Crontab fires `go j.run(...)` with
-	// no WaitGroup). The "* * * * *" job fires at second 0 of every minute, so a
-	// job dispatched just before Stop can still call the metrics mock after the
-	// test returns; without these expectations that call is gomock's
-	// t.Fatalf-on-finished-test -> panic. `defer c.Stop()` narrows the window but
-	// cannot close it — deterministic joining needs a framework change to Stop
-	// (tracked in gofr-dev/gofr#3801). Do not remove these believing Stop covers it.
+	// Stop() now joins the job goroutines a tick already dispatched, so a job can
+	// no longer reach the metrics mock after the test returns. These AnyTimes()
+	// expectations remain because the "* * * * *" job can legitimately fire at
+	// second 0 of a minute *during* the test, and the count is timing-dependent.
 	mocks.Metrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	mocks.Metrics.EXPECT().RecordHistogram(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
@@ -733,6 +728,97 @@ func TestCronTab_runScheduled_Panic(t *testing.T) {
 			assert.Contains(t, logs, tc.panicMessage)
 		})
 	}
+}
+
+func TestCronTab_runScheduled_NilLoggerAndContainer(t *testing.T) {
+	tests := []struct {
+		desc  string
+		cntnr *container.Container
+	}{
+		{"nil container", nil},
+		{"container without logger", &container.Container{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			ran := make(chan struct{}, 1)
+
+			c := &Crontab{
+				ticker:    time.NewTicker(time.Second),
+				container: tc.cntnr,
+				done:      make(chan struct{}),
+				jobs: []*job{{
+					sec:       map[int]struct{}{1: {}},
+					min:       map[int]struct{}{1: {}},
+					hour:      map[int]struct{}{1: {}},
+					day:       map[int]struct{}{1: {}},
+					month:     map[int]struct{}{1: {}},
+					dayOfWeek: map[int]struct{}{1: {}},
+					name:      "nil-logger-job",
+					fn:        func(*Context) { ran <- struct{}{} },
+				}},
+			}
+
+			// A panic here happens on the job's own goroutine and kills the test
+			// binary, so reaching Stop at all is the assertion.
+			c.runScheduled(time.Date(2024, 1, 1, 1, 1, 1, 1, time.Local))
+			c.Stop()
+
+			assert.Empty(t, ran, "job must be skipped when it cannot log")
+		})
+	}
+}
+
+func TestCrontab_Stop_JoinsInFlightJobs(t *testing.T) {
+	release := make(chan struct{})
+	finished := make(chan struct{})
+
+	c := &Crontab{
+		ticker:    time.NewTicker(time.Second),
+		container: &container.Container{Logger: logging.NewMockLogger(logging.ERROR)},
+		done:      make(chan struct{}),
+		jobs: []*job{{
+			sec:       map[int]struct{}{1: {}},
+			min:       map[int]struct{}{1: {}},
+			hour:      map[int]struct{}{1: {}},
+			day:       map[int]struct{}{1: {}},
+			month:     map[int]struct{}{1: {}},
+			dayOfWeek: map[int]struct{}{1: {}},
+			name:      "slow-job",
+			fn: func(*Context) {
+				<-release
+				close(finished)
+			},
+		}},
+	}
+
+	c.runScheduled(time.Date(2024, 1, 1, 1, 1, 1, 1, time.Local))
+
+	stopped := make(chan struct{})
+
+	go func() {
+		c.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		t.Fatal("Stop returned while a job was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-stopped:
+		<-finished
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after the job finished")
+	}
+
+	// A tick that lands after Stop must not dispatch anything more.
+	c.runScheduled(time.Date(2024, 1, 1, 1, 1, 1, 1, time.Local))
+	c.Stop()
 }
 
 func TestCrontab_Stop(t *testing.T) {

--- a/pkg/gofr/datasource/sql/sql_test.go
+++ b/pkg/gofr/datasource/sql/sql_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -350,31 +352,69 @@ func Test_sqliteErrConnLogs(t *testing.T) {
 	}
 }
 
+// waitLogger is a datasource.Logger that closes seen once a message containing
+// want has been logged. It replaces capturing stdout and sleeping for a fixed
+// duration: the retry goroutine only logs after its first ping fails, and that
+// ping's cost is a DNS lookup on the CI host, not a constant.
+type waitLogger struct {
+	want string
+	seen chan struct{}
+	once sync.Once
+}
+
+func newWaitLogger(want string) *waitLogger {
+	return &waitLogger{want: want, seen: make(chan struct{})}
+}
+
+func (l *waitLogger) record(msg string) {
+	if strings.Contains(msg, l.want) {
+		l.once.Do(func() { close(l.seen) })
+	}
+}
+
+func (l *waitLogger) Debug(args ...any)            { l.record(fmt.Sprint(args...)) }
+func (l *waitLogger) Debugf(f string, args ...any) { l.record(fmt.Sprintf(f, args...)) }
+func (l *waitLogger) Info(args ...any)             { l.record(fmt.Sprint(args...)) }
+func (l *waitLogger) Infof(f string, args ...any)  { l.record(fmt.Sprintf(f, args...)) }
+func (l *waitLogger) Warn(args ...any)             { l.record(fmt.Sprint(args...)) }
+func (l *waitLogger) Warnf(f string, args ...any)  { l.record(fmt.Sprintf(f, args...)) }
+func (l *waitLogger) Error(args ...any)            { l.record(fmt.Sprint(args...)) }
+func (l *waitLogger) Errorf(f string, args ...any) { l.record(fmt.Sprintf(f, args...)) }
+
 func Test_SQLRetryConnectionInfoLog(t *testing.T) {
-	logs := testutil.StdoutOutputForFunc(func() {
-		ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(t)
 
-		mockMetrics := NewMockMetrics(ctrl)
-		mockConfig := config.NewMockConfig(map[string]string{
-			"DB_DIALECT":  "postgres",
-			"DB_HOST":     "host",
-			"DB_USER":     "user",
-			"DB_PASSWORD": "password",
-			"DB_PORT":     "3201",
-			"DB_NAME":     "test",
-		})
-
-		mockLogger := logging.NewMockLogger(logging.DEBUG)
-
-		mockMetrics.EXPECT().SetGauge("app_sql_open_connections", float64(0))
-		mockMetrics.EXPECT().SetGauge("app_sql_inUse_connections", float64(0))
-
-		_ = NewSQL(mockConfig, mockLogger, mockMetrics)
-
-		time.Sleep(100 * time.Millisecond)
+	mockMetrics := NewMockMetrics(ctrl)
+	mockConfig := config.NewMockConfig(map[string]string{
+		"DB_DIALECT":  "postgres",
+		"DB_HOST":     "host",
+		"DB_USER":     "user",
+		"DB_PASSWORD": "password",
+		"DB_PORT":     "3201",
+		"DB_NAME":     "test",
 	})
 
-	assert.Contains(t, logs, "retrying SQL database connection")
+	logger := newWaitLogger("retrying SQL database connection")
+
+	// pushDBMetrics emits both gauges from its own goroutine and repeats every
+	// 10s, so neither the number of calls nor their timing relative to the end of
+	// this test is something the test controls. Pinning them to the default
+	// Times(1) is what made this flaky; the gauges are incidental here anyway.
+	mockMetrics.EXPECT().SetGauge("app_sql_open_connections", gomock.Any()).AnyTimes()
+	mockMetrics.EXPECT().SetGauge("app_sql_inUse_connections", gomock.Any()).AnyTimes()
+
+	db := NewSQL(mockConfig, logger, mockMetrics)
+	require.NotNil(t, db)
+
+	// Close stops the retry and metrics goroutines, so neither can touch the
+	// gomock controller after the test has finished.
+	t.Cleanup(func() { _ = db.Close() })
+
+	select {
+	case <-logger.seen:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the retry connection log")
+	}
 }
 
 func TestNewSQL_CockroachDB(t *testing.T) {

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -105,7 +105,9 @@ func (a *App) Shutdown(ctx context.Context) error {
 	}
 
 	if a.cron != nil {
-		a.cron.Stop()
+		// Joins the in-flight cron jobs, but only until the shutdown deadline —
+		// a job that outlives it must not hold the whole shutdown open.
+		a.cron.stop(ctx.Done())
 	}
 
 	if a.metricServer != nil {

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -1123,6 +1123,10 @@ func Test_AddCronJob_Fail(t *testing.T) {
 		})
 	})
 
+	// AddCronJob starts the scheduler even when the schedule itself is rejected;
+	// without this the ticker goroutine outlives the test.
+	a.cron.Stop()
+
 	assert.Contains(t, stderr, "error adding cron job")
 	assert.NotContains(t, stderr, "test-job-fail")
 }
@@ -1130,12 +1134,17 @@ func Test_AddCronJob_Fail(t *testing.T) {
 func Test_AddCronJob_Success(t *testing.T) {
 	pass := false
 	a := App{
-		container: &container.Container{},
+		container: &container.Container{Logger: logging.NewMockLogger(logging.ERROR)},
 	}
 
 	a.AddCronJob("* * * * *", "test-job", func(ctx *Context) {
 		ctx.Logger.Info("test-job-success")
 	})
+
+	// "* * * * *" fires at second 0 of every minute. Left running, this scheduler
+	// outlives the test and its job goroutine logs against a container the test
+	// no longer owns — the nil-logger panic seen in gofr-dev/gofr#3813.
+	defer a.cron.Stop()
 
 	assert.Len(t, a.cron.jobs, 1)
 


### PR DESCRIPTION
**Description:**

Fixes #3813. Also closes #3799 and the cron half of #3801. #3801 should stay open for the server half.

**What this actually fixes is data loss during shutdown, not just a flaky test.** `App.Shutdown` stops cron and *then* closes the datasources:

```go
a.cron.stop(...)       // before this change: returned as soon as the ticker halted
...
a.container.Close()    // closes SQL, Redis, pub/sub
```

Because `Stop()` returned without joining, a job still mid-work when `Shutdown` was called kept running against datasources that were being torn down underneath it — its next query fails with `sql: database is closed`, a half-written batch loses its remaining work, and the error lands after the log file is closed too. Confirmed in review against a real app on MySQL: on `development` `Shutdown` returned in 0s and the job's next query errored; with this change `Shutdown` waited 110ms and the query returned `<nil>`.

The nil-logger crash likewise is not test-only: calling `job.run` with a logger-less container panics `SIGSEGV` in `logging.(*ContextLogger).Infof` and takes the process down. The minute-boundary timing is only what made CI hit it intermittently.

#3799 reports a different symptom from the same leak: `TestCronTab_AddJob`'s unstopped `Crontab` crosses a minute boundary and its job goroutine calls the metrics mock after the test finished, so gomock raises `Fatalf` on a completed test's controller. The `Stop()` join added here is what closes that window — the `AnyTimes()` expectations merged in 24198290 (#3800) only masked it. #3799's other half (the `FileTokenAuth` refresh-log tests) already landed in that same commit, so this PR completes it.

Two unit tests failed intermittently on the `PKG Unit Testing (v1.26)` CI leg while `v1.24`/`v1.25` passed on the same commit. Both are the same shape: **a background goroutine outliving the test that owns the state it touches.**

**1. `pkg/gofr` — SIGSEGV in the cron job goroutine**

```
panic: runtime error: invalid memory address or nil pointer dereference
logging.(*ContextLogger).Infof  ->  gofr.(*job).run  <-  created by gofr.(*Crontab).runScheduled
```

`Test_AddCronJob_Success` builds `App{container: &container.Container{}}` — **no logger** — registers a `"* * * * *"` job, and never stops the scheduler. `NewCron`'s ticker goroutine therefore runs for the rest of the test binary; at second 0 of the next minute it dispatches `go j.run(container)`, which builds a `ContextLogger` over a nil base and segfaults in `Infof`. Whether the binary is still alive at a minute boundary is the entire timing dependence.

`Stop()` could not have prevented this either: it halted the ticker but did **not** join job goroutines an earlier tick had already dispatched (`go j.run(...)`, no `WaitGroup`) — the gap already noted in a `cron_test.go` comment pointing at #3801.

**2. `datasource/sql` — `Test_SQLRetryConnectionInfoLog`**

```
missing call(s) to *sql.MockMetrics.SetGauge(app_sql_open_connections, 0)
missing call(s) to *sql.MockMetrics.SetGauge(app_sql_inUse_connections, 0)
```

Not an ordering problem, despite the issue's initial read — `pushDBMetrics` emits the two gauges in a fixed order. It is count and timing: the expectations sat at gomock's default `Times(1)` while the goroutine re-emits both every 10s and the DB was never closed, and the test waited a fixed `100ms`. On a loaded runner nothing had been emitted by the time the controller finished.

**Changes**

Framework (`pkg/gofr/cron.go`, `pkg/gofr/gofr.go`):

- `Crontab` tracks dispatched jobs in a `sync.WaitGroup` and sets a `stopped` flag under the existing mutex, so `Stop` halts the ticker **and** joins in-flight jobs, and a tick racing `Stop` cannot dispatch after the join begins.
- `App.Shutdown` joins through an unexported `stop(abort <-chan struct{})` fed by `ctx.Done()`, so a long-running user job cannot hold shutdown open past the caller's own deadline. Public `Stop()` passes `nil` and waits indefinitely — that is the standalone/test contract. `stop` takes a channel rather than a `context.Context` to avoid growing the cron API a context parameter it has no other use for.
- `job.run` returns early when the container or its logger is nil, so a detached job goroutine can never nil-panic the process.

Guarding in `job.run` rather than in `logging.NewContextLogger` is deliberate: making `ContextLogger` tolerate a nil base would kill this class of panic framework-wide, but it would also silently swallow logs for every misconfigured container and mask the underlying wiring bug. The nil case is real only for detached background goroutines, so the guard sits where the detachment happens.

Tests:

- Both `AddCronJob` tests stop their scheduler; the success case gets a real logger.
- `Test_SQLRetryConnectionInfoLog` waits on a logger that signals when the retry line is actually written (no sleep), closes the DB via `t.Cleanup` so nothing touches the controller after the test, and relaxes the gauge expectations to `AnyTimes()` — they are incidental to what this test asserts.
- New `TestCrontab_Stop_JoinsInFlightJobs`: `Stop` blocks until a running job returns, and a post-`Stop` tick dispatches nothing. Both halves are asserted by counting runs in an `atomic.Int64` — the second `Stop` joins whatever the post-`Stop` tick dispatched, so the count is read after any such job has returned. Verified by mutation: removing the `stopped` check in `runScheduled` fails this test `1 != 2`. (An earlier revision only *called* `runScheduled`/`Stop` with a comment and no assertion, which the re-dispatched job's own `recover()` swallowed.)
- New `TestCronTab_runScheduled_NilLoggerAndContainer`: a nil / logger-less container is skipped rather than fatal.


**Breaking Changes (if applicable):**

`Crontab.Stop()` now blocks until in-flight cron jobs return, where previously it returned as soon as the ticker was stopped. That is the point of the fix — an unjoined job keeps logging and recording metrics against a container the caller is tearing down — but it is a visible behaviour change for anyone calling `Stop()` directly with a long-running job.

Application shutdown is not exposed to that: `App.Shutdown` passes its own `ctx.Done()` as the abort channel, so the join is capped at the caller's existing deadline and a slow job cannot extend shutdown.

No API signature changes; `Stop()` keeps its zero-argument form.


**Additional Information:**

No new dependencies.

Verification:

- `go build ./...` clean; `go vet` clean on both packages.
- `go test ./pkg/gofr/ ./pkg/gofr/datasource/sql/` passes; 5 consecutive runs of `pkg/gofr` green.
- `golangci-lint` reports no new findings from the changed files — the hits that remain in them all reproduce on `development`.

Two pre-existing failures confirmed unrelated, by stashing the change and re-running on clean `development`:

- `TestGRPC_ServerShutdown_ContextCanceled` races under `-race` (pre-existing `g.server` race in `grpc.go`).
- `go test ./pkg/gofr/ -count=3` fatals on the fixed metrics port 2121.


**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.


