### PR TITLE
fix(sql): correct query duration logging unit to microseconds

### DIFF
--- a/pkg/gofr/datasource/sql/db.go
+++ b/pkg/gofr/datasource/sql/db.go
@@ -54,20 +54,21 @@ func clean(query string) string {
 }
 
 func sendStats(logger datasource.Logger, metrics Metrics, config *DBConfig, start time.Time, queryType, query string, args ...any) {
-	duration := time.Since(start).Milliseconds()
+	duration := time.Since(start)
 
 	if logger != nil {
 		logger.Debug(&Log{
 			Type:     queryType,
 			Query:    query,
-			Duration: duration,
+			Duration: duration.Microseconds(),
 			Args:     args,
 		})
 	}
 
 	// This contains the fix for the nil pointer dereference
 	if metrics != nil {
-		metrics.RecordHistogram(context.Background(), "app_sql_stats", float64(duration), "hostname", config.HostName,
+		metrics.RecordHistogram(context.Background(), "app_sql_stats",
+			float64(duration)/float64(time.Millisecond), "hostname", config.HostName,
 			"database", config.Database, "type", getOperationType(query))
 	}
 }

--- a/pkg/gofr/datasource/sql/db_test.go
+++ b/pkg/gofr/datasource/sql/db_test.go
@@ -772,14 +772,12 @@ func TestDB_sendOperationStats_RecordsMilliseconds(t *testing.T) {
 	start := time.Now().Add(-1500 * time.Millisecond) // 1.5 seconds ago
 
 	mockMetrics.EXPECT().RecordHistogram(
-		gomock.Any(), "app_sql_stats", float64(1500),
+		gomock.Any(), "app_sql_stats",
+		gomock.Cond(func(v float64) bool { return v >= 1500 && v < 1510 }),
 		"hostname", "host", "database", "db", "type", "SELECT",
 	)
 
 	db.sendOperationStats(start, "SELECT", "SELECT * FROM users")
-
-	duration := time.Since(start).Milliseconds()
-	assert.Equal(t, int64(1500), duration)
 }
 
 // --- Tx method tests ---


### PR DESCRIPTION
Issue: #3877

## Description

This PR fixes an inconsistency in SQL query duration logging while keeping the existing `app_sql_stats` metric contract unchanged.

### Problem

SQL query duration in `sendStats` is consumed by two different paths:

- **SQL logs** should report query duration in **microseconds (`µs`)**
- **`app_sql_stats`** is documented and registered as reporting query duration in **milliseconds (`ms`)**

Previously, `sendStats` calculated a single duration value using:

go
duration := time.Since(start).Milliseconds()- **Expected Benefits:** Developers will see accurate query runtimes in console logs matching the format of all other GoFr database adapters (Redis, MongoDB, etc.).

**Breaking Changes (if applicable):**

- None. Telemetry endpoints and metrics are backward-compatible.

**Additional Information:**

- No new dependencies or external libraries were added.
- The change was verified through existing unit test adaptations.

**Checklist:**

- [✔️] I have formatted my code using `goimport` and `golangci-lint`.
- [✔️] All new code is covered by unit tests.
- [✔️] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.


