### PR TITLE
chore(ci): build the website workflows on Node 24 instead of EOL Node 18 (#3870)

### DIFF
--- a/.github/workflows/website-prod.yml
+++ b/.github/workflows/website-prod.yml
@@ -46,10 +46,15 @@ jobs:
           # "Last updated" byline.
           fetch-depth: 0
 
+      # 24.x is the active LTS (EOL 2028-04-30); 22.x entered maintenance
+      # on 2025-10-21. This governs only the two runner-side steps below,
+      # `yarn install` and `yarn refresh-data` — the `next build` itself
+      # runs inside the website image, which pins its own Node in
+      # gofr-dev/website's Dockerfile and is unaffected by this value.
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 18.x
+          node-version: 24.x
 
       - name: Install website deps
         working-directory: ./website-src

--- a/.github/workflows/website-stage.yml
+++ b/.github/workflows/website-stage.yml
@@ -50,10 +50,13 @@ jobs:
           # "Last updated" byline.
           fetch-depth: 0
 
+      # Same rationale as website-prod.yml — 24.x is the active LTS and
+      # only covers the runner-side `yarn install` / `yarn refresh-data`
+      # steps. Kept in lockstep with prod so the two don't drift.
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 18.x
+          node-version: 24.x
 
       - name: Install website deps
         working-directory: ./website-src


### PR DESCRIPTION
**Description:**

Fixes #3870.

> **Merge order: please merge after #3821.**
>
> The `Example Unit Testing (v1.24)` shard on this PR is red for a reason unrelated to the change here. `TestIntegration_AddRESTHandlers` waits a flat `time.Sleep(100 * time.Millisecond)` after `go main()`, but that example runs its migrations before `a.Run()` binds the port, so the first request can hit a socket that is not listening yet:
>
> ```
> Get "http://localhost:34207/": dial tcp [::1]:34207: connect: connection refused
> ```
>
> Pre-existing and repo-wide — the file has not changed since #1571, and 16 example `main_test.go` files share the pattern. The v1.25 and v1.26 shards passed on this same commit. #3821 replaces those sleeps with `testutil.WaitForHTTPServer`, including in this exact test.
>
> This branch is now rebased onto current `development` (which does not yet carry #3821 — `examples/using-add-rest-handlers/main_test.go:25` still sleeps a flat 100ms), so that shard can still flake here through no fault of this change. Once #3821 lands, rebasing again reruns the pipeline on a tree where the flake is gone; retriggering before that would only be rerolling the dice.

Both website workflows built the site on Node 18:

```
.github/workflows/website-prod.yml:52    node-version: 18.x
.github/workflows/website-stage.yml:56   node-version: 18.x
```

Node 18 "Hydrogen" reached end-of-life on **2025-04-30** and receives no security patches, including for the bundled OpenSSL and undici. These are the two workflows that build and deploy `gofr.dev` — they run `yarn install --frozen-lockfile` and `yarn refresh-data` against the network while holding `GOFR_WEBSITE_GOFR_DEV*_DEPLOYMENT_KEY` and `packages: write`. That is the wrong place for the least-maintained runtime in the repo.

Both files are changed together so prod and stage cannot drift.

**Why 24.x and not the 22.x the issue suggested**

Verified against [`nodejs/Release`'s `schedule.json`](https://raw.githubusercontent.com/nodejs/Release/main/schedule.json):

| line | lts | maintenance | end of life | status today |
|---|---|---|---|---|
| v18 Hydrogen | 2022-10-25 | 2023-10-18 | **2025-04-30** | EOL |
| v20 Iron | 2023-10-24 | 2024-10-22 | 2026-04-30 | EOL |
| v22 Jod | 2024-10-29 | **2025-10-21** | 2027-04-30 | maintenance |
| v24 Krypton | 2025-10-28 | 2026-10-20 | 2028-04-30 | **Active LTS** |

v22 has been in maintenance since 2025-10-21; v24 is the Active LTS and buys roughly 12 additional months before this recurs.

The one argument for capping at 22 would be avoiding a runner newer than the image that consumes the same lockfile (`gofr-dev/website`'s Dockerfile builds on `node:23.11.1`). It does not apply: that repo's `.dockerignore` excludes `node_modules` and its Dockerfile runs its own `yarn install` from `package.json` + `yarn.lock`, so the runner's install never crosses into the image. The only artifacts that do cross are the JSON/RSS/txt files written by `refresh-data`, which are runtime-independent data.

**On the caveats raised in the issue**

All three were checked up front rather than left to CI:

1. **`engines` / Node-sensitive deps in `gofr-dev/website`** — `package.json` declares no `engines` field, so nothing constrains the major. No matching change is needed there first.
2. **`--frozen-lockfile` could go red for lockfile reasons** — run against the website's actual `package.json` + `yarn.lock` in a throwaway `node:24-alpine` container (Node v24.19.0, Yarn 1.22.22): **exit 0**, lockfile satisfied, no new warnings beyond the pre-existing unmet-peer-dependency set.
3. **The Dockerfile stage pinning its own Node** — it does, in the website repo, so nothing here needs changing for this bump to take effect. See the scope note below.

**Scope — what this does and does not fix**

`setup-node` in these workflows governs only the two runner-side steps, `yarn install` and `yarn refresh-data`. The actual `next build` runs inside the website image (`docs/Dockerfile` does `FROM ghcr.io/gofr-dev/website:${WEBSITE_TAG} AS builder`, then `npm run build`), which carries its own Node.

Worth flagging explicitly: that image pins `node:23.11.1-alpine3.21`, and **v23 is a non-LTS line that went EOL 2025-06-01** — staler than the Node 18 this issue is about. `setup-node` here cannot reach it; the pin lives in `gofr-dev/website`. Filed separately rather than smuggled into a `gofr` CI PR.

**Breaking Changes (if applicable):**

None. CI-only change; no framework code, no public API, no user-facing behaviour.

**Additional Information:**

These workflows cannot be exercised from a fork — prod fires on `v*.*.*` tags, stage on pushes to `development`, and both jobs are gated on `if: github.repository == 'gofr-dev/gofr'`. The real verification is the first stage run after merge. Ahead of that: both files parse clean as YAML, and the install step is verified green on Node 24 as described above.

**Checklist:**

-   [x] I have formatted my code using `goimport` and `golangci-lint`. — n/a, no Go code changed; both YAML files validated with a parser instead
-   [x] All new code is covered by unit tests. — n/a, CI workflow configuration; covered by the Node 24 install verification above
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.


