### PR TITLE
fix(http): keep Params returning nil for an absent key

### DIFF
--- a/pkg/gofr/http/request.go
+++ b/pkg/gofr/http/request.go
@@ -90,14 +90,17 @@ func (r *Request) HostName() string {
 	return fmt.Sprintf("%s://%s", proto, r.req.Host)
 }
 
-// Params returns a slice of strings containing the values associated with the given query parameter key.
-// If the parameter is not present, a nil slice is returned.
+// Params returns the values associated with the given query parameter key. Each value is
+// additionally split on commas, so ?tag=a,b&tag=c yields []string{"a", "b", "c"}.
+//
+// If the key is absent, a nil slice is returned. A handler may return this value directly, and a
+// nil slice marshals to `null` in the response body where an empty one marshals to `[]`.
 func (r *Request) Params(key string) []string {
 	values := r.req.URL.Query()[key]
 
-	// Deliberately not preallocated. A handler may return this slice directly, and a nil slice
-	// marshals to `null` where an empty one marshals to `[]`. Preallocating would silently change
-	// that response body for every absent key, so the allocation hint is declined here.
+	// Deliberately not preallocated: that would return an empty slice for an absent key and
+	// silently change the response body from `null` to `[]`. The hint is also a poor estimate,
+	// since len(values) under-counts as soon as any value contains a comma.
 	//nolint:prealloc // preserves the nil return for an absent key; see comment above
 	var result []string
 

--- a/pkg/gofr/http/request.go
+++ b/pkg/gofr/http/request.go
@@ -94,7 +94,7 @@ func (r *Request) HostName() string {
 // additionally split on commas, so ?tag=a,b&tag=c yields []string{"a", "b", "c"}.
 //
 // If the key is absent, a nil slice is returned. A handler may return this value directly, and a
-// nil slice marshals to `null` in the response body where an empty one marshals to `[]`.
+// nil slice reaches the client as "null" in the response body where an empty one reaches it as "[]".
 func (r *Request) Params(key string) []string {
 	values := r.req.URL.Query()[key]
 

--- a/pkg/gofr/http/request.go
+++ b/pkg/gofr/http/request.go
@@ -91,11 +91,15 @@ func (r *Request) HostName() string {
 }
 
 // Params returns a slice of strings containing the values associated with the given query parameter key.
-// If the parameter is not present, an empty slice is returned.
+// If the parameter is not present, a nil slice is returned.
 func (r *Request) Params(key string) []string {
 	values := r.req.URL.Query()[key]
 
-	result := make([]string, 0, len(values))
+	// Deliberately not preallocated. A handler may return this slice directly, and a nil slice
+	// marshals to `null` where an empty one marshals to `[]`. Preallocating would silently change
+	// that response body for every absent key, so the allocation hint is declined here.
+	//nolint:prealloc // preserves the nil return for an absent key; see comment above
+	var result []string
 
 	for _, value := range values {
 		result = append(result, strings.Split(value, ",")...)

--- a/pkg/gofr/http/request_test.go
+++ b/pkg/gofr/http/request_test.go
@@ -251,7 +251,7 @@ func Test_Params(t *testing.T) {
 	assert.ElementsMatch(t, expectedCategories, r.Params("category"), "expected all values of 'category' to match")
 	assert.ElementsMatch(t, expectedTags, r.Params("tag"), "expected all values of 'tag' to match")
 	assert.Empty(t, r.Params("nonexistent"), "expected empty slice for non-existent query param")
-	assert.NotNil(t, r.Params("nonexistent"), "absent key must return an empty non-nil slice, not nil")
+	assert.Nil(t, r.Params("nonexistent"), "absent key must return nil so a handler returning it responds `null`, not `[]`")
 }
 
 func TestBind_FormURLEncoded(t *testing.T) {

--- a/pkg/gofr/http/request_test.go
+++ b/pkg/gofr/http/request_test.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"io"
 	"mime/multipart"
@@ -254,11 +253,13 @@ func Test_Params(t *testing.T) {
 	// Nil, not merely empty: assert.Empty alone would pass for both.
 	assert.Nil(t, r.Params("nonexistent"), "absent key must return a nil slice")
 
-	// The contract users actually observe is the response body. Pin it at that layer too, since a
-	// handler may return Params directly and an empty slice would serialize as `[]`, not `null`.
-	body, err := json.Marshal(r.Params("nonexistent"))
-	require.NoError(t, err)
-	assert.JSONEq(t, `null`, string(body), "an absent key must serialize as null in a response body")
+	// Pin the actual response body, not just the marshaled value: a handler may return Params
+	// directly, and this is what its client receives. Going through Responder means a future change
+	// to how it normalizes nil values cannot silently alter the wire shape while this test passes.
+	rec := httptest.NewRecorder()
+	NewResponder(rec, http.MethodGet).Respond(r.Params("nonexistent"), nil)
+	assert.JSONEq(t, `{"data":null}`, rec.Body.String(),
+		"an absent key must reach the client as null, not [] or an omitted field")
 }
 
 func TestBind_FormURLEncoded(t *testing.T) {

--- a/pkg/gofr/http/request_test.go
+++ b/pkg/gofr/http/request_test.go
@@ -250,8 +250,9 @@ func Test_Params(t *testing.T) {
 
 	assert.ElementsMatch(t, expectedCategories, r.Params("category"), "expected all values of 'category' to match")
 	assert.ElementsMatch(t, expectedTags, r.Params("tag"), "expected all values of 'tag' to match")
-	assert.Empty(t, r.Params("nonexistent"), "expected empty slice for non-existent query param")
-	assert.Nil(t, r.Params("nonexistent"), "absent key must return nil so a handler returning it responds `null`, not `[]`")
+	// Nil, not merely empty: a handler may return this directly, and nil marshals to `null` where
+	// an empty slice marshals to `[]`. assert.Empty alone would pass for both.
+	assert.Nil(t, r.Params("nonexistent"), "absent key must return a nil slice")
 }
 
 func TestBind_FormURLEncoded(t *testing.T) {

--- a/pkg/gofr/http/request_test.go
+++ b/pkg/gofr/http/request_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"mime/multipart"
@@ -250,9 +251,14 @@ func Test_Params(t *testing.T) {
 
 	assert.ElementsMatch(t, expectedCategories, r.Params("category"), "expected all values of 'category' to match")
 	assert.ElementsMatch(t, expectedTags, r.Params("tag"), "expected all values of 'tag' to match")
-	// Nil, not merely empty: a handler may return this directly, and nil marshals to `null` where
-	// an empty slice marshals to `[]`. assert.Empty alone would pass for both.
+	// Nil, not merely empty: assert.Empty alone would pass for both.
 	assert.Nil(t, r.Params("nonexistent"), "absent key must return a nil slice")
+
+	// The contract users actually observe is the response body. Pin it at that layer too, since a
+	// handler may return Params directly and an empty slice would serialize as `[]`, not `null`.
+	body, err := json.Marshal(r.Params("nonexistent"))
+	require.NoError(t, err)
+	assert.JSONEq(t, `null`, string(body), "an absent key must serialize as null in a response body")
 }
 
 func TestBind_FormURLEncoded(t *testing.T) {


### PR DESCRIPTION
## What

Restores `Request.Params(key)` to returning a **nil** slice for an absent query key, undoing the one behavioural change that arrived in #3921.

## Why

#3921 was a mechanical lint cleanup. One of its three `prealloc` hits was here:

```
pkg/gofr/http/request.go:96:6: Consider preallocating result (prealloc)
	var result []string
```

The fix was `var result []string` → `make([]string, 0, len(values))`. For an absent key the loop never runs, so the return went from nil to empty — and a handler written as

```go
app.GET("/search", func(c *gofr.Context) (any, error) { return c.Params("tag"), nil })
```

started responding `{"data":[]}` where it previously responded `{"data":null}`.

`prealloc` is a performance hint; nothing about it required changing what the function returns. The other two `prealloc` hits in that same PR (`opentsdb_test.go:97` and `:989`) were resolved with `//nolint:prealloc` precisely because preallocating was wrong there. This applies the same treatment to the one case that touches a public API's response body.

Only nil has ever shipped — v1.58.0 returns nil, and the empty-slice behaviour exists only on `development`.

## Changes

- `Params` keeps `var result []string`, with a comment explaining why the allocation hint is declined and a `//nolint:prealloc` carrying that reason. The hint is also a poor estimate on its own terms: `len(values)` under-counts as soon as any value contains a comma.
- **Godoc corrected.** It claimed "If the parameter is not present, an empty slice is returned", which was never true before #3921 and is the mismatch that made the change look harmless. It now describes the actual behaviour, and documents comma-splitting — which `cmd`'s `Params` and the docs site both mention, but the godoc users see on pkg.go.dev did not.
- `Test_Params` pins the contract twice: `assert.Nil` on the returned value, and the response body through the real `Responder`. The previous `assert.Empty` passed for both nil and empty, which is why the original change slipped through unnoticed.

## Release-branch action required before #3923 merges

This PR takes the change off `development` only. **`release/v1.59.0` was cut before this and still carries the empty-slice behaviour**, plus a "⚠️ Behavioural change" section in #3923's notes announcing it. Without action there, v1.59.0 ships the regression *and* documents it, and v1.60.0 then ships the un-announcement — a behaviour flip-flop across one minor version, which is worse for users than either endpoint.

The release branch needs these commits cherry-picked (or a re-cut from `development` once this lands), and that section removed from #3923.

## Not closing the door

Returning an empty slice may well be the better contract — `null` breaks naive JavaScript clients (`data.map`, `data.length`) where `[]` does not. But it is a bigger decision than it looks: of the seven `gofr.Request` implementations, six return nil for an absent key, four of them with existing `assert.Nil` tests, and `pkg/gofr/cmd/request.go:90` is the lone outlier returning `[]string{}`. Adopting `[]` means changing six implementations and their tests, with a release note — not a one-line alignment. That deserves its own PR, not a silent arrival inside a lint cleanup.

## Verification

`go build ./...`, `go vet`, and `go test ./pkg/gofr/http/...` pass. `golangci-lint` reports zero issues in `request.go`; `nolintlint` runs with `allow-unused: false` and does not flag the new directive, confirming `prealloc` genuinely fires there. Both test pins were verified by reintroducing the preallocation and watching them fail.
