### PR TITLE
fix(grpc): guard the server handle so Run and Shutdown stop racing (#3929)

### DIFF
--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -1832,8 +1832,10 @@ func TestStartGRPCServer_Registered(t *testing.T) {
 	// Give it a moment to start then shut down
 	time.Sleep(50 * time.Millisecond)
 
-	if app.grpcServer != nil && app.grpcServer.server != nil {
-		app.grpcServer.server.Stop()
+	// Read through getServer rather than the field: createServer publishes it from the serve
+	// goroutine, so an unguarded read here races that write.
+	if app.grpcServer != nil {
+		app.grpcServer.forceStop()
 	}
 
 	wg.Wait()

--- a/pkg/gofr/grpc.go
+++ b/pkg/gofr/grpc.go
@@ -20,7 +20,7 @@ import (
 )
 
 type grpcServer struct {
-	// srvMu guards server, which createServer writes on the serve goroutine and Shutdown reads on the caller goroutine.
+	// srvMu guards server, which ensureServer writes on the serve goroutine and Shutdown reads on the caller goroutine.
 	srvMu              sync.Mutex
 	server             *grpc.Server
 	interceptors       []grpc.UnaryServerInterceptor
@@ -125,14 +125,30 @@ func registerGRPCMetrics(c *container.Container) {
 	c.Metrics().NewCounter("app_grpc_rate_limit_exceeded_total", "Total gRPC requests rejected by rate limiter")
 }
 
-func (g *grpcServer) createServer() error {
+// ensureServer returns the server, creating it on first call. The check and the publish happen
+// under a single hold — mirroring httpServer.run — so two concurrent callers cannot both observe
+// nil and both build one, leaving the loser to Serve a server no later getServer sees and no
+// Shutdown stops. The hold also covers the append to g.options.
+//
+// Building under the lock is safe: grpc.NewServer and reflection.Register do not block. The
+// server is published only once fully set up, so a concurrent Shutdown sees either no server or
+// a ready one, never a partially registered one. Callers use the returned copy for blocking
+// calls such as Serve, which must never hold srvMu.
+func (g *grpcServer) ensureServer() (*grpc.Server, error) {
+	g.srvMu.Lock()
+	defer g.srvMu.Unlock()
+
+	if g.server != nil {
+		return g.server, nil
+	}
+
 	interceptorOption := grpc.ChainUnaryInterceptor(g.interceptors...)
 	streamOpt := grpc.ChainStreamInterceptor(g.streamInterceptors...)
 	g.options = append(g.options, interceptorOption, streamOpt)
 
 	srv := grpc.NewServer(g.options...)
 	if srv == nil {
-		return errFailedCreateServer
+		return nil, errFailedCreateServer
 	}
 
 	enabled := strings.ToLower(g.config.GetOrDefault("GRPC_ENABLE_REFLECTION", "false"))
@@ -140,13 +156,9 @@ func (g *grpcServer) createServer() error {
 		reflection.Register(srv)
 	}
 
-	// Publish under the lock, and only after the server is fully set up, so a concurrent
-	// Shutdown either sees no server at all or one that is ready to be stopped.
-	g.srvMu.Lock()
 	g.server = srv
-	g.srvMu.Unlock()
 
-	return nil
+	return srv, nil
 }
 
 // getServer returns the current server under the lock. Callers operate on the returned
@@ -159,16 +171,12 @@ func (g *grpcServer) getServer() *grpc.Server {
 }
 
 func (g *grpcServer) Run(c *container.Container) {
-	srv := g.getServer()
-	if srv == nil {
-		if err := g.createServer(); err != nil {
-			c.Logger.Fatalf("failed to create gRPC server: %v", err)
-			c.Metrics().IncrementCounter(context.Background(), "grpc_server_errors_total")
+	srv, err := g.ensureServer()
+	if err != nil {
+		c.Logger.Fatalf("failed to create gRPC server: %v", err)
+		c.Metrics().IncrementCounter(context.Background(), "grpc_server_errors_total")
 
-			return
-		}
-
-		srv = g.getServer()
+		return
 	}
 
 	if !isPortAvailable(g.port) {
@@ -236,19 +244,18 @@ func (g *grpcServer) forceStop() {
 
 // RegisterService adds a gRPC service to the GoFr application.
 func (a *App) RegisterService(desc *grpc.ServiceDesc, impl any) {
-	if !a.grpcRegistered {
-		if err := a.grpcServer.createServer(); err != nil {
-			a.container.Logger.Errorf("failed to create gRPC server for service %s: %v", desc.ServiceName, err)
-			return
-		}
+	srv, err := a.grpcServer.ensureServer()
+	if err != nil {
+		a.container.Logger.Errorf("failed to create gRPC server for service %s: %v", desc.ServiceName, err)
+		return
 	}
 
 	a.container.Logger.Infof("registering gRPC Service: %s", desc.ServiceName)
-	a.grpcServer.getServer().RegisterService(desc, impl)
+	srv.RegisterService(desc, impl)
 
 	a.container.Metrics().IncrementCounter(context.Background(), "grpc_services_registered_total")
 
-	err := injectContainer(impl, a.container)
+	err = injectContainer(impl, a.container)
 	if err != nil {
 		a.container.Logger.Fatalf("failed to inject container into gRPC service %s: %v", desc.ServiceName, err)
 	}

--- a/pkg/gofr/grpc.go
+++ b/pkg/gofr/grpc.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"google.golang.org/grpc"
@@ -19,6 +20,8 @@ import (
 )
 
 type grpcServer struct {
+	// srvMu guards server, which createServer writes on the serve goroutine and Shutdown reads on the caller goroutine.
+	srvMu              sync.Mutex
 	server             *grpc.Server
 	interceptors       []grpc.UnaryServerInterceptor
 	streamInterceptors []grpc.StreamServerInterceptor
@@ -127,27 +130,45 @@ func (g *grpcServer) createServer() error {
 	streamOpt := grpc.ChainStreamInterceptor(g.streamInterceptors...)
 	g.options = append(g.options, interceptorOption, streamOpt)
 
-	g.server = grpc.NewServer(g.options...)
-	if g.server == nil {
+	srv := grpc.NewServer(g.options...)
+	if srv == nil {
 		return errFailedCreateServer
 	}
 
 	enabled := strings.ToLower(g.config.GetOrDefault("GRPC_ENABLE_REFLECTION", "false"))
 	if enabled == "true" { //nolint:goconst // standard boolean string
-		reflection.Register(g.server)
+		reflection.Register(srv)
 	}
+
+	// Publish under the lock, and only after the server is fully set up, so a concurrent
+	// Shutdown either sees no server at all or one that is ready to be stopped.
+	g.srvMu.Lock()
+	g.server = srv
+	g.srvMu.Unlock()
 
 	return nil
 }
 
+// getServer returns the current server under the lock. Callers operate on the returned
+// copy so a blocking call such as Serve or GracefulStop never holds srvMu.
+func (g *grpcServer) getServer() *grpc.Server {
+	g.srvMu.Lock()
+	defer g.srvMu.Unlock()
+
+	return g.server
+}
+
 func (g *grpcServer) Run(c *container.Container) {
-	if g.server == nil {
+	srv := g.getServer()
+	if srv == nil {
 		if err := g.createServer(); err != nil {
 			c.Logger.Fatalf("failed to create gRPC server: %v", err)
 			c.Metrics().IncrementCounter(context.Background(), "grpc_server_errors_total")
 
 			return
 		}
+
+		srv = g.getServer()
 	}
 
 	if !isPortAvailable(g.port) {
@@ -174,7 +195,7 @@ func (g *grpcServer) Run(c *container.Container) {
 	c.Metrics().SetGauge("grpc_server_status", 1)
 	c.Logger.Infof("gRPC server started successfully on %s", addr)
 
-	if err := g.server.Serve(listener); err != nil {
+	if err := srv.Serve(listener); err != nil {
 		c.Logger.Errorf("error in starting gRPC server at %s: %s", addr, err)
 		c.Metrics().IncrementCounter(context.Background(), "grpc_server_errors_total")
 		c.Metrics().SetGauge("grpc_server_status", 0)
@@ -188,18 +209,29 @@ func (g *grpcServer) Run(c *container.Container) {
 
 func (g *grpcServer) Shutdown(ctx context.Context) error {
 	return ShutdownWithContext(ctx, func(_ context.Context) error {
-		if g.server != nil {
-			g.server.GracefulStop()
-		}
+		g.gracefulStop()
 
 		return nil
 	}, func() error {
-		if g.server != nil {
-			g.server.Stop()
-		}
+		g.forceStop()
 
 		return nil
 	})
+}
+
+// gracefulStop drains in-flight RPCs and returns when they are done. It is a no-op if no
+// server was ever created, which is the case when no service has been registered.
+func (g *grpcServer) gracefulStop() {
+	if srv := g.getServer(); srv != nil {
+		srv.GracefulStop()
+	}
+}
+
+// forceStop closes the listener and cuts in-flight RPCs. Same no-op contract as gracefulStop.
+func (g *grpcServer) forceStop() {
+	if srv := g.getServer(); srv != nil {
+		srv.Stop()
+	}
 }
 
 // RegisterService adds a gRPC service to the GoFr application.
@@ -212,7 +244,7 @@ func (a *App) RegisterService(desc *grpc.ServiceDesc, impl any) {
 	}
 
 	a.container.Logger.Infof("registering gRPC Service: %s", desc.ServiceName)
-	a.grpcServer.server.RegisterService(desc, impl)
+	a.grpcServer.getServer().RegisterService(desc, impl)
 
 	a.container.Metrics().IncrementCounter(context.Background(), "grpc_services_registered_total")
 

--- a/pkg/gofr/grpc_test.go
+++ b/pkg/gofr/grpc_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -373,6 +374,44 @@ func TestGRPC_Shutdown_BeforeStart_ContextCanceled(t *testing.T) {
 			_ = g.Shutdown(ctx)
 		}, "Shutdown must not panic when server was never created")
 	}
+}
+
+// TestGRPC_ConcurrentRunAndShutdown guards against a regression of the data race the
+// srvMu guard closes: createServer publishes g.server from the serve goroutine while
+// Shutdown reads it on the caller's. Meaningful under -race; without the guard the
+// detector reports both the field itself and the CAS inside grpc-go's Server.Stop.
+func TestGRPC_ConcurrentRunAndShutdown(t *testing.T) {
+	c, _, g := setupTestGRPCServer(t, testutil.GetFreePort(t), false)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		g.Run(c)
+	}()
+
+	// No sleep: racing Shutdown against Run's publish of g.server is the point.
+	require.NoError(t, g.Shutdown(t.Context()))
+
+	// That Shutdown may legitimately have observed no server yet and returned a no-op —
+	// Run is free to publish afterwards and keep serving. That lost-shutdown gap is
+	// nil-check-as-started, tracked in #3801, and is deliberately not what this test
+	// asserts; stop whatever Run ended up publishing so Run returns either way.
+	require.Eventually(t, func() bool {
+		srv := g.getServer()
+		if srv == nil {
+			return false
+		}
+
+		srv.Stop()
+
+		return true
+	}, time.Second, 10*time.Millisecond, "Run never published a server to stop")
+
+	wg.Wait()
 }
 
 func TestGRPC_ServerRun_WithInterceptorAndOptions(t *testing.T) {

--- a/pkg/gofr/grpc_test.go
+++ b/pkg/gofr/grpc_test.go
@@ -127,23 +127,28 @@ func TestGRPCServer_AddUnaryInterceptors(t *testing.T) {
 func TestGRPCServer_CreateServer(t *testing.T) {
 	_, _, g := setupTestGRPCServer(t, 9999, false)
 
-	err := g.createServer()
+	srv, err := g.ensureServer()
 	require.NoError(t, err)
-	assert.NotNil(t, g.server)
+	assert.NotNil(t, srv)
+
+	// Second call must return the same server, not build another one.
+	again, err := g.ensureServer()
+	require.NoError(t, err)
+	assert.Same(t, srv, again)
 }
 
 func TestGRPCServer_RegisterService(t *testing.T) {
 	_, _, g := setupTestGRPCServer(t, 9999, false)
 
-	err := g.createServer()
+	srv, err := g.ensureServer()
 	require.NoError(t, err)
 
 	healthServer := health.NewServer()
 	desc := &grpc_health_v1.Health_ServiceDesc
 
-	g.server.RegisterService(desc, healthServer)
+	srv.RegisterService(desc, healthServer)
 
-	services := g.server.GetServiceInfo()
+	services := srv.GetServiceInfo()
 	_, ok := services["grpc.health.v1.Health"]
 	assert.True(t, ok, "health service should be registered")
 }
@@ -166,8 +171,7 @@ func TestGRPC_ServerRun(t *testing.T) {
 			}
 
 			// Create the server first
-			err := g.createServer()
-			if err != nil {
+			if _, err := g.ensureServer(); err != nil {
 				t.Fatalf("Failed to create server: %v", err)
 			}
 
@@ -229,8 +233,7 @@ func TestGRPC_ServerRun(t *testing.T) {
 			}
 
 			// Create the server first
-			err := g.createServer()
-			if err != nil {
+			if _, err := g.ensureServer(); err != nil {
 				t.Fatalf("Failed to create server: %v", err)
 			}
 
@@ -377,7 +380,7 @@ func TestGRPC_Shutdown_BeforeStart_ContextCanceled(t *testing.T) {
 }
 
 // TestGRPC_ConcurrentRunAndShutdown guards against a regression of the data race the
-// srvMu guard closes: createServer publishes g.server from the serve goroutine while
+// srvMu guard closes: ensureServer publishes g.server from the serve goroutine while
 // Shutdown reads it on the caller's. Meaningful under -race; without the guard the
 // detector reports both the field itself and the CAS inside grpc-go's Server.Stop.
 func TestGRPC_ConcurrentRunAndShutdown(t *testing.T) {
@@ -414,6 +417,50 @@ func TestGRPC_ConcurrentRunAndShutdown(t *testing.T) {
 	wg.Wait()
 }
 
+// TestGRPC_ConcurrentEnsureServer guards the check-then-act half: with the check and the publish
+// under one hold, concurrent callers all get the same server. Split across separate holds, two
+// callers can both observe nil and both build one — the loser then serves a server no getServer
+// returns and no Shutdown stops. The options length also pins the append inside ensureServer,
+// which the same hold covers.
+func TestGRPC_ConcurrentEnsureServer(t *testing.T) {
+	const callers = 8
+
+	_, _, g := setupTestGRPCServer(t, testutil.GetFreePort(t), false)
+
+	var (
+		wg      sync.WaitGroup
+		servers = make([]*grpc.Server, callers)
+		errs    = make([]error, callers)
+		start   = make(chan struct{})
+	)
+
+	for i := range callers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			<-start
+
+			servers[i], errs[i] = g.ensureServer()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i := range callers {
+		require.NoError(t, errs[i])
+		require.NotNil(t, servers[i])
+		assert.Samef(t, servers[0], servers[i], "caller %d got a different server: two were created", i)
+	}
+
+	// Exactly one build happened: the unary and stream interceptor options, appended once.
+	assert.Len(t, g.options, 2)
+
+	servers[0].Stop()
+}
+
 func TestGRPC_ServerRun_WithInterceptorAndOptions(t *testing.T) {
 	freePort := testutil.GetFreePort(t)
 	c, _, g := setupTestGRPCServer(t, freePort, false)
@@ -444,7 +491,7 @@ func TestGRPC_ServerRun_WithInterceptorAndOptions(t *testing.T) {
 	app.AddGRPCUnaryInterceptors(interceptor1, interceptor2)
 
 	// Create the server first
-	err := app.grpcServer.createServer()
+	srv, err := app.grpcServer.ensureServer()
 	require.NoError(t, err)
 
 	// Start the server in a goroutine
@@ -462,7 +509,7 @@ func TestGRPC_ServerRun_WithInterceptorAndOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that the server was created with the interceptors and options
-	assert.NotNil(t, app.grpcServer.server)
+	assert.NotNil(t, srv)
 	assert.Len(t, app.grpcServer.interceptors, 4) // 2 default + 2 test interceptors
 	assert.Len(t, app.grpcServer.options, 4)      // 2 test options + 2 default (interceptor) options
 }
@@ -474,10 +521,10 @@ func TestApp_WithReflection(t *testing.T) {
 	app.container = c
 	app.grpcServer = g
 
-	err := app.grpcServer.createServer()
+	srv, err := app.grpcServer.ensureServer()
 	require.NoError(t, err)
 
-	services := app.grpcServer.server.GetServiceInfo()
+	services := srv.GetServiceInfo()
 	_, ok := services["grpc.reflection.v1alpha.ServerReflection"]
 	assert.True(t, ok, "reflection service should be registered")
 }


### PR DESCRIPTION
**Description:**

Fixes #3929.

`grpcServer.server` was written on the serve goroutine and read on the shutdown goroutine with no synchronisation — the same defect #3762 fixed for `httpServer.srv`, on the field that fix explicitly deferred:

> The gRPC server (races on a different field, `g.server`, created at registration) and a pre-existing websocket race are out of scope and reproduce on development independently; tracked separately.
> — 050596e8

**Root Cause Analysis**

**Symptom.** Three tests fail under `-race` on clean `development` (verified at `ceb50390`): `TestStartGRPCServer_Registered`, `TestGRPC_ServerShutdown`, `TestGRPC_ServerShutdown_ContextCanceled`. The detector reports each occurrence twice — once on `g.server` itself, then once inside grpc-go, where `NewServer`'s `grpcsync.NewEvent` races `Server.Stop`'s `CompareAndSwapUint32` (`google.golang.org/grpc@v1.83.0/server.go:1944`), which is the downstream consequence of the first.

**Root cause.** `createServer()` assigns the field (`grpc.go:130`), reached from `Run()` on whichever goroutine serves; `Shutdown()` dereferences it on the caller's goroutine, in both the graceful and the force-close closure (`grpc.go:189-201`). Nothing orders `App.startGRPCServer → Run()` against `App.Shutdown() → Shutdown()`.

**Impact beyond tests.** This is the nil-check-as-started pattern #3762 named. If `Shutdown` observes a stale `nil`, both closures no-op and `Shutdown` returns success having stopped nothing — the process can exit with the gRPC server still serving, and in-flight RPCs are cut at process death instead of drained by `GracefulStop`.

**Why it wasn't caught.** The race is a latent field race, invisible without `-race`, and CI's race legs are sharded by Go version — the same commit goes green on one shard and red on another, which reads as flake. #3762 found and fixed the identical pattern in the three HTTP-family servers but scoped the gRPC field out for a separate change; that change was never filed until #3929.

**Fix.** A `sync.Mutex` on `grpcServer` guarding `server`, mirroring `httpServer` so the four servers share one shape:
- `createServer` builds into a local, registers reflection on the local, and publishes under the lock **last** — so a concurrent `Shutdown` sees either no server or a fully set-up one, never a half-registered one.
- `Run`, `Shutdown` and `RegisterService` read through `getServer()`. The lock is never held across a blocking call (`Serve`, `GracefulStop`) — each operates on the returned copy.
- `TestStartGRPCServer_Registered` read `app.grpcServer.server` directly and raced the same write; it now stops via `forceStop()`.

**Prevention.** `TestGRPC_ConcurrentRunAndShutdown` races `Shutdown` against `Run`'s publish with no sleep between them. Mutation-verified: with the two `srvMu` Lock/Unlock pairs removed it reports `WARNING: DATA RACE` on every run; with them, clean at `-count=5 -race`.

**On the helper methods**

The natural shape is one guarded read at the top of `Shutdown` into a local both closures capture. `gracefulStop()`/`forceStop()` exist because a local pre-commit hook rejects edits spanning `Shutdown`'s `context.Context` signature line; the methods give the same guarantee at the cost of one extra guarded read on the force path. Since the field never changes once published, both reads observe the same server. Happy to fold them back into a single local read if reviewers prefer that form.

**Why the read side takes the lock too, and mutex vs `atomic.Pointer`**

Guarding only the write would fix nothing. A mutex creates ordering solely between parties that both take it: the release in `createServer` synchronises-with a matching *acquire*, so a lock-free reader pairs with nothing and is left with both a data race on the field and no guarantee that the constructed `Server` is visible to it. That is not theoretical here — with `createServer` and `Shutdown` already guarded, `TestStartGRPCServer_Registered` still raced, because it read `app.grpcServer.server` directly:

```
Read at 0x00c0005f4708 by goroutine 22:
  TestStartGRPCServer_Registered   gofr_test.go:1835
Previous write at 0x00c0005f4708 by goroutine 28:
  (*grpcServer).createServer       grpc.go:146     <- already under the lock
```

One unguarded reader reinstates the whole race, which is why `Run`, `RegisterService` and that test all go through `getServer()`/`forceStop()` rather than touching the field.

Note the lock covers only the handle. The pointee needs no protection from us: `grpc.Server` guards its own state with `s.mu` (`server.go:132`, "guards following"), taken by the `stop()` path behind both `Stop` and `GracefulStop`. Hence the local copy and the release of the lock before any blocking call.

Given that, `atomic.Pointer[grpc.Server]` would give identical publish/acquire semantics with lock-free reads, and arguably suits a write-once field better. I chose the mutex only because #3762 established that shape for `httpServer`, `metricServer` and `mcpServer`, and one shape across all four servers seemed worth more than the read cost on a path taken twice per process lifetime. Happy to switch if reviewers prefer the atomic — it is a small, contained change.

**Out of scope, deliberately**

- **Nil-check-as-started (#3801, server half).** Writing the test surfaced it: a `Shutdown` that runs before `Run` publishes reads nil, no-ops, and `Run` then serves forever — the first draft of the test deadlocked on exactly that. Fixing it needs a `stopped` flag and a `Run` that refuses to start after it, a behaviour change well past a race fix. The test stops whatever `Run` published rather than asserting shutdown wins, with a comment pointing at #3801 so the gap stays visible.
- **The websocket race**, the other half of `050596e8`'s deferred scope — `App.WebSocket` writes `ctx.Context` while `serveWithGoroutine` reads it. Filed as #3930.

**Breaking Changes (if applicable):**

None. No API or signature changes; `getServer`, `gracefulStop` and `forceStop` are unexported.

**Additional Information:**

No new dependencies.

Verification:

- `go build ./...` and `go vet ./pkg/gofr/` clean.
- `go test ./pkg/gofr/ -race -short` goes from **28 race warnings / 4 failures** to **1 / 1** on this branch. The remaining one is the websocket race (#3930), which reproduces on `development`.
- `go test ./pkg/gofr/ -run 'GRPC|RegisterService' -count=1 -race` green; `go test ./examples/grpc/...` green.
- `golangci-lint run ./pkg/gofr/...` reports nothing in the three changed files.

**Checklist:**

-   [x] I have formatted my code using `goimport` and `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.
