### PR TITLE
chore(ci): pin ls-lint/action to node24 commit to clear Node 20 deprecation warning

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -576,7 +576,9 @@ jobs:
 
       # Check file naming conventions using ls-lint
       - name: Check for file names errors
-        uses: ls-lint/action@v2.3.1
+        # Pinned to main: v2.3.1 still declares the deprecated node20 runtime.
+        # 0c7f19c ("chore: run on the node24 runtime") is not in a tagged release yet.
+        uses: ls-lint/action@0c7f19c04594e52a801dec991aae70a7ae5c6665 # main, node24 runtime
         with:
           config: .ls-lint.yml
 


### PR DESCRIPTION
**Description:**

Every run of the `Linting Party🥳` job emits a Node.js 20 deprecation warning:

> `##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: ls-lint/action@v2.3.1`

([example run](https://github.com/gofr-dev/gofr/actions/runs/31266842627/job/93126257911))

`ls-lint/action`'s `action.yml` at tag `v2.3.1` declares `using: 'node20'`. Upstream has already
fixed this — `main` declares `using: 'node24'` as of [`14a5505`](https://github.com/ls-lint/action/commit/14a5505ae77fe0b195d7e87206df152d0d042b16)
("chore: run on the node24 runtime"), merged as [`0c7f19c`](https://github.com/ls-lint/action/commit/0c7f19c04594e52a801dec991aae70a7ae5c6665).
The latest release (`v2.3.1`, Dec 2025) predates that commit, so **no tag carries the fix yet** and a
commit SHA is the only way to pick it up.

This PR pins the step to that SHA, with a comment recording why. A SHA rather than `@main` so CI can't
silently pull unreviewed upstream changes — that also matches GitHub's hardening guidance for
third-party actions.

The action's inputs are unchanged, so lint behaviour is identical. `ls-lint/action` was the only action
flagged in that run; the rest of `go.yml` is already on node24-capable majors.

Once ls-lint cuts a release containing the node24 runtime, this should go back to `@vX.Y.Z`.

**Breaking Changes (if applicable):**

None. CI-only change; no framework or user-facing code is touched.

**Additional Information:**

The pin does not receive upstream fixes automatically — that's the accepted trade-off of a SHA pin,
and the inline comment plus this note flag the revert-to-tag follow-up.

**Checklist:**

-   [x] I have formatted my code using `goimport` and `golangci-lint`.
-   [x] All new code is covered by unit tests. *(N/A — workflow config change)*
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.