### PR TITLE
fix: correct serup and unadressable typos

### DIFF
--- a/docs/datasources/couchbase/page.md
+++ b/docs/datasources/couchbase/page.md
@@ -38,7 +38,7 @@ type Couchbase interface {
 ```
 
 Users can easily inject a driver that supports this interface, providing usability without compromising the extensibility to use multiple databases.
-Don't forget to serup the Couchbase cluster in Couchbase Web Console first. [Follow for more details](https://docs.couchbase.com/server/current/install/getting-started-docker.html#section_jvt_zvj_42b).
+Don't forget to setup the Couchbase cluster in Couchbase Web Console first. [Follow for more details](https://docs.couchbase.com/server/current/install/getting-started-docker.html#section_jvt_zvj_42b).
 To begin using Couchbase in your GoFr application, you need to import the Couchbase datasource package:
 
 ```shell

--- a/pkg/gofr/grpc_test.go
+++ b/pkg/gofr/grpc_test.go
@@ -295,7 +295,7 @@ func Test_injectContainer_Fails(t *testing.T) {
 	require.ErrorIs(t, err, errNonAddressable)
 	require.Nil(t, srv1.c1)
 
-	// Case: server is passed as unadressable(non-pointer)
+	// Case: server is passed as unaddressable(non-pointer)
 	srv3 := fail{}
 	out := testutil.StdoutOutputForFunc(func() {
 		cont, _ := container.NewMockContainer(t)


### PR DESCRIPTION
Fixes #3861

- `docs/datasources/couchbase/page.md`: `serup` -> `setup`
- `pkg/gofr/grpc_test.go`: `unadressable` -> `unaddressable`

No behavior change. Verified with `go test ./pkg/gofr -run Test_injectContainer_Fails -count=1`.