### PR TITLE
fix(examples): wait on a readiness signal instead of sleeping, and make using-migrations self-contained (#3818, #3816)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -122,13 +122,17 @@ jobs:
           docker logs minio || true
           exit 1
 
-      # Run tests with automatic retry on failures
-      - name: Test with Retry Logic
+      - name: Test
         id: test
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5  # Maximum time for the tests to run
-          max_attempts: 2      # Retry up to 2 times if tests fail
+          # No retry. The example tests used to race their own server's boot — every one of them
+          # slept a fixed 100ms after `go main()` and hoped — and a retry turned that into a green
+          # tick. It equally hid a real regression that happened to pass on the second attempt.
+          # They now wait on a readiness signal (testutil.WaitFor*), so a failure here is a
+          # failure. The action is kept for its timeout_minutes.
+          max_attempts: 1
           command: |
             # The retry action runs this block with a plain shell (no errexit),
             # unlike native `run:` steps that default to `bash -eo pipefail`.

--- a/examples/grpc/grpc-streaming-server/main_test.go
+++ b/examples/grpc/grpc-streaming-server/main_test.go
@@ -14,6 +14,8 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	"gofr.dev/examples/grpc/grpc-streaming-server/server"
@@ -58,7 +60,11 @@ func TestMain(m *testing.M) {
 	grpcHost = fmt.Sprintf("localhost:%d", grpcPort)
 
 	go main()
-	time.Sleep(300 * time.Millisecond) // wait for server to boot
+
+	if err := waitForServer(grpcHost); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	os.Exit(m.Run())
 }
@@ -76,6 +82,33 @@ func reserveFreePort() (int, error) {
 	port := listener.Addr().(*net.TCPAddr).Port
 
 	return port, listener.Close()
+}
+
+// waitForServer blocks until a gRPC connection to addr is ready, so the tests below do not race
+// the server's boot. It mirrors testutil.WaitForGRPCServer, which cannot be used here: TestMain
+// gets a *testing.M and has no *testing.T to fail. A bare TCP dial would not do — the kernel
+// accepts connections from the moment the listener exists, whereas reaching the ready state means
+// the HTTP/2 handshake completed and the server is really serving.
+func waitForServer(addr string) error {
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("failed to create a gRPC client for %s: %w", addr, err)
+	}
+
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn.Connect()
+
+	for state := conn.GetState(); state != connectivity.Ready; state = conn.GetState() {
+		if !conn.WaitForStateChange(ctx, state) {
+			return fmt.Errorf("gRPC server at %s did not start in time", addr)
+		}
+	}
+
+	return nil
 }
 
 func TestServerStream(t *testing.T) {
@@ -160,8 +193,9 @@ func TestBiDiStream(t *testing.T) {
 	messages := []string{"msg1", "msg2", "msg3"}
 	go func() {
 		for _, msg := range messages {
+			// No pacing needed: the server handles this stream's messages one at a time and
+			// replies in order, so the responses stay ordered regardless of send timing.
 			_ = stream.Send(&server.Request{Message: msg})
-			time.Sleep(100 * time.Millisecond)
 		}
 		_ = stream.CloseSend()
 	}()
@@ -220,10 +254,9 @@ func TestServerStream_ContextCancellation(t *testing.T) {
 
 		if !receivedFirst {
 			receivedFirst = true
-			// Cancel context to trigger cancellation handling
+			// Cancel context to trigger cancellation handling. The next Recv then fails with
+			// Canceled off the client's own context — nothing to wait for the server on.
 			cancel()
-			// Give server time to detect cancellation
-			time.Sleep(200 * time.Millisecond)
 		}
 
 		_ = resp // Use response to avoid unused variable
@@ -267,10 +300,9 @@ func TestClientStream_ContextCancellation(t *testing.T) {
 		t.Fatalf("Send failed: %v", err)
 	}
 
-	// Cancel context
+	// Cancel context. The call below fails with Canceled off the client's own context, so there
+	// is nothing to wait for the server to notice.
 	cancel()
-	// Give server time to detect cancellation
-	time.Sleep(200 * time.Millisecond)
 
 	// Try to close and receive - should get cancellation error
 	_, err = stream.CloseAndRecv()
@@ -357,10 +389,9 @@ func TestBiDiStream_ContextCancellation(t *testing.T) {
 		t.Errorf("Unexpected response: got %q, want %q", resp.GetMessage(), "Echo: test")
 	}
 
-	// Cancel context
+	// Cancel context. The call below fails with Canceled off the client's own context, so there
+	// is nothing to wait for the server to notice.
 	cancel()
-	// Give server time to detect cancellation
-	time.Sleep(200 * time.Millisecond)
 
 	// Try to receive - should get cancellation error
 	_, err = stream.Recv()

--- a/examples/grpc/grpc-streaming-server/main_test.go
+++ b/examples/grpc/grpc-streaming-server/main_test.go
@@ -40,9 +40,9 @@ func TestMain(m *testing.M) {
 
 	go main()
 
-	// AwaitGRPCServer rather than WaitForGRPCServer: TestMain gets a *testing.M and has no
+	// WaitForGRPCServerE rather than WaitForGRPCServer: TestMain gets a *testing.M and has no
 	// *testing.T for require to fail on, so it takes the error-returning variant of the same wait.
-	if err := testutil.AwaitGRPCServer(grpcHost); err != nil {
+	if err := testutil.WaitForGRPCServerE(grpcHost); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/examples/grpc/grpc-streaming-server/main_test.go
+++ b/examples/grpc/grpc-streaming-server/main_test.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -19,45 +17,28 @@ import (
 	"google.golang.org/grpc/status"
 
 	"gofr.dev/examples/grpc/grpc-streaming-server/server"
+	"gofr.dev/pkg/gofr/testutil"
 )
 
-// grpcHost is the address the example server under test listens on.
-//
-// The example's configs/.env pins GRPC_PORT=9000 for documentation purposes,
-// but the test must not inherit it: `go test ./examples/...` runs packages
-// concurrently and CI additionally binds host port 9000 (MinIO), so a fixed
-// port makes the server fail to bind and the whole package abort with
-// "gRPC port 9000 is blocked or unreachable". Reserve free ports instead —
-// the same thing testutil.NewServerConfigs does for tests that have a
-// *testing.T to attach the env cleanup to, which TestMain does not.
+// grpcHost is the address the example's gRPC server listens on, assigned in TestMain.
 var grpcHost string
 
 func TestMain(m *testing.M) {
 	os.Setenv("GOFR_TELEMETRY", "false")
 
-	grpcPort, err := reserveFreePort()
+	// Point the example at free ports rather than the fixed ones its configs/.env asks for. A
+	// fixed port is a hazard in a test: gofr.New() reports an already-taken port with Fatalf,
+	// which exits the process, so the whole package dies before a single test runs. configs/.env
+	// asks for GRPC_PORT 9000 — the port MinIO serves on, including in the CI job that runs these
+	// very tests. The system environment takes precedence over the config file, so what is set
+	// here is what the example uses.
+	configs, err := testutil.ReserveServerPorts()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "could not reserve a free gRPC port: %v\n", err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
-	httpPort, err := reserveFreePort()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "could not reserve a free HTTP port: %v\n", err)
-		os.Exit(1)
-	}
-
-	metricsPort, err := reserveFreePort()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "could not reserve a free metrics port: %v\n", err)
-		os.Exit(1)
-	}
-
-	os.Setenv("GRPC_PORT", strconv.Itoa(grpcPort))
-	os.Setenv("HTTP_PORT", strconv.Itoa(httpPort))
-	os.Setenv("METRICS_PORT", strconv.Itoa(metricsPort))
-
-	grpcHost = fmt.Sprintf("localhost:%d", grpcPort)
+	grpcHost = configs.GRPCHost
 
 	go main()
 
@@ -67,21 +48,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
-}
-
-// reserveFreePort asks the kernel for a free port and releases it immediately
-// so the server under test can bind it.
-func reserveFreePort() (int, error) {
-	lc := net.ListenConfig{}
-
-	listener, err := lc.Listen(context.Background(), "tcp", "localhost:0")
-	if err != nil {
-		return 0, err
-	}
-
-	port := listener.Addr().(*net.TCPAddr).Port
-
-	return port, listener.Close()
 }
 
 // waitForServer blocks until a gRPC connection to addr is ready, so the tests below do not race

--- a/examples/grpc/grpc-streaming-server/main_test.go
+++ b/examples/grpc/grpc-streaming-server/main_test.go
@@ -12,8 +12,6 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	"gofr.dev/examples/grpc/grpc-streaming-server/server"
@@ -42,39 +40,14 @@ func TestMain(m *testing.M) {
 
 	go main()
 
-	if err := waitForServer(grpcHost); err != nil {
+	// AwaitGRPCServer rather than WaitForGRPCServer: TestMain gets a *testing.M and has no
+	// *testing.T for require to fail on, so it takes the error-returning variant of the same wait.
+	if err := testutil.AwaitGRPCServer(grpcHost); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
 	os.Exit(m.Run())
-}
-
-// waitForServer blocks until a gRPC connection to addr is ready, so the tests below do not race
-// the server's boot. It mirrors testutil.WaitForGRPCServer, which cannot be used here: TestMain
-// gets a *testing.M and has no *testing.T to fail. A bare TCP dial would not do — the kernel
-// accepts connections from the moment the listener exists, whereas reaching the ready state means
-// the HTTP/2 handshake completed and the server is really serving.
-func waitForServer(addr string) error {
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return fmt.Errorf("failed to create a gRPC client for %s: %w", addr, err)
-	}
-
-	defer conn.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	conn.Connect()
-
-	for state := conn.GetState(); state != connectivity.Ready; state = conn.GetState() {
-		if !conn.WaitForStateChange(ctx, state) {
-			return fmt.Errorf("gRPC server at %s did not start in time", addr)
-		}
-	}
-
-	return nil
 }
 
 func TestServerStream(t *testing.T) {

--- a/examples/grpc/grpc-unary-client/main_test.go
+++ b/examples/grpc/grpc-unary-client/main_test.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,15 +55,14 @@ func TestIntegration_UnaryClient(t *testing.T) {
 	}()
 	defer grpcServer.Stop()
 
-	// Give gRPC server time to start
-	time.Sleep(100 * time.Millisecond)
+	testutil.WaitForGRPCServer(t, configs.GRPCHost)
 
 	// Set the gRPC server host for the client
 	t.Setenv("GRPC_SERVER_HOST", configs.GRPCHost)
 
 	// Start the HTTP server (unary client example)
 	go main()
-	time.Sleep(100 * time.Millisecond) // Give HTTP server time to start
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	// Test HTTP endpoints that use GoFr gRPC client internally
 	tests := []struct {
@@ -115,15 +113,14 @@ func TestIntegration_UnaryClient_Concurrent(t *testing.T) {
 	}()
 	defer grpcServer.Stop()
 
-	// Give gRPC server time to start
-	time.Sleep(100 * time.Millisecond)
+	testutil.WaitForGRPCServer(t, configs.GRPCHost)
 
 	// Set the gRPC server host for the client
 	t.Setenv("GRPC_SERVER_HOST", configs.GRPCHost)
 
 	// Start the HTTP server (unary client example)
 	go main()
-	time.Sleep(100 * time.Millisecond) // Give HTTP server time to start
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	numClients := 5
 	done := make(chan bool, numClients)

--- a/examples/grpc/grpc-unary-server/main_test.go
+++ b/examples/grpc/grpc-unary-server/main_test.go
@@ -29,7 +29,7 @@ func TestIntegration_UnaryServer(t *testing.T) {
 	configs := testutil.NewServerConfigs(t)
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Giving some time to start the server
+	testutil.WaitForGRPCServer(t, configs.GRPCHost)
 
 	// Create gRPC client connection
 	conn, err := grpc.Dial(configs.GRPCHost, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -64,7 +64,7 @@ func TestIntegration_UnaryServer_Concurrent(t *testing.T) {
 	configs := testutil.NewServerConfigs(t)
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Giving some time to start the server
+	testutil.WaitForGRPCServer(t, configs.GRPCHost)
 
 	// Create gRPC client connection
 	conn, err := grpc.Dial(configs.GRPCHost, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -97,7 +97,7 @@ func TestIntegration_UnaryServer_ErrorHandling(t *testing.T) {
 	configs := testutil.NewServerConfigs(t)
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Giving some time to start the server
+	testutil.WaitForGRPCServer(t, configs.GRPCHost)
 
 	// Create gRPC client connection
 	conn, err := grpc.Dial(configs.GRPCHost, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -164,7 +164,7 @@ func TestIntegration_UnaryServer_RateLimited(t *testing.T) {
 		app.Run()
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	testutil.WaitForGRPCServer(t, configs.GRPCHost)
 
 	conn, err := grpc.NewClient(configs.GRPCHost, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err, "Failed to connect to rate-limited server")

--- a/examples/grpc/grpc-unary-server/server/health_test.go
+++ b/examples/grpc/grpc-unary-server/server/health_test.go
@@ -50,9 +50,11 @@ func TestGoFrHealthServer_Methods(t *testing.T) {
 	ctx := createTestContext()
 
 	t.Run("CheckMethodExists", func(t *testing.T) {
-		// Test that GoFr's Check method exists and accepts correct parameters
+		// The health server is a process-wide singleton, so this name must be one no other test
+		// registers — TestGoFrHealthServer_SetServingStatus registers "test-service", which made
+		// this sub-test fail on the second and later iterations of `go test -count=N`.
 		req := &healthpb.HealthCheckRequest{
-			Service: "test-service",
+			Service: "never-registered-service",
 		}
 
 		// Test GoFr's Check method signature - this will fail with "unknown service" which is expected

--- a/examples/http-server-using-redis/main_test.go
+++ b/examples/http-server-using-redis/main_test.go
@@ -31,7 +31,7 @@ func TestHTTPServerUsingRedis(t *testing.T) {
 	configs := testutil.NewServerConfigs(t)
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Giving some time to start the server
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	tests := []struct {
 		desc       string

--- a/examples/http-server/main_test.go
+++ b/examples/http-server/main_test.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/go-redis/redismock/v9"
 	"github.com/stretchr/testify/assert"
@@ -56,7 +55,7 @@ func TestIntegration_SimpleAPIServer(t *testing.T) {
 	host := fmt.Sprintf("http://localhost:%d", httpPort)
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Giving some time to start the server
+	testutil.WaitForHTTPServer(t, host)
 
 	tests := []struct {
 		desc string
@@ -106,7 +105,7 @@ func TestIntegration_SimpleAPIServer_Errors(t *testing.T) {
 	host := fmt.Sprintf("http://localhost:%d", httpPort)
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Giving some time to start the server
+	testutil.WaitForHTTPServer(t, host)
 
 	tests := []struct {
 		desc       string
@@ -171,7 +170,7 @@ func TestIntegration_SimpleAPIServer_Health(t *testing.T) {
 	host := fmt.Sprintf("http://localhost:%d", httpPort)
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Giving some time to start the server
+	testutil.WaitForHTTPServer(t, host)
 
 	tests := []struct {
 		desc       string

--- a/examples/using-add-rest-handlers/main_test.go
+++ b/examples/using-add-rest-handlers/main_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,7 +21,9 @@ func TestIntegration_AddRESTHandlers(t *testing.T) {
 	configs := testutil.NewServerConfigs(t)
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Giving some time to start the server
+	// On a datastore that has not seen this example before, the migration runs at startup, which a
+	// fixed sleep would not reliably cover.
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	tests := []struct {
 		desc       string

--- a/examples/using-cron-jobs/main_test.go
+++ b/examples/using-cron-jobs/main_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gofr.dev/pkg/gofr/testutil"
 )
@@ -19,16 +19,17 @@ func Test_UserPurgeCron(t *testing.T) {
 	configs := testutil.NewServerConfigs(t)
 
 	go main()
-	time.Sleep(1100 * time.Millisecond)
 
-	expected := 1
+	// The job is scheduled every second. Waiting on the counter it increments covers both the
+	// server's startup and the first tick, neither of which fits a fixed duration: a sleep long
+	// enough for a loaded runner also lets the job fire more than once, which the old
+	// assert.Equal(1, n) would then fail on.
+	require.Eventually(t, func() bool {
+		mu.RLock()
+		defer mu.RUnlock()
 
-	var m int
+		return n > 0
+	}, 30*time.Second, 100*time.Millisecond, "cron job did not run in time")
 
-	mu.Lock()
-	m = n
-	mu.Unlock()
-
-	assert.Equal(t, expected, m)
 	t.Logf("Metrics server running at: %s", configs.MetricsHost)
 }

--- a/examples/using-custom-metrics/main_test.go
+++ b/examples/using-custom-metrics/main_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -22,7 +21,7 @@ func TestIntegration(t *testing.T) {
 	configs := testutil.NewServerConfigs(t)
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Giving some time to start the server
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	c := http.Client{}
 

--- a/examples/using-file-bind/main_test.go
+++ b/examples/using-file-bind/main_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +23,7 @@ func TestMain_BindError(t *testing.T) {
 	configs := testutil.NewServerConfigs(t)
 
 	go main()
-	time.Sleep(100 * time.Millisecond)
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	c := http.Client{}
 

--- a/examples/using-graphql/main_test.go
+++ b/examples/using-graphql/main_test.go
@@ -8,31 +8,12 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gofr.dev/pkg/gofr"
 	"gofr.dev/pkg/gofr/testutil"
 )
-
-func waitForReady(t *testing.T, host string) {
-	t.Helper()
-	client := &http.Client{Timeout: 1 * time.Second}
-	deadline := time.Now().Add(10 * time.Second)
-
-	for time.Now().Before(deadline) {
-		resp, err := client.Get(host + "/.well-known/alive")
-		if err == nil {
-			resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				return
-			}
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	t.Fatalf("Server at %s not ready after 10s", host)
-}
 
 // newTestApp creates a GoFr application configured for integration testing.
 func newTestApp(t *testing.T) (*gofr.App, string) {
@@ -93,7 +74,7 @@ func TestIntegration_GraphQL(t *testing.T) {
 
 	go app.Run()
 
-	waitForReady(t, host)
+	testutil.WaitForHTTPServer(t, host)
 
 	t.Run("hello query", func(t *testing.T) {
 		query := `{"query": "{ hello }"}`

--- a/examples/using-html-template/main_test.go
+++ b/examples/using-html-template/main_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +24,7 @@ func Test_ListHandler(t *testing.T) {
 	c := &http.Client{}
 
 	go main()
-	time.Sleep(100 * time.Millisecond)
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	// Make a GET request to the /list endpoint
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
@@ -62,7 +61,7 @@ func Test_IndexHTML(t *testing.T) {
 	c := &http.Client{}
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Allow server to start
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	// Request root endpoint
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
@@ -91,7 +90,7 @@ func Test_404HTML(t *testing.T) {
 	c := &http.Client{}
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Allow server to start
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	// Request non-existent endpoint
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,

--- a/examples/using-http-auth-middleware/main_test.go
+++ b/examples/using-http-auth-middleware/main_test.go
@@ -14,8 +14,7 @@ func Test_setupAPIKeyAuthFailed(t *testing.T) {
 	// Run main() in a goroutine to avoid blocking
 	go main()
 
-	// Allow time for server to start
-	time.Sleep(100 * time.Millisecond)
+	testutil.WaitForHTTPServer(t, serverConfigs.HTTPHost)
 
 	client := &http.Client{Timeout: 200 * time.Millisecond}
 
@@ -41,8 +40,7 @@ func Test_setupAPIKeyAuthSuccess(t *testing.T) {
 	// Run main() in a goroutine to avoid blocking
 	go main()
 
-	// Allow time for server to start
-	time.Sleep(100 * time.Millisecond)
+	testutil.WaitForHTTPServer(t, serverConfigs.HTTPHost)
 
 	client := &http.Client{Timeout: 200 * time.Millisecond}
 

--- a/examples/using-http-service/main_test.go
+++ b/examples/using-http-service/main_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +35,7 @@ func Test_main(t *testing.T) {
 	c := &http.Client{}
 
 	go main()
-	time.Sleep(100 * time.Millisecond)
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	testCases := []struct {
 		desc        string

--- a/examples/using-migrations/main_test.go
+++ b/examples/using-migrations/main_test.go
@@ -86,6 +86,12 @@ func setupSQL(c config.Config) error {
 // setupRedis empties the logical Redis database this test migrates into and points the example at
 // it. GoFr reads REDIS_DB (pkg/gofr/datasource/redis/config.go), and the Redis migrator runs on
 // that same client, so the selection covers the migration bookkeeping as well as the data.
+//
+// FLUSHDB, not a list of the keys the example writes: a list has to be kept in step with
+// migrations/, and the next Redis migration that writes a key nobody remembered to add would
+// silently make this example non-repeatable again. The cost is that this empties logical database
+// testRedisDB in full — safe against the throwaway container the test job runs, worth knowing
+// before pointing REDIS_HOST/REDIS_PORT at a Redis that holds anything else.
 func setupRedis(c config.Config) error {
 	client := redis.NewClient(&redis.Options{
 		Addr: net.JoinHostPort(c.Get("REDIS_HOST"), c.Get("REDIS_PORT")),

--- a/examples/using-migrations/main_test.go
+++ b/examples/using-migrations/main_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -23,12 +24,22 @@ import (
 const (
 	configFolder = "./configs"
 
-	// testDatabase is created and dropped by the test run. The example's own configs point at the
+	// testDatabase is the MySQL database this test owns. The example's own configs point at the
 	// shared `test` database, which every other example migrates into as well - migration
 	// bookkeeping there is keyed by version only, so the highest version any example has run wins
 	// and the others get skipped. Migrating into a database this test owns keeps the run
 	// independent of the other examples and of what previous runs left behind.
+	//
+	// It is dropped and re-created at the start of every run rather than dropped at the end, so a
+	// failing run leaves its data behind to be inspected.
 	testDatabase = "test_using_migrations"
+
+	// testRedisDB is the logical Redis database this test owns, and is the same idea as
+	// testDatabase: the migrator uses the container's client, so pointing the example at a
+	// database the test flushes first means no previous run's bookkeeping can make this one skip
+	// its migrations. Namespacing rather than deleting a known list of keys - the list would go
+	// stale, silently, the first time a Redis migration writes a key nobody thought to add to it.
+	testRedisDB = 1
 )
 
 func TestMain(m *testing.M) {
@@ -41,10 +52,8 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	// Redis has no per-test namespace here, so clear the keys this example writes instead. Left
-	// behind, the migration bookkeeping makes the runner skip the migrations on the next run.
-	if err := resetRedis(c); err != nil {
-		fmt.Fprintf(os.Stderr, "could not reset redis: %v\n", err)
+	if err := setupRedis(c); err != nil {
+		fmt.Fprintf(os.Stderr, "could not set up the test redis database: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -74,14 +83,23 @@ func setupSQL(c config.Config) error {
 	return os.Setenv("DB_NAME", testDatabase)
 }
 
-func resetRedis(c config.Config) error {
-	client := redis.NewClient(&redis.Options{Addr: net.JoinHostPort(c.Get("REDIS_HOST"), c.Get("REDIS_PORT"))})
+// setupRedis empties the logical Redis database this test migrates into and points the example at
+// it. GoFr reads REDIS_DB (pkg/gofr/datasource/redis/config.go), and the Redis migrator runs on
+// that same client, so the selection covers the migration bookkeeping as well as the data.
+func setupRedis(c config.Config) error {
+	client := redis.NewClient(&redis.Options{
+		Addr: net.JoinHostPort(c.Get("REDIS_HOST"), c.Get("REDIS_PORT")),
+		DB:   testRedisDB,
+	})
 
 	defer client.Close()
 
-	// gofr_migrations holds the bookkeeping, gofr_migrations_lock the migration lock, and
-	// Umang is the key the Redis migration writes.
-	return client.Del(context.Background(), "gofr_migrations", "gofr_migrations_lock", "Umang").Err()
+	if err := client.FlushDB(context.Background()).Err(); err != nil {
+		return err
+	}
+
+	// The config files are read again by gofr.New(), which does not override what is already set.
+	return os.Setenv("REDIS_DB", strconv.Itoa(testRedisDB))
 }
 
 func TestExampleMigration(t *testing.T) {

--- a/examples/using-migrations/main_test.go
+++ b/examples/using-migrations/main_test.go
@@ -2,27 +2,94 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"testing"
-	"time"
 
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"gofr.dev/pkg/gofr/config"
+	"gofr.dev/pkg/gofr/logging"
 	"gofr.dev/pkg/gofr/testutil"
+)
+
+const (
+	configFolder = "./configs"
+
+	// testDatabase is created and dropped by the test run. The example's own configs point at the
+	// shared `test` database, which every other example migrates into as well - migration
+	// bookkeeping there is keyed by version only, so the highest version any example has run wins
+	// and the others get skipped. Migrating into a database this test owns keeps the run
+	// independent of the other examples and of what previous runs left behind.
+	testDatabase = "test_using_migrations"
 )
 
 func TestMain(m *testing.M) {
 	os.Setenv("GOFR_TELEMETRY", "false")
+
+	c := config.NewEnvFile(configFolder, logging.NewLogger(logging.ERROR))
+
+	if err := setupSQL(c); err != nil {
+		fmt.Fprintf(os.Stderr, "could not set up the test database: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Redis has no per-test namespace here, so clear the keys this example writes instead. Left
+	// behind, the migration bookkeeping makes the runner skip the migrations on the next run.
+	if err := resetRedis(c); err != nil {
+		fmt.Fprintf(os.Stderr, "could not reset redis: %v\n", err)
+		os.Exit(1)
+	}
+
 	m.Run()
+}
+
+// setupSQL recreates the database this test migrates into and points the example at it.
+func setupSQL(c config.Config) error {
+	// Connecting without a database, as the one this test uses is about to be created.
+	dsn := fmt.Sprintf("%s:%s@tcp(%s)/", c.Get("DB_USER"), c.Get("DB_PASSWORD"),
+		net.JoinHostPort(c.Get("DB_HOST"), c.Get("DB_PORT")))
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return err
+	}
+
+	defer db.Close()
+
+	for _, query := range []string{"DROP DATABASE IF EXISTS " + testDatabase, "CREATE DATABASE " + testDatabase} {
+		if _, err := db.Exec(query); err != nil {
+			return err
+		}
+	}
+
+	// The config files are read again by gofr.New(), which does not override what is already set.
+	return os.Setenv("DB_NAME", testDatabase)
+}
+
+func resetRedis(c config.Config) error {
+	client := redis.NewClient(&redis.Options{Addr: net.JoinHostPort(c.Get("REDIS_HOST"), c.Get("REDIS_PORT"))})
+
+	defer client.Close()
+
+	// gofr_migrations holds the bookkeeping, gofr_migrations_lock the migration lock, and
+	// Umang is the key the Redis migration writes.
+	return client.Del(context.Background(), "gofr_migrations", "gofr_migrations_lock", "Umang").Err()
 }
 
 func TestExampleMigration(t *testing.T) {
 	configs := testutil.NewServerConfigs(t)
 
 	go main()
-	time.Sleep(100 * time.Millisecond) // Giving some time to start the server
+	// The migrations run at startup, which a fixed sleep would not reliably cover.
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	tests := []struct {
 		desc       string

--- a/examples/using-publisher/main_test.go
+++ b/examples/using-publisher/main_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,7 +32,7 @@ func TestExamplePublisherError(t *testing.T) {
 	host := fmt.Sprint("http://localhost:", configs.HTTPPort)
 
 	go main()
-	time.Sleep(200 * time.Millisecond)
+	testutil.WaitForHTTPServer(t, host)
 
 	testCases := []struct {
 		desc               string

--- a/examples/using-s3-filestore/main_test.go
+++ b/examples/using-s3-filestore/main_test.go
@@ -63,7 +63,7 @@ func TestS3FileStore_RoundTrip(t *testing.T) {
 	t.Setenv("GOFR_TELEMETRY", "false")
 
 	go main()
-	time.Sleep(200 * time.Millisecond) // give the server time to start
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	// Defect 1: an object larger than one HTTP transport chunk must round-trip
 	// byte-for-byte. The pre-fix Read filled only the first few KB of the buffer.

--- a/examples/using-s3-filestore/main_test.go
+++ b/examples/using-s3-filestore/main_test.go
@@ -211,7 +211,7 @@ func download(t *testing.T, host, name string) string {
 // This directory is a separate module whose go.mod requires the released
 // gofr.dev v1.57.0 with no `replace`, and that release's testutil has no
 // WaitForHTTPServer. Calling the shared one would compile only inside the
-// workspace and break `GOWORK=off go build ./...` here. Drop this in favour of
+// workspace and break `GOWORK=off go build ./...` here. Drop this in favor of
 // testutil.WaitForHTTPServer once this module's gofr.dev requirement moves to a
 // release that carries it.
 func waitForHTTPServer(t *testing.T, host string) {

--- a/examples/using-s3-filestore/main_test.go
+++ b/examples/using-s3-filestore/main_test.go
@@ -63,7 +63,7 @@ func TestS3FileStore_RoundTrip(t *testing.T) {
 	t.Setenv("GOFR_TELEMETRY", "false")
 
 	go main()
-	testutil.WaitForHTTPServer(t, configs.HTTPHost)
+	waitForHTTPServer(t, configs.HTTPHost)
 
 	// Defect 1: an object larger than one HTTP transport chunk must round-trip
 	// byte-for-byte. The pre-fix Read filled only the first few KB of the buffer.
@@ -200,6 +200,38 @@ func download(t *testing.T, host, name string) string {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&env))
 
 	return env.Data.Content
+}
+
+// waitForHTTPServer blocks until the server at host answers its liveness probe,
+// and fails the test if it never does. It replaces a fixed sleep after
+// `go main()`: a sleep long enough for a loaded CI runner is wasted on every
+// other run, and one short enough to be cheap races the listener.
+//
+// pkg/gofr/testutil has the same helper, and this is a copy of it — deliberately.
+// This directory is a separate module whose go.mod requires the released
+// gofr.dev v1.57.0 with no `replace`, and that release's testutil has no
+// WaitForHTTPServer. Calling the shared one would compile only inside the
+// workspace and break `GOWORK=off go build ./...` here. Drop this in favour of
+// testutil.WaitForHTTPServer once this module's gofr.dev requirement moves to a
+// release that carries it.
+func waitForHTTPServer(t *testing.T, host string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, host+"/.well-known/alive", http.NoBody)
+		if err != nil {
+			return false
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false
+		}
+
+		defer resp.Body.Close()
+
+		return resp.StatusCode == http.StatusOK
+	}, 30*time.Second, 100*time.Millisecond, "HTTP server at %s did not start in time", host)
 }
 
 // newSDKClient builds a raw S3 client used only for test setup (bucket

--- a/examples/using-subscriber/main_test.go
+++ b/examples/using-subscriber/main_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"strings"
 	"testing"
 
 	"gofr.dev/pkg/gofr"
@@ -20,22 +19,14 @@ func TestMain(m *testing.M) {
 }
 
 func TestMainInitialization(t *testing.T) {
-	configs := testutil.NewServerConfigs(t)
+	// The example registers no routes, only subscribers, so GoFr starts no HTTP server here and
+	// there is no liveness endpoint to poll. The Kafka connection log is the startup signal, and
+	// waiting for it is the assertion: the helper fails the test if it never arrives.
+	testutil.NewServerConfigs(t)
 
-	log := testutil.StdoutOutputForFunc(func() {
-		// gofr.New() connects to Kafka — writing the line asserted below — before app.Run()
-		// starts the HTTP server, so a server answering its liveness probe means the log has
-		// already been written. If the connection instead fails and retries in the background,
-		// the assertion below reports that rather than a timeout here.
+	testutil.WaitForStdoutContains(t, "connected to 1 Kafka brokers", func() {
 		go main()
-
-		testutil.WaitForHTTPServer(t, configs.HTTPHost)
 	})
-
-	expectedLog := "connected to 1 Kafka brokers"
-	if !strings.Contains(log, expectedLog) {
-		t.Errorf("Expected log to contain %q, but got: %s", expectedLog, log)
-	}
 }
 
 type errorRequest struct{}

--- a/examples/using-subscriber/main_test.go
+++ b/examples/using-subscriber/main_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"gofr.dev/pkg/gofr"
 	"gofr.dev/pkg/gofr/container"
@@ -21,10 +20,16 @@ func TestMain(m *testing.M) {
 }
 
 func TestMainInitialization(t *testing.T) {
+	configs := testutil.NewServerConfigs(t)
+
 	log := testutil.StdoutOutputForFunc(func() {
+		// gofr.New() connects to Kafka — writing the line asserted below — before app.Run()
+		// starts the HTTP server, so a server answering its liveness probe means the log has
+		// already been written. If the connection instead fails and retries in the background,
+		// the assertion below reports that rather than a timeout here.
 		go main()
 
-		time.Sleep(200 * time.Millisecond)
+		testutil.WaitForHTTPServer(t, configs.HTTPHost)
 	})
 
 	expectedLog := "connected to 1 Kafka brokers"

--- a/examples/using-web-socket/main_test.go
+++ b/examples/using-web-socket/main_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +21,7 @@ func Test_WebSocket_Success(t *testing.T) {
 	wsURL := fmt.Sprintf("ws://localhost:%d/ws", configs.HTTPPort)
 
 	go main()
-	time.Sleep(100 * time.Millisecond)
+	testutil.WaitForHTTPServer(t, configs.HTTPHost)
 
 	testMessage := "Hello! GoFr"
 	dialer := &websocket.Dialer{}

--- a/pkg/gofr/testutil/port.go
+++ b/pkg/gofr/testutil/port.go
@@ -85,22 +85,25 @@ func NewServerConfigs(t *testing.T) *ServiceConfigs {
 // error, and sets the ports with os.Setenv rather than t.Setenv, there being no test scope to
 // restore them at the end of. Prefer NewServerConfigs wherever a *testing.T is in hand.
 func ReserveServerPorts() (*ServiceConfigs, error) {
-	ports := map[string]int{httpPortEnv: 0, metricsPortEnv: 0, grpcPortEnv: 0}
+	// A slice rather than a map: the order the ports are reserved in, and the name that appears in
+	// an error, are then the same on every run.
+	names := []string{httpPortEnv, metricsPortEnv, grpcPortEnv}
+	ports := make([]int, len(names))
 
-	for name := range ports {
+	for i, name := range names {
 		port, err := reserveFreePort(context.Background())
 		if err != nil {
 			return nil, fmt.Errorf("failed to reserve a free %s: %w", name, err)
 		}
 
-		ports[name] = port
+		ports[i] = port
 
 		if err := os.Setenv(name, strconv.Itoa(port)); err != nil {
 			return nil, fmt.Errorf("failed to set %s: %w", name, err)
 		}
 	}
 
-	return newServiceConfigs(ports[httpPortEnv], ports[metricsPortEnv], ports[grpcPortEnv]), nil
+	return newServiceConfigs(ports[0], ports[1], ports[2]), nil
 }
 
 func newServiceConfigs(httpPort, metricsPort, grpcPort int) *ServiceConfigs {

--- a/pkg/gofr/testutil/port.go
+++ b/pkg/gofr/testutil/port.go
@@ -1,28 +1,46 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+// Environment variables the framework reads its listen ports from.
+const (
+	httpPortEnv    = "HTTP_PORT"
+	metricsPortEnv = "METRICS_PORT"
+	grpcPortEnv    = "GRPC_PORT"
+)
+
 // GetFreePort asks the kernel for a free open port that is ready to use for tests.
 func GetFreePort(t *testing.T) int {
 	t.Helper()
 
-	lc := net.ListenConfig{}
-	listener, err := lc.Listen(t.Context(), "tcp", "localhost:0")
-	require.NoError(t, err, "Failed to get a free port.")
-
-	port := listener.Addr().(*net.TCPAddr).Port
-
-	err = listener.Close()
+	port, err := reserveFreePort(t.Context())
 	require.NoError(t, err, "Failed to get a free port.")
 
 	return port
+}
+
+// reserveFreePort asks the kernel for a free open port. It is the plumbing behind GetFreePort and
+// ReserveServerPorts, which differ only in how they report a failure.
+func reserveFreePort(ctx context.Context) (int, error) {
+	lc := net.ListenConfig{}
+
+	listener, err := lc.Listen(ctx, "tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	return port, listener.Close()
 }
 
 // ServiceConfigs holds the configuration details for different server components.
@@ -55,10 +73,37 @@ func NewServerConfigs(t *testing.T) *ServiceConfigs {
 	metricsPort := GetFreePort(t)
 	grpcPort := GetFreePort(t)
 
-	t.Setenv("HTTP_PORT", strconv.Itoa(httpPort))
-	t.Setenv("METRICS_PORT", strconv.Itoa(metricsPort))
-	t.Setenv("GRPC_PORT", strconv.Itoa(grpcPort))
+	t.Setenv(httpPortEnv, strconv.Itoa(httpPort))
+	t.Setenv(metricsPortEnv, strconv.Itoa(metricsPort))
+	t.Setenv(grpcPortEnv, strconv.Itoa(grpcPort))
 
+	return newServiceConfigs(httpPort, metricsPort, grpcPort)
+}
+
+// ReserveServerPorts is NewServerConfigs for a caller that has no *testing.T to fail on — a
+// TestMain, which gets only a *testing.M, is the usual one. It reports a failure by returning an
+// error, and sets the ports with os.Setenv rather than t.Setenv, there being no test scope to
+// restore them at the end of. Prefer NewServerConfigs wherever a *testing.T is in hand.
+func ReserveServerPorts() (*ServiceConfigs, error) {
+	ports := map[string]int{httpPortEnv: 0, metricsPortEnv: 0, grpcPortEnv: 0}
+
+	for name := range ports {
+		port, err := reserveFreePort(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("failed to reserve a free %s: %w", name, err)
+		}
+
+		ports[name] = port
+
+		if err := os.Setenv(name, strconv.Itoa(port)); err != nil {
+			return nil, fmt.Errorf("failed to set %s: %w", name, err)
+		}
+	}
+
+	return newServiceConfigs(ports[httpPortEnv], ports[metricsPortEnv], ports[grpcPortEnv]), nil
+}
+
+func newServiceConfigs(httpPort, metricsPort, grpcPort int) *ServiceConfigs {
 	return &ServiceConfigs{
 		HTTPPort:    httpPort,
 		HTTPHost:    fmt.Sprintf("http://localhost:%d", httpPort),

--- a/pkg/gofr/testutil/port_test.go
+++ b/pkg/gofr/testutil/port_test.go
@@ -125,3 +125,38 @@ func TestServiceConfigs_GetOrDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestReserveServerPorts(t *testing.T) {
+	// os.Setenv rather than t.Setenv, so restore what this test displaces.
+	for _, key := range []string{"HTTP_PORT", "METRICS_PORT", "GRPC_PORT"} {
+		t.Setenv(key, os.Getenv(key))
+	}
+
+	configs, err := ReserveServerPorts()
+	require.NoError(t, err, "ReserveServerPorts should not fail")
+
+	tests := []struct {
+		desc     string
+		envKey   string
+		port     int
+		host     string
+		expected string
+	}{
+		{"http", "HTTP_PORT", configs.HTTPPort, configs.HTTPHost, "http://localhost:"},
+		{"metrics", "METRICS_PORT", configs.MetricsPort, configs.MetricsHost, "http://localhost:"},
+		{"grpc", "GRPC_PORT", configs.GRPCPort, configs.GRPCHost, "localhost:"},
+	}
+
+	for i, tc := range tests {
+		assert.NotZero(t, tc.port, "TEST[%d], Failed.\n%s", i, tc.desc)
+		assert.Equal(t, strconv.Itoa(tc.port), os.Getenv(tc.envKey), "TEST[%d], Failed.\n%s", i, tc.desc)
+		assert.Equal(t, tc.expected+strconv.Itoa(tc.port), tc.host, "TEST[%d], Failed.\n%s", i, tc.desc)
+
+		// The reserved port must actually be bindable.
+		lc := net.ListenConfig{}
+
+		listener, err := lc.Listen(t.Context(), "tcp", fmt.Sprintf("localhost:%d", tc.port))
+		require.NoError(t, err, "TEST[%d], Failed.\n%s", i, tc.desc)
+		require.NoError(t, listener.Close(), "TEST[%d], Failed.\n%s", i, tc.desc)
+	}
+}

--- a/pkg/gofr/testutil/wait.go
+++ b/pkg/gofr/testutil/wait.go
@@ -3,6 +3,9 @@ package testutil
 import (
 	"context"
 	"net/http"
+	"os"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +22,9 @@ const (
 
 	serverStartTimeout = 30 * time.Second
 	serverPollInterval = 100 * time.Millisecond
+
+	// stdoutReadBuffer is the chunk size the stdout capture reads with; a log line is far shorter.
+	stdoutReadBuffer = 4096
 )
 
 // WaitForHTTPServer blocks until the server at host answers its liveness probe, and fails the
@@ -66,4 +72,91 @@ func WaitForGRPCServer(t *testing.T, addr string) {
 	for state := conn.GetState(); state != connectivity.Ready; state = conn.GetState() {
 		require.True(t, conn.WaitForStateChange(ctx, state), "gRPC server at %s did not start in time", addr)
 	}
+}
+
+// WaitForStdoutContains runs f with os.Stdout captured and blocks until the captured output
+// contains substr, returning everything captured up to that point. It fails the test if substr
+// never appears.
+//
+// Use it for an app whose only startup signal is a log line. An app that registers no routes -
+// a subscriber-only one, say - leaves App.httpRegistered false, so GoFr starts no HTTP server
+// and WaitForHTTPServer would wait for a port that never opens. StdoutOutputForFunc cannot serve
+// here either: it reads the pipe only once f has returned, so f would have to sleep to give the
+// app time to log, which is the race this package exists to remove.
+func WaitForStdoutContains(t *testing.T, substr string, f func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err, "failed to create a pipe to capture stdout")
+
+	old := os.Stdout
+	os.Stdout = w
+
+	var (
+		mu       sync.Mutex
+		captured strings.Builder
+	)
+
+	found := captureUntil(r, substr, &mu, &captured)
+
+	f()
+
+	var timedOut bool
+
+	select {
+	case <-found:
+	case <-time.After(serverStartTimeout):
+		timedOut = true
+	}
+
+	// Restoring before the assertion below keeps a failure message on the real stdout. Closing the
+	// writer ends the reader; the app under test goes on writing to a closed pipe, as it does with
+	// StdoutOutputForFunc too.
+	os.Stdout = old
+	_ = w.Close()
+
+	mu.Lock()
+	out := captured.String()
+	mu.Unlock()
+
+	if timedOut {
+		require.Fail(t, "expected output never appeared on stdout",
+			"waited %s for %q, captured:\n%s", serverStartTimeout, substr, out)
+	}
+
+	return out
+}
+
+// captureUntil drains r into out and closes the returned channel as soon as out holds substr. It
+// reads concurrently rather than in one ReadAll at the end, so a caller can act on the signal
+// while the process that writes it is still running.
+func captureUntil(r *os.File, substr string, mu *sync.Mutex, out *strings.Builder) <-chan struct{} {
+	found := make(chan struct{})
+
+	go func() {
+		var once sync.Once
+
+		buf := make([]byte, stdoutReadBuffer)
+
+		for {
+			n, err := r.Read(buf)
+
+			if n > 0 {
+				mu.Lock()
+				out.Write(buf[:n])
+				hit := strings.Contains(out.String(), substr)
+				mu.Unlock()
+
+				if hit {
+					once.Do(func() { close(found) })
+				}
+			}
+
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	return found
 }

--- a/pkg/gofr/testutil/wait.go
+++ b/pkg/gofr/testutil/wait.go
@@ -1,0 +1,69 @@
+package testutil
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	// alivePath duplicates service.AlivePath. It cannot be imported here: pkg/gofr/service's own
+	// tests import this package, so testutil -> service would be an import cycle.
+	alivePath = "/.well-known/alive"
+
+	serverStartTimeout = 30 * time.Second
+	serverPollInterval = 100 * time.Millisecond
+)
+
+// WaitForHTTPServer blocks until the server at host answers its liveness probe, and fails the
+// test if it never does. Use it instead of sleeping a fixed duration after `go main()`: a sleep
+// long enough for a loaded CI runner is wasted on every other run, and one short enough to be
+// cheap races the listener.
+func WaitForHTTPServer(t *testing.T, host string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, host+alivePath, http.NoBody)
+		if err != nil {
+			return false
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false
+		}
+
+		defer resp.Body.Close()
+
+		return resp.StatusCode == http.StatusOK
+	}, serverStartTimeout, serverPollInterval, "HTTP server at %s did not start in time", host)
+}
+
+// WaitForGRPCServer blocks until a gRPC connection to addr reaches the ready state, and fails the
+// test if it never does. gRPC examples that serve no HTTP port have no liveness endpoint to poll,
+// and a bare TCP dial is not enough — the kernel accepts connections from the moment the listener
+// exists, so it succeeds before the server is serving. Reaching ready means the HTTP/2 handshake
+// completed, which only happens once it is.
+func WaitForGRPCServer(t *testing.T, addr string) {
+	t.Helper()
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err, "failed to create a gRPC client for %s", addr)
+
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), serverStartTimeout)
+	defer cancel()
+
+	conn.Connect()
+
+	for state := conn.GetState(); state != connectivity.Ready; state = conn.GetState() {
+		require.True(t, conn.WaitForStateChange(ctx, state), "gRPC server at %s did not start in time", addr)
+	}
+}

--- a/pkg/gofr/testutil/wait.go
+++ b/pkg/gofr/testutil/wait.go
@@ -89,11 +89,16 @@ func waitForGRPC(ctx context.Context, addr string) error {
 	ctx, cancel := context.WithTimeout(ctx, serverStartTimeout)
 	defer cancel()
 
+	start := time.Now()
+
 	conn.Connect()
 
 	for state := conn.GetState(); state != connectivity.Ready; state = conn.GetState() {
 		if !conn.WaitForStateChange(ctx, state) {
-			return fmt.Errorf("%w: gRPC server at %s did not start in %s", errServerNotReady, addr, serverStartTimeout)
+			// The elapsed time rather than serverStartTimeout: the caller's own context can
+			// expire first, and a message naming the constant would then overstate the wait.
+			return fmt.Errorf("%w: gRPC server at %s did not start in %s",
+				errServerNotReady, addr, time.Since(start).Round(time.Millisecond))
 		}
 	}
 

--- a/pkg/gofr/testutil/wait.go
+++ b/pkg/gofr/testutil/wait.go
@@ -68,15 +68,16 @@ func WaitForGRPCServer(t *testing.T, addr string) {
 	require.NoError(t, waitForGRPC(t.Context(), addr))
 }
 
-// AwaitGRPCServer is WaitForGRPCServer for a caller that has no *testing.T to fail on — a
+// WaitForGRPCServerE is WaitForGRPCServer for a caller that has no *testing.T to fail on — a
 // TestMain, which gets only a *testing.M, is the usual one. It reports a failure by returning an
-// error. Prefer WaitForGRPCServer wherever a *testing.T is in hand.
-func AwaitGRPCServer(addr string) error {
+// error. The E suffix is the Foo/FooE convention for exactly this pair; prefer WaitForGRPCServer
+// wherever a *testing.T is in hand.
+func WaitForGRPCServerE(addr string) error {
 	return waitForGRPC(context.Background(), addr)
 }
 
 // waitForGRPC blocks until a gRPC connection to addr reaches the ready state. It is the plumbing
-// behind WaitForGRPCServer and AwaitGRPCServer, which differ only in how they report a failure.
+// behind WaitForGRPCServer and WaitForGRPCServerE, which differ only in how they report a failure.
 func waitForGRPC(ctx context.Context, addr string) error {
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {

--- a/pkg/gofr/testutil/wait.go
+++ b/pkg/gofr/testutil/wait.go
@@ -2,6 +2,8 @@ package testutil
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -26,6 +28,10 @@ const (
 	// stdoutReadBuffer is the chunk size the stdout capture reads with; a log line is far shorter.
 	stdoutReadBuffer = 4096
 )
+
+// errServerNotReady is what the error-returning wait variants wrap, so a caller can tell a
+// readiness timeout apart from a failure to set the wait up at all.
+var errServerNotReady = errors.New("server did not become ready in time")
 
 // WaitForHTTPServer blocks until the server at host answers its liveness probe, and fails the
 // test if it never does. Use it instead of sleeping a fixed duration after `go main()`: a sleep
@@ -59,19 +65,38 @@ func WaitForHTTPServer(t *testing.T, host string) {
 func WaitForGRPCServer(t *testing.T, addr string) {
 	t.Helper()
 
+	require.NoError(t, waitForGRPC(t.Context(), addr))
+}
+
+// AwaitGRPCServer is WaitForGRPCServer for a caller that has no *testing.T to fail on — a
+// TestMain, which gets only a *testing.M, is the usual one. It reports a failure by returning an
+// error. Prefer WaitForGRPCServer wherever a *testing.T is in hand.
+func AwaitGRPCServer(addr string) error {
+	return waitForGRPC(context.Background(), addr)
+}
+
+// waitForGRPC blocks until a gRPC connection to addr reaches the ready state. It is the plumbing
+// behind WaitForGRPCServer and AwaitGRPCServer, which differ only in how they report a failure.
+func waitForGRPC(ctx context.Context, addr string) error {
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	require.NoError(t, err, "failed to create a gRPC client for %s", addr)
+	if err != nil {
+		return fmt.Errorf("failed to create a gRPC client for %s: %w", addr, err)
+	}
 
 	defer conn.Close()
 
-	ctx, cancel := context.WithTimeout(t.Context(), serverStartTimeout)
+	ctx, cancel := context.WithTimeout(ctx, serverStartTimeout)
 	defer cancel()
 
 	conn.Connect()
 
 	for state := conn.GetState(); state != connectivity.Ready; state = conn.GetState() {
-		require.True(t, conn.WaitForStateChange(ctx, state), "gRPC server at %s did not start in time", addr)
+		if !conn.WaitForStateChange(ctx, state) {
+			return fmt.Errorf("%w: gRPC server at %s did not start in %s", errServerNotReady, addr, serverStartTimeout)
+		}
 	}
+
+	return nil
 }
 
 // WaitForStdoutContains runs f with os.Stdout captured and blocks until the captured output
@@ -134,7 +159,13 @@ func captureUntil(r *os.File, substr string, mu *sync.Mutex, out *strings.Builde
 	found := make(chan struct{})
 
 	go func() {
-		var once sync.Once
+		var (
+			once sync.Once
+			// scanned is how much of out has already been searched. Rescanning the whole builder
+			// on every read would be quadratic in the captured output — free when the signal
+			// arrives in the first read or two, but not on the timeout path against a chatty app.
+			scanned int
+		)
 
 		buf := make([]byte, stdoutReadBuffer)
 
@@ -144,7 +175,13 @@ func captureUntil(r *os.File, substr string, mu *sync.Mutex, out *strings.Builde
 			if n > 0 {
 				mu.Lock()
 				out.Write(buf[:n])
-				hit := strings.Contains(out.String(), substr)
+
+				// Carry over len(substr)-1 bytes so a match straddling a read boundary is found.
+				from := max(scanned-len(substr)+1, 0)
+				// strings.Builder.String does not copy, so this stays linear overall.
+				s := out.String()
+				hit := strings.Contains(s[from:], substr)
+				scanned = len(s)
 				mu.Unlock()
 
 				if hit {

--- a/pkg/gofr/testutil/wait_test.go
+++ b/pkg/gofr/testutil/wait_test.go
@@ -1,0 +1,111 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// startHTTPServerAfter starts an HTTP server serving the liveness path on addr once delay has
+// elapsed, mimicking an example whose startup is slower than the caller's first request.
+func startHTTPServerAfter(t *testing.T, delay time.Duration) (host string) {
+	t.Helper()
+
+	port := GetFreePort(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(alivePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := &http.Server{Addr: fmt.Sprintf("localhost:%d", port), Handler: mux, ReadHeaderTimeout: time.Second}
+
+	go func() {
+		time.Sleep(delay)
+
+		_ = srv.ListenAndServe()
+	}()
+
+	t.Cleanup(func() {
+		_ = srv.Close()
+	})
+
+	return fmt.Sprintf("http://localhost:%d", port)
+}
+
+// startGRPCServerAfter starts a bare gRPC server on addr once delay has elapsed.
+func startGRPCServerAfter(t *testing.T, delay time.Duration) (addr string) {
+	t.Helper()
+
+	port := GetFreePort(t)
+	addr = fmt.Sprintf("localhost:%d", port)
+	srv := grpc.NewServer()
+
+	go func() {
+		time.Sleep(delay)
+
+		listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", addr)
+		if err != nil {
+			return
+		}
+
+		_ = srv.Serve(listener)
+	}()
+
+	t.Cleanup(srv.Stop)
+
+	return addr
+}
+
+func TestWaitForHTTPServer(t *testing.T) {
+	tests := []struct {
+		desc       string
+		startDelay time.Duration
+	}{
+		{"server already listening", 0},
+		{"server starts after the first probe", 300 * time.Millisecond},
+	}
+
+	for i, tc := range tests {
+		host := startHTTPServerAfter(t, tc.startDelay)
+
+		WaitForHTTPServer(t, host)
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, host+alivePath, http.NoBody)
+		require.NoError(t, err, "TEST[%d], Failed.\n%s", i, tc.desc)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err, "TEST[%d], Failed.\n%s", i, tc.desc)
+
+		resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "TEST[%d], Failed.\n%s", i, tc.desc)
+	}
+}
+
+func TestWaitForGRPCServer(t *testing.T) {
+	tests := []struct {
+		desc       string
+		startDelay time.Duration
+	}{
+		{"server already listening", 0},
+		{"server starts after the first probe", 300 * time.Millisecond},
+	}
+
+	for i, tc := range tests {
+		addr := startGRPCServerAfter(t, tc.startDelay)
+
+		WaitForGRPCServer(t, addr)
+
+		conn, err := (&net.Dialer{}).DialContext(t.Context(), "tcp", addr)
+		require.NoError(t, err, "TEST[%d], Failed.\n%s", i, tc.desc)
+
+		require.NoError(t, conn.Close(), "TEST[%d], Failed.\n%s", i, tc.desc)
+	}
+}

--- a/pkg/gofr/testutil/wait_test.go
+++ b/pkg/gofr/testutil/wait_test.go
@@ -94,9 +94,14 @@ func TestWaitForStdoutContains(t *testing.T) {
 	tests := []struct {
 		desc      string
 		writeWait time.Duration
+		// writes are logged in order, with a pause between them so each lands in its own read.
+		// Splitting the awaited substring across two of them puts it across a read boundary, which
+		// the incremental scan has to carry over rather than miss.
+		writes []string
 	}{
-		{"line already written when f returns", 0},
-		{"line written well after f returns", 300 * time.Millisecond},
+		{"line already written when f returns", 0, []string{"starting up\nready to serve\n"}},
+		{"line written well after f returns", 300 * time.Millisecond, []string{"starting up\nready to serve\n"}},
+		{"substring straddles a read boundary", 0, []string{"starting up\nrea", "dy to serve\n"}},
 	}
 
 	for i, tc := range tests {
@@ -104,7 +109,11 @@ func TestWaitForStdoutContains(t *testing.T) {
 			go func() {
 				time.Sleep(tc.writeWait)
 
-				fmt.Fprintln(os.Stdout, "starting up\nready to serve")
+				for _, w := range tc.writes {
+					fmt.Fprint(os.Stdout, w)
+					// Long enough for the reader to drain what has been written so far.
+					time.Sleep(100 * time.Millisecond)
+				}
 			}()
 		})
 
@@ -133,4 +142,36 @@ func TestWaitForGRPCServer(t *testing.T) {
 
 		require.NoError(t, conn.Close(), "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
+}
+
+func TestAwaitGRPCServer(t *testing.T) {
+	tests := []struct {
+		desc       string
+		startDelay time.Duration
+	}{
+		{"server already listening", 0},
+		{"server starts after the first probe", 300 * time.Millisecond},
+	}
+
+	for i, tc := range tests {
+		addr := startGRPCServerAfter(t, tc.startDelay)
+
+		require.NoError(t, AwaitGRPCServer(addr), "TEST[%d], Failed.\n%s", i, tc.desc)
+	}
+}
+
+// TestWaitForGRPC_Timeout covers the failure path the exported wrappers share. It exercises
+// waitForGRPC rather than WaitForGRPCServer or AwaitGRPCServer so the deadline can be a short one:
+// the wrappers hardcode serverStartTimeout, and a test is not going to wait 30s to see it.
+func TestWaitForGRPC_Timeout(t *testing.T) {
+	// A port reserved and released: nothing is listening, so the wait cannot succeed.
+	addr := fmt.Sprintf("localhost:%d", GetFreePort(t))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	err := waitForGRPC(ctx, addr)
+
+	require.ErrorIs(t, err, errServerNotReady)
+	require.ErrorContains(t, err, addr, "the error should name the server that did not come up")
 }

--- a/pkg/gofr/testutil/wait_test.go
+++ b/pkg/gofr/testutil/wait_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -86,6 +87,30 @@ func TestWaitForHTTPServer(t *testing.T) {
 		resp.Body.Close()
 
 		require.Equal(t, http.StatusOK, resp.StatusCode, "TEST[%d], Failed.\n%s", i, tc.desc)
+	}
+}
+
+func TestWaitForStdoutContains(t *testing.T) {
+	tests := []struct {
+		desc      string
+		writeWait time.Duration
+	}{
+		{"line already written when f returns", 0},
+		{"line written well after f returns", 300 * time.Millisecond},
+	}
+
+	for i, tc := range tests {
+		out := WaitForStdoutContains(t, "ready", func() {
+			go func() {
+				time.Sleep(tc.writeWait)
+
+				fmt.Fprintln(os.Stdout, "starting up\nready to serve")
+			}()
+		})
+
+		require.Contains(t, out, "ready to serve", "TEST[%d], Failed.\n%s", i, tc.desc)
+		// Everything written before the awaited line is returned as well.
+		require.Contains(t, out, "starting up", "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }
 

--- a/pkg/gofr/testutil/wait_test.go
+++ b/pkg/gofr/testutil/wait_test.go
@@ -144,7 +144,7 @@ func TestWaitForGRPCServer(t *testing.T) {
 	}
 }
 
-func TestAwaitGRPCServer(t *testing.T) {
+func TestWaitForGRPCServerE(t *testing.T) {
 	tests := []struct {
 		desc       string
 		startDelay time.Duration
@@ -156,12 +156,12 @@ func TestAwaitGRPCServer(t *testing.T) {
 	for i, tc := range tests {
 		addr := startGRPCServerAfter(t, tc.startDelay)
 
-		require.NoError(t, AwaitGRPCServer(addr), "TEST[%d], Failed.\n%s", i, tc.desc)
+		require.NoError(t, WaitForGRPCServerE(addr), "TEST[%d], Failed.\n%s", i, tc.desc)
 	}
 }
 
 // TestWaitForGRPC_Timeout covers the failure path the exported wrappers share. It exercises
-// waitForGRPC rather than WaitForGRPCServer or AwaitGRPCServer so the deadline can be a short one:
+// waitForGRPC rather than WaitForGRPCServer or WaitForGRPCServerE so the deadline can be a short one:
 // the wrappers hardcode serverStartTimeout, and a test is not going to wait 30s to see it.
 func TestWaitForGRPC_Timeout(t *testing.T) {
 	// A port reserved and released: nothing is listening, so the wait cannot succeed.


### PR DESCRIPTION
**Description:**

Fixes #3818. Fixes #3816 — superseding #3817, which is closed in favor of this PR because its two
files need the `testutil` helpers added here and stacking across a fork is not possible.

Most example tests started the server with `go main()` and then waited for it with
`time.Sleep(100 * time.Millisecond)`. Nothing verified the server was listening, so on a slow or
loaded runner the first request can hit a socket that is not accepting yet and the test fails for
reasons unrelated to what it covers. The `Example Unit Testing` job's `max_attempts: 2` retry is
what keeps this latent — and it equally masks a genuine regression that happens to pass on retry.

All 31 sleeps the issue enumerates are replaced with an observable signal:

- `testutil.WaitForHTTPServer` polls `/.well-known/alive`.
- `testutil.WaitForGRPCServer` waits for a gRPC connection to reach `connectivity.Ready`. A bare TCP
  dial would not do — the kernel accepts connections from the moment the listener exists, so it
  succeeds before the server is serving, restoring the race it is meant to remove. GoFr registers no
  gRPC health service by default, so there is no health RPC to call.

Both fail with a named timeout after 30s rather than a bare connection-refused from the first
assertion.

Three cases needed more than a substitution:

- **`using-cron-jobs`** asserted `n == 1` after sleeping past one tick of a 1-second cron. That
  equality was itself the flake — any wait long enough to be safe on a loaded runner also lets the
  job fire twice. It now waits for `n > 0`, which is the claim the test actually makes.
- **The four mid-test sleeps in `grpc-streaming-server` are deleted, not converted.** Three are
  "give server time to detect cancellation" after `cancel()`; the following `Recv`/`CloseAndRecv`
  fails with `Canceled` off the client's own context, so there is nothing to wait for. The fourth
  paced `stream.Send`, but the server handles one stream sequentially and replies in order, so it
  cannot affect the ordering the test asserts.
- **`using-subscriber` has no HTTP server to poll and gets a third helper,
  `testutil.WaitForStdoutContains`.** The example registers only subscribers, so `App.httpRegistered`
  stays false and `startHTTPServer` never runs — there is no liveness endpoint, and no port that
  ever opens. Its assertion is on a Kafka log line captured by `StdoutOutputForFunc`, which reads
  the pipe only once its function has returned, so waiting inside it would mean sleeping again. The
  new helper captures stdout and reads it concurrently, returning as soon as the awaited line
  appears and failing with everything captured if it never does: the line the test asserts on is now
  the signal it waits for.

**`using-migrations` owning no namespace (#3816)** is the same class of problem one layer down: the
example passed once against a fresh Redis/MySQL pair and failed on every run after that.

- The migration bookkeeping is keyed by version and lives in **both** datastores (`gofr_migrations`
  hash in Redis, `gofr_migrations` table in MySQL), and `redisMigrator.getLastMigration` returns
  `max(redis, sql)` — so a stale Redis record alone is enough to skip the schema-creating migration.
  With Redis carried over and MySQL recreated, the run logs `no new migrations to run` and every
  request fails with `Table 'test.employee' doesn't exist`.
- The row the test POSTs (`id: 2`) and the row the migration inserts survive in MySQL, so a re-run
  collides: `expected 201, actual 500` / `Duplicate entry '2' for key 'employee.PRIMARY'`.
- Every MySQL example migrates into the same `test` database and therefore shares one
  `gofr_migrations` table. `using-migrations`' versions (`1722507126`, `1722507180`) are higher than
  `using-add-rest-handlers`' (`1721816030`), so once `using-migrations` has run, the sibling's
  migration is considered applied and its `user` table is never created. It works today only because
  `go test` happens to run the alphabetically earlier package first on a fresh database.

CI never sees any of this — every job gets fresh service containers, so every CI run is a first run.

`TestMain` now creates (and re-creates) a `test_using_migrations` database the test owns and points
the example at it via `DB_NAME`, and does the same one layer down for Redis: it selects logical
database 1 via `REDIS_DB` — which GoFr reads, and which the migrator inherits because it runs on the
same client — and empties it with `FLUSHDB`. `configs/.env` is untouched — it is what a human runs the
example with, and `gofr.New()` honors the override because `godotenv.Load` does not replace
variables already set in the environment. Giving the example its own database removes the sibling
coupling as well.

`FLUSHDB` rather than deleting the keys the example happens to write today: a key list has to be kept
in step with a sibling `migrations/` directory, and the first Redis migration writing an unlisted key
would make the example non-repeatable again, which is the failure mode this change exists to close.
It is the more destructive of the two — it empties logical database 1 in full — so the comment says
so, for anyone who points `REDIS_HOST`/`REDIS_PORT` at a Redis holding anything else.

`using-graphql` was checked and is unaffected — its test builds its own app with stubbed resolvers
and never calls `Migrate`. `using-publisher` / `using-subscriber` migrate Kafka topics, not a shared
table.

The health-server commit is unrelated to sleeps but the same class of problem: `TestGoFrHealthServer_Methods`
and `TestGoFrHealthServer_SetServingStatus` both used the service name `"test-service"` against a
process-wide singleton, one asserting `"unknown service"` and the other registering it as SERVING.
Source order hides it on a single pass, but `go test -count=3` fails on the second iteration.

**Breaking Changes (if applicable):**

None. Five new exported test helpers in `pkg/gofr/testutil` — `WaitForHTTPServer`,
`WaitForGRPCServer`, `WaitForGRPCServerE`, `WaitForStdoutContains` and `ReserveServerPorts`; no
production code paths change.

**Additional Information:**

No new dependencies. The `using-migrations` setup uses `github.com/go-sql-driver/mysql` and
`github.com/redis/go-redis/v9` directly, both already direct dependencies of the module, and reads
the connection details through `gofr.dev/pkg/gofr/config` rather than hardcoding them.

`using-migrations` and `using-add-rest-handlers` were verified against `redis:7.0.5` and
`mysql:8.2.0` on the ports the `Example-Unit-Testing` job uses. Before the change,
`using-migrations` failed on runs 2 and 3 against the same containers and `using-add-rest-handlers`
failed on a genuinely fresh database (server not yet listening); after it, three consecutive runs
against the same containers pass.

The issue sketched a `waitForServer` local to each `main_test.go`. Fourteen copies of the same twenty
lines is a lot of surface to keep in step, and every example already imports `testutil` for
`NewServerConfigs`/`GetFreePort` — the same "wiring for example tests" role — so the helpers live
there instead. `testutil` re-declares the liveness path rather than importing `service.AlivePath`,
because `pkg/gofr/service`'s own tests import `testutil` and that would be an import cycle in the
service test binary; there is a comment saying so.

`grpc-streaming-server` waits in `TestMain`, which gets a `*testing.M` and has no `*testing.T` for
`require` to fail on, so it takes `WaitForGRPCServerE` — the error-returning half of the same wait,
sharing one unexported `waitForGRPC` with `WaitForGRPCServer` rather than duplicating it.
`using-graphql`'s bespoke `waitForReady` is dropped in favor of the shared helper.

The `E` suffix is a deliberate choice rather than a default. Two exported waits that differ only in
how they report a failure need the difference in the name, `testutil` is a package users consume, so
these names are permanent surface, and `Foo`/`FooE` is the established Go convention for exactly this
pair — a reader infers the split without reading the doc comment. `NewServerConfigs` /
`ReserveServerPorts` below is the same split under two unrelated verbs; making the package uniform
means renaming that to `NewServerConfigsE`, which is churn on settled surface and belongs in its own
change. Happy to do it here instead if you would rather the package land consistent.

`testutil.ReserveServerPorts` exists for the same reason. `development` already gives
`grpc-streaming-server`'s `TestMain` free ports instead of the `GRPC_PORT=9000` its `configs/.env`
pins, but does it with a private `reserveFreePort` copied into the test — the port-assignment half
of what `NewServerConfigs` already does, duplicated because `NewServerConfigs` takes a `*testing.T`
and `TestMain` has none. `ReserveServerPorts` is that same function for a caller with no `*testing.T`
to fail on: it returns an error instead of calling `require`, and uses `os.Setenv` rather than
`t.Setenv`, there being no test scope to restore the variables at the end of. Both now share one
implementation, and the example test drops its private copy.

`using-subscriber` was verified against the same `bitnamilegacy/kafka:3.4.1` broker this job runs,
because CI caught a real bug here first: with `WaitForHTTPServer` it failed after the full 30s
timeout even with a healthy broker, which reproduces locally on the pre-fix file and is what the
helper above fixes.

**`examples/using-s3-filestore` gets a local wait helper rather than the shared one, and must be
checked with `GOWORK=off go build ./...` from inside that directory.** It is a separate module whose
`go.mod` requires the released `gofr.dev v1.57.0` with no `replace`, and that release's `testutil`
has none of the helpers this PR adds. Calling `testutil.WaitForHTTPServer` there compiled only
because `go.work` redirects `gofr.dev` to this checkout — `GOWORK=off go vet ./...` failed on this
branch and is clean on `development`, so it was a straight regression.

Nothing in CI reports it: `go test ./examples/...` silently excludes the module, the MinIO step runs
from inside it and walks up to `go.work`, and the lint job skipped this PR. All 16 checks were green
over a module that did not build, which is why the manual command is written down here.

A `replace` was the smallest fix and is the one to avoid — `ceb50390` had just moved the gcp exporter
the other way. Reverting the file to `time.Sleep` was the other option, but it leaves one example
carrying the flake this PR exists to remove for as long as it takes the helpers to reach a release.
The local copy's comment says it is local *because* this module builds against a release, and names
the condition for deleting it. Making CI vet the workspace's submodules standalone is the real fix
and is out of scope here.

Not verified locally for want of the datastores: `http-server`, `http-server-using-redis`,
`using-publisher`, `using-http-service`, `using-s3-filestore`. They build and vet clean; CI has the
service containers.

`examples/using-html-template`'s `Test_IndexHTML` used to fail on `development` for an unrelated,
pre-existing reason (#3819); #3820 has since merged and it passes here.

This branch was rebased onto the rewritten `development` rather than merged: the force-update gave
every commit a new SHA, so the merge base fell back to the initial commit and a merge produced 72
add/add conflicts in files neither side touched. The five commits here are the same work replayed on
top of `ceb50390`. One commit was dropped in the process — the one that gave
`grpc-streaming-server`'s test free ports, now redundant against the inline version `development`
carries; the `ReserveServerPorts` refactor described above is what remains of it.

**Checklist:**

- [x] I have formatted my code using `goimport` and `golangci-lint`.
- [x] All new code is covered by unit tests.
- [x] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.


