### PR TITLE
perf(tracer): stop rebuilding span metadata on every request

### DIFF
--- a/pkg/gofr/http/middleware/routecache.go
+++ b/pkg/gofr/http/middleware/routecache.go
@@ -1,0 +1,101 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// routeCacheLimit caps the number of entries any per-route cache in this package
+// will hold.
+//
+// With cacheableMethod filtering the method half of the key, the reachable key
+// space is (standard methods x registered routes), which is fixed at startup —
+// so this cap is a backstop for a pathologically large route table, not the
+// primary bound. It is a backstop that matters: the primary bound is an argument
+// about reachability, and an argument is a weaker thing to rest process memory on
+// than a number.
+const routeCacheLimit = 4096
+
+// cacheableMethod reports whether method may be used as part of a cache key.
+//
+// This is the load-bearing half of every per-route cache's bound, and it exists
+// because the "only bounded route templates are cached" claim does not survive
+// contact with a real GoFr app. gofr.go registers a PathPrefix("/") catch-all, so
+// mux.CurrentRoute is set for EVERY request and GetPathTemplate() returns "/"
+// even for a path no route matched — the templated guard is therefore true
+// always, and the route half of the key is not the bound it looks like.
+//
+// The method half is worse, because it is not drawn from a fixed set at all:
+// net/http accepts any RFC 7230 token as a method, so an unauthenticated client
+// streaming M00001, M00002, ... mints a permanent cache entry per request and
+// grows resident memory without bound. Restricting the key to methods that are
+// actually defined turns "methods x routes" back into the fixed quantity the
+// caches were designed around.
+//
+// A request with a non-standard method still works — its per-route data is built
+// fresh, exactly as it was before any cache existed. It just never persists.
+func cacheableMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// routeKey identifies a (method, route-template) pair.
+type routeKey struct {
+	method, route string
+}
+
+// routeCache is a bounded, concurrent cache keyed on routeKey.
+//
+// Reads stay on sync.Map's lock-free path. Writes stop at routeCacheLimit rather
+// than evicting: the entries are pure functions of their key and are all equally
+// valid forever, so there is no staleness to evict for, and refusing to grow is
+// both cheaper and easier to reason about than an eviction policy. Past the cap
+// the affected requests rebuild their data per request — the optimization stops
+// applying, but memory is flat and behavior is unchanged.
+type routeCache struct {
+	entries sync.Map
+	count   atomic.Int64
+}
+
+// load returns the cached value for key, if present.
+func (c *routeCache) load(key routeKey) (any, bool) {
+	return c.entries.Load(key)
+}
+
+// store caches value under key unless the cache is already at its limit.
+//
+// The count is advisory: concurrent stores can race past the cap by the number of
+// goroutines in flight, which is bounded and harmless. What matters is that the
+// cache cannot grow without limit.
+func (c *routeCache) store(key routeKey, value any) {
+	if c.count.Load() >= routeCacheLimit {
+		return
+	}
+
+	if _, loaded := c.entries.LoadOrStore(key, value); !loaded {
+		c.count.Add(1)
+	}
+}
+
+// len reports the number of cached entries. Test-only.
+func (c *routeCache) len() int64 {
+	return c.count.Load()
+}
+
+// reset empties the cache. Test-only: the package-level caches are process-wide,
+// so a test that asserts on size has to start from a known state.
+func (c *routeCache) reset() {
+	c.entries.Range(func(k, _ any) bool {
+		c.entries.Delete(k)
+
+		return true
+	})
+	c.count.Store(0)
+}

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -26,6 +25,17 @@ import (
 // the heap (verified via go build -gcflags='-m=2'). Factoring the
 // constructor into its own function does not avoid the alloc — it is
 // still useful as a single source of truth for the attribute key.
+// buildSpanName renders the OTel HTTP semconv span name ("GET /users/{id}").
+//
+// Concatenation rather than fmt.Sprintf. Both cost the one unavoidable
+// allocation for the result string, so this is a CPU saving only, not an
+// allocation saving: Sprintf walks a format string and boxes two arguments that
+// are already strings. Measured by BenchmarkBuildSpanName on this call site:
+// 44.3 ns/op -> 22.6 ns/op, both at 16 B/op and 1 alloc/op.
+func buildSpanName(method, route string) string {
+	return method + " " + route
+}
+
 func methodKV(method string) attribute.KeyValue {
 	return attribute.String("http.request.method", method)
 }
@@ -77,7 +87,7 @@ func Tracer(inner http.Handler) http.Handler {
 		// value per concrete path (e.g. "/users/42"). Fall back to URL.Path
 		// when no route matched (404 / unknown route).
 		route := routeTemplate(r)
-		spanName := fmt.Sprintf("%s %s", method, route)
+		spanName := buildSpanName(method, route)
 
 		ctxOut, span := tr.Start(ctx, spanName, trace.WithAttributes(
 			methodKV(method),

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -116,6 +116,17 @@ func Tracer(inner http.Handler) http.Handler {
 		// implicit 200 in that case, so the span attribute must report 200
 		// rather than be omitted (or worse, recorded as 0).
 		defer func(s trace.Span, rw *StatusResponseWriter) {
+			// A non-recording span discards SetAttributes by contract, but the
+			// call still builds the variadic []attribute.KeyValue to hand it.
+			// On the default deployment every span is non-recording — GoFr
+			// installs an SDK provider with NeverSample when no TRACE_EXPORTER
+			// is set — so that slice was allocated and thrown away on every
+			// request. Recording spans are unaffected; see
+			// TestTracerStatusAttributeStillRecorded.
+			if !s.IsRecording() {
+				return
+			}
+
 			s.SetAttributes(attribute.Int("http.response.status_code", rw.Status()))
 		}(span, srw)
 

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -127,6 +127,14 @@ func newSpanMeta(method, route string) *spanMeta {
 	}
 }
 
+// The lowercase header names the W3C propagators look up. They are the keys the
+// propagators pass to the carrier, not the spellings that go on the wire.
+const (
+	headerTraceparent = "traceparent"
+	headerTracestate  = "tracestate"
+	headerBaggage     = "baggage"
+)
+
 // canonicalPropagationKeys maps the lowercase header names the W3C propagators
 // look up to their canonical spellings.
 //
@@ -137,9 +145,9 @@ func newSpanMeta(method, route string) *spanMeta {
 //
 //nolint:gochecknoglobals // immutable, process-wide header constants.
 var canonicalPropagationKeys = map[string]string{
-	"traceparent": textproto.CanonicalMIMEHeaderKey("traceparent"),
-	"tracestate":  textproto.CanonicalMIMEHeaderKey("tracestate"),
-	"baggage":     textproto.CanonicalMIMEHeaderKey("baggage"),
+	headerTraceparent: textproto.CanonicalMIMEHeaderKey(headerTraceparent),
+	headerTracestate:  textproto.CanonicalMIMEHeaderKey(headerTracestate),
+	headerBaggage:     textproto.CanonicalMIMEHeaderKey(headerBaggage),
 }
 
 // headerCarrier adapts http.Header for the OTel propagators without paying to
@@ -163,6 +171,25 @@ func (c headerCarrier) Get(key string) string {
 }
 
 func (c headerCarrier) Set(key, value string) { http.Header(c).Set(key, value) }
+
+// Values returns every value for key, satisfying propagation.ValuesGetter.
+//
+// Not optional. propagation.Baggage.Extract type-asserts the carrier to
+// ValuesGetter and, when it matches, combines ALL values of the Baggage header;
+// the stdlib propagation.HeaderCarrier this type replaces satisfies it. Without
+// this method the assertion fails and Extract silently falls back to the
+// single-value Get, dropping every baggage member after the first whenever a
+// request carries more than one Baggage header -- which is legal per W3C and is
+// what proxies and service meshes commonly emit. GoFr installs
+// propagation.Baggage in its default composite propagator, so that path is live.
+//
+// Measured against the stdlib carrier with three Baggage headers: stdlib
+// extracted 3 members, this carrier extracted 1 before the method existed.
+//
+// The canonical-key fast path is deliberately not used here. Baggage is not one
+// of the keys canonicalPropagationKeys covers, and a carrier that replaces a
+// stdlib one has to be a faithful drop-in first and an optimization second.
+func (c headerCarrier) Values(key string) []string { return http.Header(c).Values(key) }
 
 func (c headerCarrier) Keys() []string {
 	keys := make([]string, 0, len(c))

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"strings"
-	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -35,8 +34,10 @@ func methodKV(method string) attribute.KeyValue {
 // Concatenation rather than fmt.Sprintf. Both cost the one unavoidable
 // allocation for the result string, so this is a CPU saving only, not an
 // allocation saving: Sprintf walks a format string and boxes two arguments that
-// are already strings. Measured by BenchmarkBuildSpanName on this call site:
-// 44.3 ns/op -> 22.6 ns/op, both at 16 B/op and 1 alloc/op.
+// are already strings.
+//
+// No before/after figure is quoted here: the fmt.Sprintf baseline it would be
+// measured against is gone, so nothing in the tree can reproduce one.
 func buildSpanName(method, route string) string {
 	return method + " " + route
 }
@@ -57,11 +58,6 @@ func routeTemplate(r *http.Request) (route string, templated bool) {
 	return r.URL.Path, false
 }
 
-// spanKey identifies a (method, route-template) pair.
-type spanKey struct {
-	method, route string
-}
-
 // spanMeta is the immutable per-route span data: the semconv span name and the
 // attribute slice handed to trace.WithAttributes. Both are pure functions of
 // (method, route), so they are provider-independent and safe to share process
@@ -77,37 +73,43 @@ type spanMeta struct {
 	startOpts []trace.SpanStartOption
 }
 
-// tracerSpanCache maps spanKey -> *spanMeta.
+// tracerSpanCache maps routeKey -> *spanMeta.
 //
-// Keyed on the ROUTE TEMPLATE ("/users/{id}"), never a concrete path, so it is
-// bounded by routes x methods — the same bound metrics.go relies on for its
-// routeAttrs cache. Unmatched requests carry a raw path, which is attacker
-// controlled and unbounded, so spanMetaFor deliberately does not cache those.
+// Keyed on the ROUTE TEMPLATE ("/users/{id}"), never a concrete path. That alone
+// was once believed to bound it by routes x methods, but neither half of that
+// product is bounded by itself in a real GoFr app -- see cacheableMethod, and
+// routeCache for the cap that backs the argument up.
 //
 // It is package level because the middleware chain is rebuilt around the matched
 // handler on every request, so a cache owned by the closure would be discarded
 // each time and never serve a second request.
 //
 //nolint:gochecknoglobals // rationale above: a per-closure cache would never be reused.
-var tracerSpanCache sync.Map
+var tracerSpanCache routeCache
 
 // spanMetaFor returns the span name and attributes for a route, building them on
-// first use. templated reports whether route came from a matched route template;
-// when false the value is a raw request path and must not enter the cache.
+// first use.
+//
+// templated reports whether route came from a matched route template; when false
+// the value is a raw request path and must not enter the cache. That guard is
+// necessary but NOT sufficient -- GoFr's catch-all makes it true for every
+// request, including ones no route matched -- so the method is filtered too, and
+// the cache itself is capped. An entry that cannot be cached is simply rebuilt,
+// which is what every request did before this cache existed.
 func spanMetaFor(method, route string, templated bool) *spanMeta {
-	if !templated {
+	if !templated || !cacheableMethod(method) {
 		return newSpanMeta(method, route)
 	}
 
-	key := spanKey{method: method, route: route}
-	if v, ok := tracerSpanCache.Load(key); ok {
+	key := routeKey{method: method, route: route}
+	if v, ok := tracerSpanCache.load(key); ok {
 		meta, _ := v.(*spanMeta)
 
 		return meta
 	}
 
 	meta := newSpanMeta(method, route)
-	tracerSpanCache.Store(key, meta)
+	tracerSpanCache.store(key, meta)
 
 	return meta
 }

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -211,40 +211,32 @@ func Tracer(inner http.Handler) http.Handler {
 		ctxOut, span := tr.Start(ctx, meta.name, meta.startOpts...)
 		defer span.End()
 
-		// http.response.status_code is set after the handler returns via
-		// the StatusResponseWriter wrap shared with Logging.
-
-		// Capture the response status via a StatusResponseWriter. Reuse an
-		// existing wrap if some outer middleware already provided one;
-		// otherwise wrap locally.
+		// The response status is only ever read to put it on the span, so the
+		// writer is only wrapped when the span will keep it.
 		//
-		// In GoFr's default chain Tracer is registered FIRST, i.e. outermost,
-		// so nothing has wrapped w yet and the local wrap is what actually
-		// happens on every request — Logging then wraps this one in turn.
-		srw, ok := w.(*StatusResponseWriter)
-		if !ok {
-			srw = &StatusResponseWriter{ResponseWriter: w}
-			w = srw
-		}
-
-		// rw.Status() normalizes the zero-default to http.StatusOK when the
-		// handler called neither WriteHeader nor Write — net/http emits an
-		// implicit 200 in that case, so the span attribute must report 200
-		// rather than be omitted (or worse, recorded as 0).
-		defer func(s trace.Span, rw *StatusResponseWriter) {
-			// A non-recording span discards SetAttributes by contract, but the
-			// call still builds the variadic []attribute.KeyValue to hand it.
-			// On the default deployment every span is non-recording — GoFr
-			// installs an SDK provider with NeverSample when no TRACE_EXPORTER
-			// is set — so that slice was allocated and thrown away on every
-			// request. Recording spans are unaffected; see
-			// TestTracerStatusAttributeStillRecorded.
-			if !s.IsRecording() {
-				return
+		// Tracer is the outermost middleware, so the wrapper Logging installs
+		// does not exist yet and this type assertion always failed -- meaning a
+		// StatusResponseWriter was allocated on every request and, on the
+		// default deployment, never read. GoFr installs an SDK provider with
+		// NeverSample when no TRACE_EXPORTER is configured, so no span records.
+		//
+		// Recording spans are unaffected: they still get the wrapper and the
+		// attribute, pinned by TestTracerStatusAttributeStillRecorded.
+		if span.IsRecording() {
+			srw, ok := w.(*StatusResponseWriter)
+			if !ok {
+				srw = &StatusResponseWriter{ResponseWriter: w}
+				w = srw
 			}
 
-			s.SetAttributes(attribute.Int("http.response.status_code", rw.Status()))
-		}(span, srw)
+			// Status() normalizes the zero-default to http.StatusOK when the
+			// handler called neither WriteHeader nor Write -- net/http emits an
+			// implicit 200 in that case, so the span attribute must report 200
+			// rather than be omitted, or worse recorded as 0.
+			defer func(s trace.Span, rw *StatusResponseWriter) {
+				s.SetAttributes(attribute.Int("http.response.status_code", rw.Status()))
+			}(span, srw)
+		}
 
 		inner.ServeHTTP(w, r.WithContext(ctxOut))
 	})

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -84,9 +84,11 @@ type spanMeta struct {
 // routeAttrs cache. Unmatched requests carry a raw path, which is attacker
 // controlled and unbounded, so spanMetaFor deliberately does not cache those.
 //
-// Router.Match), so a closure-owned cache would be discarded every request.
+// It is package level because the middleware chain is rebuilt around the matched
+// handler on every request, so a cache owned by the closure would be discarded
+// each time and never serve a second request.
 //
-//nolint:gochecknoglobals // mux rebuilds the middleware chain per request (see
+//nolint:gochecknoglobals // rationale above: a per-closure cache would never be reused.
 var tracerSpanCache sync.Map
 
 // spanMetaFor returns the span name and attributes for a route, building them on

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -59,12 +59,11 @@ func routeTemplate(r *http.Request) (route string, templated bool) {
 }
 
 // spanMeta is the immutable per-route span data: the semconv span name and the
-// attribute slice handed to trace.WithAttributes. Both are pure functions of
-// (method, route), so they are provider-independent and safe to share process
-// wide even across TracerProvider replacement.
+// start options carrying its attributes. Both are pure functions of (method,
+// route), so they are provider-independent and safe to share process wide even
+// across TracerProvider replacement.
 type spanMeta struct {
-	name  string
-	attrs []attribute.KeyValue
+	name string
 	// startOpts is the fully built []trace.SpanStartOption handed to Start.
 	// trace.WithAttributes allocates an option wrapper AND the variadic option
 	// slice on every call, so caching the attribute slice alone still left two
@@ -122,7 +121,6 @@ func newSpanMeta(method, route string) *spanMeta {
 
 	return &spanMeta{
 		name:      buildSpanName(method, route),
-		attrs:     attrs,
 		startOpts: []trace.SpanStartOption{trace.WithAttributes(attrs...)},
 	}
 }
@@ -253,6 +251,14 @@ func Tracer(inner http.Handler) http.Handler {
 		//
 		// Recording spans are unaffected: they still get the wrapper and the
 		// attribute, pinned by TestTracerStatusAttributeStillRecorded.
+		//
+		// The cost of this is that the ResponseWriter reaching the next middleware
+		// now depends on whether the span records. GoFr's own chain is unaffected --
+		// Logging wraps immediately after and Metrics reuses that wrapper -- but a
+		// user middleware inserted between Tracer and Logging that type-asserts
+		// *StatusResponseWriter will see it on a sampled request and not on an
+		// unsampled one. That is a hard bug to find from the symptom, so it is worth
+		// knowing before inserting anything at that position.
 		if span.IsRecording() {
 			srw, ok := w.(*StatusResponseWriter)
 			if !ok {

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -2,12 +2,12 @@ package middleware
 
 import (
 	"net/http"
+	"net/textproto"
 	"strings"
 	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
 	gofrhttp "gofr.dev/pkg/gofr/http"
@@ -123,6 +123,52 @@ func newSpanMeta(method, route string) *spanMeta {
 	}
 }
 
+// canonicalPropagationKeys maps the lowercase header names the W3C propagators
+// look up to their canonical spellings.
+//
+// http.Header.Get canonicalizes whatever key it is handed, and none of these
+// names is already canonical, so each lookup allocated the canonical string --
+// on every request, whether or not the header was even present. The spellings
+// are constants, so they are resolved once here.
+//
+//nolint:gochecknoglobals // immutable, process-wide header constants.
+var canonicalPropagationKeys = map[string]string{
+	"traceparent": textproto.CanonicalMIMEHeaderKey("traceparent"),
+	"tracestate":  textproto.CanonicalMIMEHeaderKey("tracestate"),
+	"baggage":     textproto.CanonicalMIMEHeaderKey("baggage"),
+}
+
+// headerCarrier adapts http.Header for the OTel propagators without paying to
+// canonicalize the lookup key on every request.
+//
+// A key it does not recognize falls through to the ordinary lookup, so a custom
+// propagator using its own header names keeps working unchanged.
+type headerCarrier http.Header
+
+func (c headerCarrier) Get(key string) string {
+	canonical, ok := canonicalPropagationKeys[key]
+	if !ok {
+		return http.Header(c).Get(key)
+	}
+
+	if v := c[canonical]; len(v) > 0 {
+		return v[0]
+	}
+
+	return ""
+}
+
+func (c headerCarrier) Set(key, value string) { http.Header(c).Set(key, value) }
+
+func (c headerCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
 // Tracer is a middleware that starts a new OpenTelemetry trace span for each
 // request and records http.request.method, http.route, and
 // http.response.status_code attributes on it, following the current OTel
@@ -149,7 +195,7 @@ func Tracer(inner http.Handler) http.Handler {
 		// extract the traceID and spanID from the headers and create a new context for the same
 		// this context will make a new span using the traceID and link the incoming SpanID as
 		// its parentID, thus connecting two spans
-		ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(r.Header))
+		ctx = otel.GetTextMapPropagator().Extract(ctx, headerCarrier(r.Header))
 
 		method := strings.ToUpper(r.Method)
 		// Prefer the gorilla/mux route template (e.g. "/users/{id}") so the

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"strings"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -40,17 +41,77 @@ func methodKV(method string) attribute.KeyValue {
 	return attribute.String("http.request.method", method)
 }
 
-// routeTemplate returns the matched route template (e.g. "/users/{id}") for
-// the request, otherwise the raw URL path. Used for the span name and
-// http.route attribute so tracing cardinality stays bounded by route count,
-// not request count. gofrhttp.RouteTemplate resolves the template under both
-// the trie and the default mux router.
-func routeTemplate(r *http.Request) string {
+// routeTemplate returns the matched route template (e.g. "/users/{id}") for the request, otherwise
+// the raw URL path. Used for the span name and http.route attribute so tracing cardinality stays
+// bounded by route count, not request count.
+//
+// The bool reports whether a template was resolved, which is what makes the span-name cache safe:
+// only a templated route may be cached, since a raw path is unbounded and would grow the cache once
+// per distinct request. gofrhttp.RouteTemplate resolves the template under both the trie and the
+// default mux router.
+func routeTemplate(r *http.Request) (route string, templated bool) {
 	if t := gofrhttp.RouteTemplate(r); t != "" {
-		return t
+		return t, true
 	}
 
-	return r.URL.Path
+	return r.URL.Path, false
+}
+
+// spanKey identifies a (method, route-template) pair.
+type spanKey struct {
+	method, route string
+}
+
+// spanMeta is the immutable per-route span data: the semconv span name and the
+// attribute slice handed to trace.WithAttributes. Both are pure functions of
+// (method, route), so they are provider-independent and safe to share process
+// wide even across TracerProvider replacement.
+type spanMeta struct {
+	name  string
+	attrs []attribute.KeyValue
+}
+
+// tracerSpanCache maps spanKey -> *spanMeta.
+//
+// Keyed on the ROUTE TEMPLATE ("/users/{id}"), never a concrete path, so it is
+// bounded by routes x methods — the same bound metrics.go relies on for its
+// routeAttrs cache. Unmatched requests carry a raw path, which is attacker
+// controlled and unbounded, so spanMetaFor deliberately does not cache those.
+//
+// Router.Match), so a closure-owned cache would be discarded every request.
+//
+//nolint:gochecknoglobals // mux rebuilds the middleware chain per request (see
+var tracerSpanCache sync.Map
+
+// spanMetaFor returns the span name and attributes for a route, building them on
+// first use. templated reports whether route came from a matched route template;
+// when false the value is a raw request path and must not enter the cache.
+func spanMetaFor(method, route string, templated bool) *spanMeta {
+	if !templated {
+		return newSpanMeta(method, route)
+	}
+
+	key := spanKey{method: method, route: route}
+	if v, ok := tracerSpanCache.Load(key); ok {
+		meta, _ := v.(*spanMeta)
+
+		return meta
+	}
+
+	meta := newSpanMeta(method, route)
+	tracerSpanCache.Store(key, meta)
+
+	return meta
+}
+
+func newSpanMeta(method, route string) *spanMeta {
+	return &spanMeta{
+		name: buildSpanName(method, route),
+		attrs: []attribute.KeyValue{
+			methodKV(method),
+			attribute.String("http.route", route),
+		},
+	}
 }
 
 // Tracer is a middleware that starts a new OpenTelemetry trace span for each
@@ -86,13 +147,13 @@ func Tracer(inner http.Handler) http.Handler {
 		// span name and http.route attribute do not explode to one unique
 		// value per concrete path (e.g. "/users/42"). Fall back to URL.Path
 		// when no route matched (404 / unknown route).
-		route := routeTemplate(r)
-		spanName := buildSpanName(method, route)
+		route, templated := routeTemplate(r)
+		meta := spanMetaFor(method, route, templated)
 
-		ctxOut, span := tr.Start(ctx, spanName, trace.WithAttributes(
-			methodKV(method),
-			attribute.String("http.route", route),
-		))
+		// The attribute slice is passed to Start, not applied afterwards: a
+		// sampler can read attributes when deciding, so moving them after the
+		// span exists would change sampling for anyone sampling on http.route.
+		ctxOut, span := tr.Start(ctx, meta.name, trace.WithAttributes(meta.attrs...))
 		defer span.End()
 
 		// http.response.status_code is set after the handler returns via

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -101,10 +101,15 @@ func spanMetaFor(method, route string, templated bool) *spanMeta {
 	}
 
 	key := routeKey{method: method, route: route}
-	if v, ok := tracerSpanCache.load(key); ok {
-		meta, _ := v.(*spanMeta)
 
-		return meta
+	// A failed assertion falls through to the rebuild below rather than returning
+	// the nil it would otherwise produce. Nothing else stores into this cache, so
+	// it cannot fail today; ignoring the result would turn any future change that
+	// broke that into a nil dereference on the request path.
+	if v, ok := tracerSpanCache.load(key); ok {
+		if meta, ok := v.(*spanMeta); ok {
+			return meta
+		}
 	}
 
 	meta := newSpanMeta(method, route)

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -26,6 +26,10 @@ import (
 // the heap (verified via go build -gcflags='-m=2'). Factoring the
 // constructor into its own function does not avoid the alloc — it is
 // still useful as a single source of truth for the attribute key.
+func methodKV(method string) attribute.KeyValue {
+	return attribute.String("http.request.method", method)
+}
+
 // buildSpanName renders the OTel HTTP semconv span name ("GET /users/{id}").
 //
 // Concatenation rather than fmt.Sprintf. Both cost the one unavoidable
@@ -35,10 +39,6 @@ import (
 // 44.3 ns/op -> 22.6 ns/op, both at 16 B/op and 1 alloc/op.
 func buildSpanName(method, route string) string {
 	return method + " " + route
-}
-
-func methodKV(method string) attribute.KeyValue {
-	return attribute.String("http.request.method", method)
 }
 
 // routeTemplate returns the matched route template (e.g. "/users/{id}") for the request, otherwise

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -69,6 +69,12 @@ type spanKey struct {
 type spanMeta struct {
 	name  string
 	attrs []attribute.KeyValue
+	// startOpts is the fully built []trace.SpanStartOption handed to Start.
+	// trace.WithAttributes allocates an option wrapper AND the variadic option
+	// slice on every call, so caching the attribute slice alone still left two
+	// allocations per request. The option is immutable once constructed, so it
+	// is safe to share.
+	startOpts []trace.SpanStartOption
 }
 
 // tracerSpanCache maps spanKey -> *spanMeta.
@@ -105,12 +111,15 @@ func spanMetaFor(method, route string, templated bool) *spanMeta {
 }
 
 func newSpanMeta(method, route string) *spanMeta {
+	attrs := []attribute.KeyValue{
+		methodKV(method),
+		attribute.String("http.route", route),
+	}
+
 	return &spanMeta{
-		name: buildSpanName(method, route),
-		attrs: []attribute.KeyValue{
-			methodKV(method),
-			attribute.String("http.route", route),
-		},
+		name:      buildSpanName(method, route),
+		attrs:     attrs,
+		startOpts: []trace.SpanStartOption{trace.WithAttributes(attrs...)},
 	}
 }
 
@@ -153,7 +162,7 @@ func Tracer(inner http.Handler) http.Handler {
 		// The attribute slice is passed to Start, not applied afterwards: a
 		// sampler can read attributes when deciding, so moving them after the
 		// span exists would change sampling for anyone sampling on http.route.
-		ctxOut, span := tr.Start(ctx, meta.name, trace.WithAttributes(meta.attrs...))
+		ctxOut, span := tr.Start(ctx, meta.name, meta.startOpts...)
 		defer span.End()
 
 		// http.response.status_code is set after the handler returns via

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -458,19 +458,102 @@ func TestTracerImplicit200StillRecorded(t *testing.T) {
 // template must produce ONE entry no matter how many concrete paths hit it, and
 // an unmatched (attacker-controlled) path must produce none at all.
 func TestSpanMetaCacheIsBounded(t *testing.T) {
-	tracerSpanCache.Range(func(k, _ any) bool { tracerSpanCache.Delete(k); return true })
+	tracerSpanCache.reset()
 
 	for i := range 500 {
 		spanMetaFor(http.MethodGet, "/users/{id}", true)
 		spanMetaFor(http.MethodGet, "/attacker/"+strconv.Itoa(i), false)
 	}
 
-	var n int
-
-	tracerSpanCache.Range(func(_, _ any) bool { n++; return true })
-
-	require.Equal(t, 1, n,
+	require.Equal(t, int64(1), tracerSpanCache.len(),
 		"one template must yield one entry, and unmatched paths must never be cached")
+}
+
+// TestSpanMetaCacheRejectsUndefinedMethods is the regression test for a
+// remotely-triggerable unbounded-memory DoS.
+//
+// The cache's safety argument was "only bounded route templates are cached", and
+// that argument was dead in a real GoFr app. gofr.go registers a
+// PathPrefix("/") catch-all, so mux.CurrentRoute is set for every request and
+// GetPathTemplate() returns "/" even for a path nothing matched -- making the
+// templated guard true always. net/http then accepts any RFC 7230 token as a
+// method, so an unauthenticated client streaming M00001, M00002, ... minted a
+// permanent *spanMeta each and grew resident memory without bound. The
+// pre-cache fmt.Sprintf path retained no state at all, so this was introduced
+// by the cache, not inherited.
+func TestSpanMetaCacheRejectsUndefinedMethods(t *testing.T) {
+	tracerSpanCache.reset()
+
+	// The exact attack: distinct made-up methods against the catch-all template.
+	for i := range 5000 {
+		spanMetaFor("M"+strconv.Itoa(i), "/", true)
+	}
+
+	require.Zero(t, tracerSpanCache.len(),
+		"an undefined method must never mint a cache entry")
+
+	// The requests still work -- they just rebuild, as every request did before
+	// the cache existed.
+	meta := spanMetaFor("M00001", "/", true)
+	require.Equal(t, "M00001 /", meta.name)
+}
+
+// TestSpanMetaCacheStillCachesStandardMethods pins that the method filter did
+// not break the optimization it protects.
+func TestSpanMetaCacheStillCachesStandardMethods(t *testing.T) {
+	tracerSpanCache.reset()
+
+	for _, m := range []string{
+		http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace,
+	} {
+		first := spanMetaFor(m, "/users/{id}", true)
+		require.Same(t, first, spanMetaFor(m, "/users/{id}", true),
+			"a standard method must still be served from the cache")
+	}
+
+	require.Equal(t, int64(9), tracerSpanCache.len())
+}
+
+// TestRouteCacheStopsAtItsLimit pins the backstop. The method filter is the
+// primary bound, but it is an argument about reachability; the cap is a number,
+// and process memory should rest on the number too.
+func TestRouteCacheStopsAtItsLimit(t *testing.T) {
+	var c routeCache
+
+	for i := range routeCacheLimit + 500 {
+		c.store(routeKey{method: http.MethodGet, route: "/r/" + strconv.Itoa(i)}, i)
+	}
+
+	require.Equal(t, int64(routeCacheLimit), c.len(),
+		"the cache must refuse to grow past its limit")
+
+	// Past the cap, a miss is a miss -- the caller rebuilds rather than erroring.
+	_, ok := c.load(routeKey{method: http.MethodGet, route: "/r/" + strconv.Itoa(routeCacheLimit+100)})
+	require.False(t, ok)
+}
+
+// TestTracerNonRecordingPathSkipsTheWriterWrapper covers the branch this PR
+// optimizes, which had no test at all: with a non-recording provider the
+// StatusResponseWriter must not be allocated, and the handler must see the
+// writer the server handed in.
+func TestTracerNonRecordingPathSkipsTheWriterWrapper(t *testing.T) {
+	otel.SetTracerProvider(noop.NewTracerProvider())
+
+	var got http.ResponseWriter
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/x").
+		HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { got = w })
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody))
+
+	require.NotNil(t, got)
+	assert.IsType(t, &httptest.ResponseRecorder{}, got,
+		"a non-recording span must not pay for the status-capturing wrapper")
 }
 
 // TestSpanMetaContentIsCorrect pins that caching did not change what is emitted.
@@ -547,6 +630,17 @@ func TestTracerPropagatesIncomingTraceContext(t *testing.T) {
 	otel.SetTracerProvider(trace.NewTracerProvider(trace.WithSyncer(exporter)))
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
+	// Both globals are restored. Without this the recording provider and the
+	// Baggage-less propagator leak into every later test and benchmark in the
+	// package -- tests run before benchmarks, so BenchmarkTracer would measure
+	// the RECORDING path while documenting the non-recording one, and feed this
+	// exporter for the rest of the run.
+	t.Cleanup(func() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{}, propagation.Baggage{}))
+	})
+
 	router := mux.NewRouter()
 	router.Use(Tracer)
 	router.NewRoute().Methods(http.MethodGet).Path("/x").
@@ -579,6 +673,13 @@ func (*tracerBenchWriter) WriteHeader(int)             {}
 // samples: the span is still started on every request, so whatever the middleware builds up front is
 // paid for whether or not anything records it. Allocations are the metric that matters.
 func BenchmarkTracer(b *testing.B) {
+	// Pin the non-recording provider this benchmark is about. Package state is
+	// shared and tests run first, so inheriting whatever a previous test left
+	// installed would silently measure the recording path instead.
+	otel.SetTracerProvider(noop.NewTracerProvider())
+
+	b.Cleanup(func() { otel.SetTracerProvider(noop.NewTracerProvider()) })
+
 	router := mux.NewRouter()
 	router.Use(Tracer)
 	router.NewRoute().Methods(http.MethodGet).Path("/users/{id}").

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -16,9 +16,11 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	otelTrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 // W3C TraceContext fixture values reused across the propagation tests.
@@ -561,4 +563,66 @@ func TestTracerPropagatesIncomingTraceContext(t *testing.T) {
 		"the incoming trace ID must be adopted")
 	require.Equal(t, w3cFixtureParentSpan, spans[0].Parent.SpanID().String(),
 		"the incoming span must become the parent")
+}
+
+// tracerBenchWriter keeps a header map and discards the rest, so the benchmark measures the
+// middleware rather than a recorder.
+type tracerBenchWriter struct{ h http.Header }
+
+func (w *tracerBenchWriter) Header() http.Header       { return w.h }
+func (*tracerBenchWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (*tracerBenchWriter) WriteHeader(int)             {}
+
+// BenchmarkTracer measures the tracing middleware on the path every request takes.
+//
+// The default provider is non-recording, which is the common production case for a service that
+// samples: the span is still started on every request, so whatever the middleware builds up front is
+// paid for whether or not anything records it. Allocations are the metric that matters.
+func BenchmarkTracer(b *testing.B) {
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/users/{id}").
+		Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/users/42", http.NoBody)
+	w := &tracerBenchWriter{h: make(http.Header, 4)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		clear(w.h)
+		router.ServeHTTP(w, req)
+	}
+}
+
+// BenchmarkTracer_Recording is the case the per-route cache targets: a provider that actually
+// records, so the span name and attributes built by the middleware are used rather than discarded.
+//
+// BenchmarkTracer above covers the opposite case, a non-recording provider, because a sampling
+// service runs both and the middleware must not be quietly worse in either.
+func BenchmarkTracer_Recording(b *testing.B) {
+	tp := trace.NewTracerProvider(
+		trace.WithResource(resource.Empty()),
+		trace.WithSampler(trace.AlwaysSample()),
+	)
+	otel.SetTracerProvider(tp)
+
+	b.Cleanup(func() { otel.SetTracerProvider(noop.NewTracerProvider()) })
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/users/{id}").
+		Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/users/42", http.NoBody)
+	w := &tracerBenchWriter{h: make(http.Header, 4)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		clear(w.h)
+		router.ServeHTTP(w, req)
+	}
 }

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -566,11 +566,16 @@ func TestSpanMetaContentIsCorrect(t *testing.T) {
 	meta := spanMetaFor(http.MethodPost, "/orders/{id}", true)
 
 	require.Equal(t, "POST /orders/{id}", meta.name)
-	require.Len(t, meta.attrs, 2)
-	require.Equal(t, attribute.Key("http.request.method"), meta.attrs[0].Key)
-	require.Equal(t, "POST", meta.attrs[0].Value.AsString())
-	require.Equal(t, attribute.Key("http.route"), meta.attrs[1].Key)
-	require.Equal(t, "/orders/{id}", meta.attrs[1].Value.AsString())
+
+	// Read the attributes back the way the SDK does, by resolving the start
+	// options, rather than from a field the middleware itself never consults.
+	cfg := otelTrace.NewSpanStartConfig(meta.startOpts...)
+	attrs := cfg.Attributes()
+	require.Len(t, attrs, 2)
+	require.Equal(t, attribute.Key("http.request.method"), attrs[0].Key)
+	require.Equal(t, "POST", attrs[0].Value.AsString())
+	require.Equal(t, attribute.Key("http.route"), attrs[1].Key)
+	require.Equal(t, "/orders/{id}", attrs[1].Value.AsString())
 
 	// A second call must return the identical cached instance.
 	require.Same(t, meta, spanMetaFor(http.MethodPost, "/orders/{id}", true))
@@ -594,7 +599,14 @@ func TestSpanMetaConcurrent(t *testing.T) {
 
 			for range 100 {
 				m := spanMetaFor(http.MethodGet, "/c/"+strconv.Itoa(g%4)+"/{id}", true)
-				if m == nil || m.name == "" || len(m.attrs) != 2 {
+				if m == nil || m.name == "" {
+					bad.Add(1)
+
+					continue
+				}
+
+				cfg := otelTrace.NewSpanStartConfig(m.startOpts...)
+				if len(cfg.Attributes()) != 2 {
 					bad.Add(1)
 				}
 			}

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -515,3 +515,50 @@ func TestSpanMetaConcurrent(t *testing.T) {
 
 	require.Zero(t, bad.Load(), "cache returned an incomplete spanMeta under contention")
 }
+
+// TestHeaderCarrierMatchesHeaderCarrier pins that the carrier resolves exactly
+// what propagation.HeaderCarrier resolves, for the propagation headers and for
+// an unrecognized key that must fall through to the ordinary lookup.
+func TestHeaderCarrierMatchesHeaderCarrier(t *testing.T) {
+	h := http.Header{}
+	// Set with the canonical spellings; the carrier is still queried with the
+	// lowercase names the propagators actually use, which is the point.
+	h.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+	h.Set("Tracestate", "vendor=value")
+	h.Set("Baggage", "k=v")
+	h.Set("X-Custom-Propagator", "custom")
+
+	ours := headerCarrier(h)
+	theirs := propagation.HeaderCarrier(h)
+
+	for _, key := range []string{"traceparent", "tracestate", "baggage", "X-Custom-Propagator", "absent"} {
+		require.Equal(t, theirs.Get(key), ours.Get(key), "key %q must resolve identically", key)
+	}
+
+	require.ElementsMatch(t, theirs.Keys(), ours.Keys())
+}
+
+// TestTracerPropagatesIncomingTraceContext is the feature guard: an incoming
+// traceparent must still be adopted as the parent of the server span.
+func TestTracerPropagatesIncomingTraceContext(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(trace.NewTracerProvider(trace.WithSyncer(exporter)))
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/x").
+		HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody)
+	req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	require.Equal(t, w3cFixtureTraceID, spans[0].SpanContext.TraceID().String(),
+		"the incoming trace ID must be adopted")
+	require.Equal(t, w3cFixtureParentSpan, spans[0].Parent.SpanID().String(),
+		"the incoming span must become the parent")
+}

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -394,3 +394,57 @@ func BenchmarkBuildSpanName(b *testing.B) {
 		spanNameSink = buildSpanName(method, route)
 	}
 }
+
+// TestTracerStatusAttributeStillRecorded is the guard against "optimizing" by
+// silently dropping telemetry: a sampled span must still carry the status code.
+func TestTracerStatusAttributeStillRecorded(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(trace.NewTracerProvider(trace.WithSyncer(exporter)))
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/teapot").
+		HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusTeapot) })
+
+	router.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/teapot", http.NoBody))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+
+	var found bool
+
+	for _, a := range spans[0].Attributes {
+		if a.Key == "http.response.status_code" {
+			require.Equal(t, int64(http.StatusTeapot), a.Value.AsInt64())
+
+			found = true
+		}
+	}
+
+	require.True(t, found, "a sampled span must still record http.response.status_code")
+}
+
+// TestTracerImplicit200StillRecorded pins the normalization PR #3431 established:
+// a handler that never calls WriteHeader still reports 200, not 0.
+func TestTracerImplicit200StillRecorded(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(trace.NewTracerProvider(trace.WithSyncer(exporter)))
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/silent").
+		HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+
+	router.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/silent", http.NoBody))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+
+	for _, a := range spans[0].Attributes {
+		if a.Key == "http.response.status_code" {
+			require.Equal(t, int64(http.StatusOK), a.Value.AsInt64())
+		}
+	}
+}

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -447,4 +450,68 @@ func TestTracerImplicit200StillRecorded(t *testing.T) {
 			require.Equal(t, int64(http.StatusOK), a.Value.AsInt64())
 		}
 	}
+}
+
+// TestSpanMetaCacheIsBounded is the safety property for the cache: a route
+// template must produce ONE entry no matter how many concrete paths hit it, and
+// an unmatched (attacker-controlled) path must produce none at all.
+func TestSpanMetaCacheIsBounded(t *testing.T) {
+	tracerSpanCache.Range(func(k, _ any) bool { tracerSpanCache.Delete(k); return true })
+
+	for i := range 500 {
+		spanMetaFor(http.MethodGet, "/users/{id}", true)
+		spanMetaFor(http.MethodGet, "/attacker/"+strconv.Itoa(i), false)
+	}
+
+	var n int
+
+	tracerSpanCache.Range(func(_, _ any) bool { n++; return true })
+
+	require.Equal(t, 1, n,
+		"one template must yield one entry, and unmatched paths must never be cached")
+}
+
+// TestSpanMetaContentIsCorrect pins that caching did not change what is emitted.
+func TestSpanMetaContentIsCorrect(t *testing.T) {
+	meta := spanMetaFor(http.MethodPost, "/orders/{id}", true)
+
+	require.Equal(t, "POST /orders/{id}", meta.name)
+	require.Len(t, meta.attrs, 2)
+	require.Equal(t, attribute.Key("http.request.method"), meta.attrs[0].Key)
+	require.Equal(t, "POST", meta.attrs[0].Value.AsString())
+	require.Equal(t, attribute.Key("http.route"), meta.attrs[1].Key)
+	require.Equal(t, "/orders/{id}", meta.attrs[1].Value.AsString())
+
+	// A second call must return the identical cached instance.
+	require.Same(t, meta, spanMetaFor(http.MethodPost, "/orders/{id}", true))
+}
+
+// TestSpanMetaConcurrent runs the cache under contention; the race detector is
+// the point of this test.
+func TestSpanMetaConcurrent(t *testing.T) {
+	var (
+		wg  sync.WaitGroup
+		bad atomic.Int64
+	)
+
+	// require calls FailNow, which must only run on the test goroutine, so the
+	// workers record failures and the assertion happens after Wait.
+	for g := range 16 {
+		wg.Add(1)
+
+		go func(g int) {
+			defer wg.Done()
+
+			for range 100 {
+				m := spanMetaFor(http.MethodGet, "/c/"+strconv.Itoa(g%4)+"/{id}", true)
+				if m == nil || m.name == "" || len(m.attrs) != 2 {
+					bad.Add(1)
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	require.Zero(t, bad.Load(), "cache returned an incomplete spanMeta under contention")
 }

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,12 +17,15 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	otelTrace "go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
+
+	"gofr.dev/pkg/gofr/version"
 )
 
 // W3C TraceContext fixture values reused across the propagation tests.
@@ -834,4 +839,686 @@ func BenchmarkTracer_WithPropagationHeaders(b *testing.B) {
 		clear(w.h)
 		router.ServeHTTP(w, req)
 	}
+}
+
+// Characterization suite for the Tracer HTTP middleware.
+//
+// Every identifier below is prefixed with `tracerChar` so this file can be
+// merged with sibling _test.go additions in the same package without
+// collisions. Nothing here is aspirational: every assertion pins the CURRENT
+// behavior of pkg/gofr/http/middleware/tracer.go as observed against the
+// unmodified source.
+// ---------------------------------------------------------------------------
+
+// tracerCharScopeName returns the exact instrumentation-scope (tracer) name
+// the middleware resolves at chain-build time.
+func tracerCharScopeName() string { return "gofr-" + version.Framework }
+
+// tracerCharInstallRecordingTP installs an sdktrace provider with an in-memory
+// span recorder and restores the previously installed global provider on
+// cleanup. The provider MUST be installed before Tracer() is called because
+// Tracer resolves otel.Tracer(...) once at chain-build time.
+func tracerCharInstallRecordingTP(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(rec))
+
+	otel.SetTracerProvider(tp)
+
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+
+		otel.SetTracerProvider(prev)
+	})
+
+	return rec
+}
+
+// tracerCharInstallNeverSampleTP installs exactly the provider GoFr's
+// initTracer builds when no exporter is configured (otel.go), plus a recorder
+// so tests can prove nothing is ever exported.
+func tracerCharInstallNeverSampleTP(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(
+		trace.WithSampler(trace.NeverSample()),
+		trace.WithSpanProcessor(rec),
+	)
+
+	otel.SetTracerProvider(tp)
+
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+
+		otel.SetTracerProvider(prev)
+	})
+
+	return rec
+}
+
+// tracerCharAttrs returns the span's attributes sorted by key so an exact
+// expected slice can be compared — an added, renamed or retyped attribute
+// then fails the comparison.
+func tracerCharAttrs(s trace.ReadOnlySpan) []attribute.KeyValue {
+	attrs := s.Attributes()
+	out := make([]attribute.KeyValue, len(attrs))
+	copy(out, attrs)
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+
+	return out
+}
+
+// tracerCharLogger captures the RequestLog values emitted by the Logging
+// middleware.
+type tracerCharLogger struct {
+	logs   []*RequestLog
+	errors []*RequestLog
+}
+
+func (l *tracerCharLogger) Log(args ...any) {
+	if rl, ok := args[0].(*RequestLog); ok {
+		l.logs = append(l.logs, rl)
+	}
+}
+
+func (l *tracerCharLogger) Error(args ...any) {
+	if rl, ok := args[0].(*RequestLog); ok {
+		l.errors = append(l.errors, rl)
+	}
+}
+
+// last returns the single RequestLog captured on either channel.
+func (l *tracerCharLogger) last() *RequestLog {
+	if len(l.errors) > 0 {
+		return l.errors[len(l.errors)-1]
+	}
+
+	if len(l.logs) > 0 {
+		return l.logs[len(l.logs)-1]
+	}
+
+	return nil
+}
+
+// Test_TracerContract_InstrumentationScopeName pins the exact tracer name.
+func Test_TracerContract_InstrumentationScopeName(t *testing.T) {
+	rec := tracerCharInstallRecordingTP(t)
+
+	handler := Tracer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/scope", http.NoBody)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+
+	assert.Equal(t, "gofr-dev", tracerCharScopeName(),
+		"version.Framework changed; the scope name below moves with it")
+	assert.Equal(t, tracerCharScopeName(), spans[0].InstrumentationScope().Name)
+	assert.Empty(t, spans[0].InstrumentationScope().Version,
+		"middleware passes no WithInstrumentationVersion")
+	assert.Empty(t, spans[0].InstrumentationScope().SchemaURL)
+}
+
+// Test_TracerContract_SpanName pins "METHOD /route-template" across the mux
+// route-resolution paths.
+func Test_TracerContract_SpanName(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(h http.Handler) http.Handler
+		// method/target of the inbound request.
+		method string
+		target string
+		want   string
+	}{
+		{
+			name: "mux matched route uses path template",
+			build: func(h http.Handler) http.Handler {
+				r := mux.NewRouter()
+				r.Handle("/users/{id}", h).Methods(http.MethodGet)
+
+				return r
+			},
+			method: http.MethodGet,
+			target: "/users/42",
+			want:   "GET /users/{id}",
+		},
+		{
+			name: "mux PathPrefix-only route still yields a template",
+			build: func(h http.Handler) http.Handler {
+				r := mux.NewRouter()
+				r.PathPrefix("/static").Handler(h)
+
+				return r
+			},
+			method: http.MethodGet,
+			target: "/static/css/app.css",
+			want:   "GET /static",
+		},
+		{
+			name: "mux route without any path matcher falls back to URL.Path",
+			build: func(h http.Handler) http.Handler {
+				r := mux.NewRouter()
+				r.Methods(http.MethodGet).Handler(h)
+
+				return r
+			},
+			method: http.MethodGet,
+			target: "/no/path/matcher",
+			want:   "GET /no/path/matcher",
+		},
+		{
+			name: "unmatched route (404 handler, CurrentRoute nil) falls back to URL.Path",
+			build: func(h http.Handler) http.Handler {
+				r := mux.NewRouter()
+				r.Handle("/known", http.NotFoundHandler())
+				r.NotFoundHandler = h
+
+				return r
+			},
+			method: http.MethodGet,
+			target: "/definitely/unknown",
+			want:   "GET /definitely/unknown",
+		},
+		{
+			name:   "lowercase inbound method is upper-cased",
+			build:  func(h http.Handler) http.Handler { return h },
+			method: "get",
+			target: "/lower",
+			want:   "GET /lower",
+		},
+		{
+			name:   "standalone handler (no mux) uses URL.Path",
+			build:  func(h http.Handler) http.Handler { return h },
+			method: http.MethodDelete,
+			target: "/standalone",
+			want:   "DELETE /standalone",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := tracerCharInstallRecordingTP(t)
+
+			srv := tc.build(Tracer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+			req := httptest.NewRequestWithContext(t.Context(), tc.method, tc.target, http.NoBody)
+
+			srv.ServeHTTP(httptest.NewRecorder(), req)
+
+			spans := rec.Ended()
+			require.Len(t, spans, 1)
+			assert.Equal(t, tc.want, spans[0].Name())
+			// http.route always equals the route portion of the span name.
+			assert.Equal(t, strings.TrimPrefix(tc.want, strings.ToUpper(tc.method)+" "),
+				tracerCharAttrs(spans[0])[2].Value.AsString())
+		})
+	}
+}
+
+// Test_TracerContract_ExactAttributeSet pins the complete attribute set —
+// keys, values AND value types — for a matched route.
+func Test_TracerContract_ExactAttributeSet(t *testing.T) {
+	rec := tracerCharInstallRecordingTP(t)
+
+	router := mux.NewRouter()
+	router.Handle("/users/{id}", Tracer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusCreated) },
+	))).Methods(http.MethodGet)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/users/42", http.NoBody)
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+
+	want := []attribute.KeyValue{
+		attribute.String("http.request.method", "GET"),
+		attribute.Int("http.response.status_code", http.StatusCreated),
+		attribute.String("http.route", "/users/{id}"),
+	}
+
+	got := tracerCharAttrs(spans[0])
+	assert.Equal(t, want, got, "complete attribute set (sorted by key) changed")
+
+	// Pin the value TYPES explicitly so an int->string retype fails loudly.
+	assert.Equal(t, attribute.STRING, got[0].Value.Type())
+	assert.Equal(t, attribute.INT64, got[1].Value.Type())
+	assert.Equal(t, attribute.STRING, got[2].Value.Type())
+	assert.Equal(t, int64(http.StatusCreated), got[1].Value.AsInt64())
+}
+
+// Test_TracerContract_StatusCodeAttribute pins http.response.status_code
+// across the ways a handler can (not) set a status.
+func Test_TracerContract_StatusCodeAttribute(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    int64
+	}{
+		{
+			name:    "explicit WriteHeader 404",
+			handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) },
+			want:    http.StatusNotFound,
+		},
+		{
+			name:    "explicit WriteHeader 500",
+			handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusInternalServerError) },
+			want:    http.StatusInternalServerError,
+		},
+		{
+			name:    "body only, implicit 200 via StatusResponseWriter.Write",
+			handler: func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("hello")) },
+			want:    http.StatusOK,
+		},
+		{
+			name:    "handler does nothing, Status() normalizes 0 to 200",
+			handler: func(http.ResponseWriter, *http.Request) {},
+			want:    http.StatusOK,
+		},
+		{
+			name: "WriteHeader then Write keeps the explicit status",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = w.Write([]byte("ok"))
+			},
+			want: http.StatusAccepted,
+		},
+		{
+			name: "duplicate WriteHeader keeps the first status",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			want: http.StatusTeapot,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := tracerCharInstallRecordingTP(t)
+
+			handler := Tracer(tc.handler)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/status", http.NoBody)
+
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			spans := rec.Ended()
+			require.Len(t, spans, 1)
+
+			attrs := tracerCharAttrs(spans[0])
+			require.Len(t, attrs, 3)
+			assert.Equal(t, attribute.Key("http.response.status_code"), attrs[1].Key)
+			assert.Equal(t, tc.want, attrs[1].Value.AsInt64())
+		})
+	}
+}
+
+// Test_TracerContract_SpanKindStatusAndEvents pins that the middleware emits
+// an Internal span with an Unset status and no events — even for a 5xx.
+func Test_TracerContract_SpanKindStatusAndEvents(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			rec := tracerCharInstallRecordingTP(t)
+
+			handler := Tracer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+			}))
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/kind", http.NoBody)
+
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			spans := rec.Ended()
+			require.Len(t, spans, 1)
+
+			got := spans[0]
+			assert.Equal(t, otelTrace.SpanKindInternal, got.SpanKind(),
+				"middleware never calls trace.WithSpanKind, so the SDK default (Internal) applies")
+			assert.Equal(t, codes.Unset, got.Status().Code, "no SetStatus call anywhere in the middleware")
+			assert.Empty(t, got.Status().Description)
+			assert.Empty(t, got.Events(), "middleware records no events (no RecordError)")
+			assert.Empty(t, got.Links())
+			assert.True(t, got.EndTime().After(got.StartTime()) || got.EndTime().Equal(got.StartTime()))
+		})
+	}
+}
+
+// Test_TracerContract_ReusesStatusResponseWriter pins the ResponseWriter
+// wrapping behavior in all three chain arrangements.
+func Test_TracerContract_ReusesStatusResponseWriter(t *testing.T) {
+	t.Run("chained after Logging it reuses the existing StatusResponseWriter", func(t *testing.T) {
+		tracerCharInstallRecordingTP(t)
+
+		var fromLogging, inHandler http.ResponseWriter
+
+		capture := func(inner http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fromLogging = w
+				inner.ServeHTTP(w, r)
+			})
+		}
+
+		handler := Logging(LogProbes{}, &tracerCharLogger{})(
+			capture(Tracer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				inHandler = w
+			}))))
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/reuse", http.NoBody)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+
+		loggingSRW, ok := fromLogging.(*StatusResponseWriter)
+		require.True(t, ok, "Logging must hand a *StatusResponseWriter to the next middleware")
+
+		handlerSRW, ok := inHandler.(*StatusResponseWriter)
+		require.True(t, ok)
+		assert.Same(t, loggingSRW, handlerSRW, "Tracer must not double-wrap after Logging")
+	})
+
+	t.Run("standalone it wraps locally exactly once", func(t *testing.T) {
+		tracerCharInstallRecordingTP(t)
+
+		var inHandler http.ResponseWriter
+
+		handler := Tracer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			inHandler = w
+		}))
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/wrap", http.NoBody)
+		handler.ServeHTTP(rr, req)
+
+		srw, ok := inHandler.(*StatusResponseWriter)
+		require.True(t, ok, "Tracer must wrap when it is not preceded by Logging")
+		assert.NotSame(t, http.ResponseWriter(rr), inHandler)
+		assert.Same(t, rr, srw.Unwrap(), "exactly one layer of wrapping")
+	})
+
+	t.Run("production order (Tracer outer, Logging inner) double-wraps", func(t *testing.T) {
+		tracerCharInstallRecordingTP(t)
+
+		var layers []http.ResponseWriter
+
+		// The unwrap chain must be read INSIDE the handler: Logging returns its
+		// StatusResponseWriter to a sync.Pool on the way out and nils the
+		// embedded ResponseWriter, so the chain is unreadable afterwards.
+		handler := Tracer(Logging(LogProbes{}, &tracerCharLogger{})(
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				for cur := w; cur != nil; {
+					layers = append(layers, cur)
+
+					srw, ok := cur.(*StatusResponseWriter)
+					if !ok {
+						break
+					}
+
+					cur = srw.Unwrap()
+				}
+			})))
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/double", http.NoBody)
+		handler.ServeHTTP(rr, req)
+
+		// Production wires r.Use(Tracer, Logging, ...), so Tracer is the OUTER
+		// middleware: its type assertion always fails, it wraps locally, and
+		// Logging then wraps that wrapper again. Two StatusResponseWriter
+		// layers are therefore live on every production request — which is what
+		// tracer.go's comment now describes.
+		require.Len(t, layers, 3, "expected raw recorder wrapped by two StatusResponseWriters")
+		assert.IsType(t, &StatusResponseWriter{}, layers[0])
+		assert.IsType(t, &StatusResponseWriter{}, layers[1])
+		assert.Same(t, rr, layers[2])
+	})
+}
+
+// Test_TracerContract_InboundTraceparent pins W3C trace-context continuation.
+func Test_TracerContract_InboundTraceparent(t *testing.T) {
+	installPropagators(t)
+
+	rec := tracerCharInstallRecordingTP(t)
+
+	var handlerBaggage baggage.Baggage
+
+	handler := Tracer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		handlerBaggage = baggage.FromContext(r.Context())
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/inbound", http.NoBody)
+	req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+	req.Header.Set("Baggage", "tenant=acme,region=us-east")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+
+	got := spans[0]
+
+	// Trace ID is inherited verbatim from the fixture header.
+	assert.Equal(t, w3cFixtureTraceID, got.SpanContext().TraceID().String())
+	// The span's own ID is fresh and non-deterministic — pin validity/shape only.
+	assert.True(t, got.SpanContext().SpanID().IsValid())
+	assert.Len(t, got.SpanContext().SpanID().String(), 16)
+	assert.NotEqual(t, w3cFixtureParentSpan, got.SpanContext().SpanID().String())
+
+	assert.Equal(t, w3cFixtureParentSpan, got.Parent().SpanID().String())
+	assert.Equal(t, w3cFixtureTraceID, got.Parent().TraceID().String())
+	assert.True(t, got.Parent().IsRemote(), "parent must be marked remote")
+	assert.True(t, got.Parent().IsSampled())
+
+	require.Equal(t, 2, handlerBaggage.Len(), "baggage must survive into the handler context")
+	assert.Equal(t, "acme", handlerBaggage.Member("tenant").Value())
+	assert.Equal(t, "us-east", handlerBaggage.Member("region").Value())
+}
+
+// Test_TracerContract_NoInboundTraceparentIsRoot pins that a request without a
+// traceparent produces a fresh root span.
+func Test_TracerContract_NoInboundTraceparentIsRoot(t *testing.T) {
+	installPropagators(t)
+
+	rec := tracerCharInstallRecordingTP(t)
+
+	handler := Tracer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/root", http.NoBody)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+
+	got := spans[0]
+	assert.False(t, got.Parent().IsValid(), "expected a root span")
+	assert.Equal(t, zeroTraceID, got.Parent().TraceID().String())
+	assert.True(t, got.SpanContext().TraceID().IsValid())
+	assert.Len(t, got.SpanContext().TraceID().String(), 32)
+	assert.NotEqual(t, zeroTraceID, got.SpanContext().TraceID().String())
+}
+
+// Test_TracerContract_NeverSampleKeepsValidIDs is the key regression guard for
+// GoFr's default (no exporter configured) deployment: initTracer installs an
+// sdktrace provider with NeverSample — NOT a noop provider — precisely so the
+// span context handed to handlers still carries a valid TraceID/SpanID that
+// X-Correlation-ID and the trace_id log field can use.
+func Test_TracerContract_NeverSampleKeepsValidIDs(t *testing.T) {
+	installPropagators(t)
+
+	rec := tracerCharInstallNeverSampleTP(t)
+
+	var (
+		sc        otelTrace.SpanContext
+		recording bool
+	)
+
+	handler := Tracer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		span := otelTrace.SpanFromContext(r.Context())
+		sc = span.SpanContext()
+		recording = span.IsRecording()
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/never", http.NoBody)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.True(t, sc.IsValid(), "NeverSample must still yield a valid span context")
+	assert.True(t, sc.TraceID().IsValid())
+	assert.True(t, sc.SpanID().IsValid())
+	assert.NotEqual(t, zeroTraceID, sc.TraceID().String())
+	assert.NotEqual(t, zeroSpanID, sc.SpanID().String())
+	assert.Len(t, sc.TraceID().String(), 32)
+	assert.Len(t, sc.SpanID().String(), 16)
+	assert.False(t, sc.IsSampled(), "NeverSample must clear the sampled flag")
+	assert.False(t, recording, "a dropped span must not be recording")
+	assert.Empty(t, rec.Ended(), "nothing may be exported under NeverSample")
+}
+
+// Test_TracerContract_NeverSampleWithInboundTraceparent pins that NeverSample
+// is NOT parent-based: an inbound sampled=01 traceparent still gets dropped,
+// though the trace ID is inherited so the trace stays correlatable.
+func Test_TracerContract_NeverSampleWithInboundTraceparent(t *testing.T) {
+	installPropagators(t)
+
+	rec := tracerCharInstallNeverSampleTP(t)
+
+	var sc otelTrace.SpanContext
+
+	handler := Tracer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		sc = otelTrace.SpanFromContext(r.Context()).SpanContext()
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/never-parent", http.NoBody)
+	req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.True(t, sc.IsValid())
+	assert.Equal(t, w3cFixtureTraceID, sc.TraceID().String())
+	assert.False(t, sc.IsSampled())
+	assert.Empty(t, rec.Ended())
+}
+
+// tracerCharChain builds the two possible orderings of Logging and Tracer.
+func tracerCharChain(loggingOuter bool, lg logger, h http.Handler) http.Handler {
+	logging := Logging(LogProbes{}, lg)
+
+	if loggingOuter {
+		return logging(Tracer(h))
+	}
+
+	return Tracer(logging(h))
+}
+
+// Test_TracerContract_CorrelationIDWithLogging characterizes the interaction
+// between Tracer and the Logging middleware's X-Correlation-ID header and
+// trace_id/span_id log fields, for BOTH chain orders and BOTH provider
+// configurations.
+//
+// FINDING: production (pkg/gofr/http_server.go) registers
+// r.Use(middleware.Tracer, middleware.Logging(...)) — with gorilla/mux the
+// FIRST registered middleware is the OUTERMOST, so production runs
+// Tracer-outer / Logging-inner. That is the order in which Logging observes
+// the span Tracer just started, and the correlation ID is real. The
+// Logging-outer order (which reads the span context BEFORE Tracer starts a
+// span) yields the all-zeros constants instead.
+func Test_TracerContract_CorrelationIDWithLogging(t *testing.T) {
+	tests := []struct {
+		name         string
+		loggingOuter bool
+		neverSample  bool
+		traceparent  bool
+		wantZeroIDs  bool
+	}{
+		{name: "production order, recording provider", wantZeroIDs: false},
+		{name: "production order, NeverSample provider", neverSample: true, wantZeroIDs: false},
+		{name: "production order, inbound traceparent", traceparent: true, wantZeroIDs: false},
+		{name: "logging outer, recording provider", loggingOuter: true, wantZeroIDs: true},
+		{name: "logging outer, NeverSample provider", loggingOuter: true, neverSample: true, wantZeroIDs: true},
+		{name: "logging outer, inbound traceparent", loggingOuter: true, traceparent: true, wantZeroIDs: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			installPropagators(t)
+
+			if tc.neverSample {
+				tracerCharInstallNeverSampleTP(t)
+			} else {
+				tracerCharInstallRecordingTP(t)
+			}
+
+			lg := &tracerCharLogger{}
+
+			var inHandler otelTrace.SpanContext
+
+			handler := tracerCharChain(tc.loggingOuter, lg,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					inHandler = otelTrace.SpanFromContext(r.Context()).SpanContext()
+					_, _ = w.Write([]byte("ok"))
+				}))
+
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/corr", http.NoBody)
+
+			if tc.traceparent {
+				req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+			}
+
+			handler.ServeHTTP(rr, req)
+
+			rl := lg.last()
+			require.NotNil(t, rl, "Logging must emit a RequestLog")
+			assert.Equal(t, http.StatusOK, rl.Response)
+
+			corr := rr.Header().Get("X-Correlation-ID")
+			assert.Equal(t, rl.TraceID, corr, "header and log field always agree")
+
+			if tc.wantZeroIDs {
+				assert.Equal(t, zeroTraceID, rl.TraceID,
+					"Logging read the span context before Tracer started a span")
+				assert.Equal(t, zeroSpanID, rl.SpanID)
+
+				return
+			}
+
+			require.True(t, inHandler.IsValid())
+			assert.Equal(t, inHandler.TraceID().String(), rl.TraceID,
+				"log trace_id must equal the span Tracer started")
+			assert.Equal(t, inHandler.SpanID().String(), rl.SpanID)
+			assert.Len(t, rl.TraceID, 32)
+			assert.Len(t, rl.SpanID, 16)
+
+			if tc.traceparent {
+				assert.Equal(t, w3cFixtureTraceID, rl.TraceID,
+					"inbound traceparent must surface as the correlation ID")
+			}
+		})
+	}
+}
+
+// Test_TracerContract_StatusFlowsThroughLoggingChain pins that the span's
+// http.response.status_code is correct in the production chain order, where
+// Tracer's own StatusResponseWriter sits outside Logging's.
+func Test_TracerContract_StatusFlowsThroughLoggingChain(t *testing.T) {
+	rec := tracerCharInstallRecordingTP(t)
+
+	lg := &tracerCharLogger{}
+	handler := Tracer(Logging(LogProbes{}, lg)(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/chain", http.NoBody)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+
+	attrs := tracerCharAttrs(spans[0])
+	assert.Equal(t, int64(http.StatusServiceUnavailable), attrs[1].Value.AsInt64())
+	assert.Equal(t, codes.Unset, spans[0].Status().Code, "5xx does not mark the span as errored")
+
+	require.Len(t, lg.errors, 1, "5xx is logged via Error")
+	assert.Equal(t, http.StatusServiceUnavailable, lg.errors[0].Response)
 }

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"sort"
-	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -14,13 +12,10 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	otelTrace "go.opentelemetry.io/otel/trace"
-
-	"gofr.dev/pkg/gofr/version"
 )
 
 // W3C TraceContext fixture values reused across the propagation tests.
@@ -316,685 +311,86 @@ func TestTracer_EmitsOTelHTTPSemconvAttributes(t *testing.T) {
 	assert.Equal(t, int64(http.StatusCreated), attrs[attribute.Key("http.response.status_code")].AsInt64())
 }
 
-// ---------------------------------------------------------------------------
-// Characterization suite for the Tracer HTTP middleware.
-//
-// Every identifier below is prefixed with `tracerChar` so this file can be
-// merged with sibling _test.go additions in the same package without
-// collisions. Nothing here is aspirational: every assertion pins the CURRENT
-// behavior of pkg/gofr/http/middleware/tracer.go as observed against the
-// unmodified source.
-// ---------------------------------------------------------------------------
-
-// tracerCharScopeName returns the exact instrumentation-scope (tracer) name
-// the middleware resolves at chain-build time.
-func tracerCharScopeName() string { return "gofr-" + version.Framework }
-
-// tracerCharInstallRecordingTP installs an sdktrace provider with an in-memory
-// span recorder and restores the previously installed global provider on
-// cleanup. The provider MUST be installed before Tracer() is called because
-// Tracer resolves otel.Tracer(...) once at chain-build time.
-func tracerCharInstallRecordingTP(t *testing.T) *tracetest.SpanRecorder {
-	t.Helper()
-
-	prev := otel.GetTracerProvider()
-	rec := tracetest.NewSpanRecorder()
-	tp := trace.NewTracerProvider(trace.WithSpanProcessor(rec))
-
-	otel.SetTracerProvider(tp)
-
-	t.Cleanup(func() {
-		_ = tp.Shutdown(context.Background())
-
-		otel.SetTracerProvider(prev)
-	})
-
-	return rec
-}
-
-// tracerCharInstallNeverSampleTP installs exactly the provider GoFr's
-// initTracer builds when no exporter is configured (otel.go), plus a recorder
-// so tests can prove nothing is ever exported.
-func tracerCharInstallNeverSampleTP(t *testing.T) *tracetest.SpanRecorder {
-	t.Helper()
-
-	prev := otel.GetTracerProvider()
-	rec := tracetest.NewSpanRecorder()
-	tp := trace.NewTracerProvider(
-		trace.WithSampler(trace.NeverSample()),
-		trace.WithSpanProcessor(rec),
-	)
-
-	otel.SetTracerProvider(tp)
-
-	t.Cleanup(func() {
-		_ = tp.Shutdown(context.Background())
-
-		otel.SetTracerProvider(prev)
-	})
-
-	return rec
-}
-
-// tracerCharAttrs returns the span's attributes sorted by key so an exact
-// expected slice can be compared — an added, renamed or retyped attribute
-// then fails the comparison.
-func tracerCharAttrs(s trace.ReadOnlySpan) []attribute.KeyValue {
-	attrs := s.Attributes()
-	out := make([]attribute.KeyValue, len(attrs))
-	copy(out, attrs)
-
-	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
-
-	return out
-}
-
-// tracerCharLogger captures the RequestLog values emitted by the Logging
-// middleware.
-type tracerCharLogger struct {
-	logs   []*RequestLog
-	errors []*RequestLog
-}
-
-func (l *tracerCharLogger) Log(args ...any) {
-	if rl, ok := args[0].(*RequestLog); ok {
-		l.logs = append(l.logs, rl)
-	}
-}
-
-func (l *tracerCharLogger) Error(args ...any) {
-	if rl, ok := args[0].(*RequestLog); ok {
-		l.errors = append(l.errors, rl)
-	}
-}
-
-// last returns the single RequestLog captured on either channel.
-func (l *tracerCharLogger) last() *RequestLog {
-	if len(l.errors) > 0 {
-		return l.errors[len(l.errors)-1]
-	}
-
-	if len(l.logs) > 0 {
-		return l.logs[len(l.logs)-1]
-	}
-
-	return nil
-}
-
-// Test_TracerContract_InstrumentationScopeName pins the exact tracer name.
-func Test_TracerContract_InstrumentationScopeName(t *testing.T) {
-	rec := tracerCharInstallRecordingTP(t)
-
-	handler := Tracer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/scope", http.NoBody)
-
-	handler.ServeHTTP(httptest.NewRecorder(), req)
-
-	spans := rec.Ended()
-	require.Len(t, spans, 1)
-
-	assert.Equal(t, "gofr-dev", tracerCharScopeName(),
-		"version.Framework changed; the scope name below moves with it")
-	assert.Equal(t, tracerCharScopeName(), spans[0].InstrumentationScope().Name)
-	assert.Empty(t, spans[0].InstrumentationScope().Version,
-		"middleware passes no WithInstrumentationVersion")
-	assert.Empty(t, spans[0].InstrumentationScope().SchemaURL)
-}
-
-// Test_TracerContract_SpanName pins "METHOD /route-template" across the mux
-// route-resolution paths.
-func Test_TracerContract_SpanName(t *testing.T) {
+// TestBuildSpanName pins the OTel HTTP semconv span-name format. The
+// construction changes; the content must not.
+func TestBuildSpanName(t *testing.T) {
 	tests := []struct {
-		name  string
-		build func(h http.Handler) http.Handler
-		// method/target of the inbound request.
+		name   string
 		method string
-		target string
+		route  string
 		want   string
 	}{
-		{
-			name: "mux matched route uses path template",
-			build: func(h http.Handler) http.Handler {
-				r := mux.NewRouter()
-				r.Handle("/users/{id}", h).Methods(http.MethodGet)
-
-				return r
-			},
-			method: http.MethodGet,
-			target: "/users/42",
-			want:   "GET /users/{id}",
-		},
-		{
-			name: "mux PathPrefix-only route still yields a template",
-			build: func(h http.Handler) http.Handler {
-				r := mux.NewRouter()
-				r.PathPrefix("/static").Handler(h)
-
-				return r
-			},
-			method: http.MethodGet,
-			target: "/static/css/app.css",
-			want:   "GET /static",
-		},
-		{
-			name: "mux route without any path matcher falls back to URL.Path",
-			build: func(h http.Handler) http.Handler {
-				r := mux.NewRouter()
-				r.Methods(http.MethodGet).Handler(h)
-
-				return r
-			},
-			method: http.MethodGet,
-			target: "/no/path/matcher",
-			want:   "GET /no/path/matcher",
-		},
-		{
-			name: "unmatched route (404 handler, CurrentRoute nil) falls back to URL.Path",
-			build: func(h http.Handler) http.Handler {
-				r := mux.NewRouter()
-				r.Handle("/known", http.NotFoundHandler())
-				r.NotFoundHandler = h
-
-				return r
-			},
-			method: http.MethodGet,
-			target: "/definitely/unknown",
-			want:   "GET /definitely/unknown",
-		},
-		{
-			name:   "lowercase inbound method is upper-cased",
-			build:  func(h http.Handler) http.Handler { return h },
-			method: "get",
-			target: "/lower",
-			want:   "GET /lower",
-		},
-		{
-			name:   "standalone handler (no mux) uses URL.Path",
-			build:  func(h http.Handler) http.Handler { return h },
-			method: http.MethodDelete,
-			target: "/standalone",
-			want:   "DELETE /standalone",
-		},
+		{"templated route", http.MethodGet, "/users/{id}", "GET /users/{id}"},
+		{"root", http.MethodPost, "/", "POST /"},
+		{"unmatched falls back to path", http.MethodDelete, "/nope/deeper", "DELETE /nope/deeper"},
+		{"empty route", http.MethodGet, "", "GET "},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			rec := tracerCharInstallRecordingTP(t)
-
-			srv := tc.build(Tracer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
-			req := httptest.NewRequestWithContext(t.Context(), tc.method, tc.target, http.NoBody)
-
-			srv.ServeHTTP(httptest.NewRecorder(), req)
-
-			spans := rec.Ended()
-			require.Len(t, spans, 1)
-			assert.Equal(t, tc.want, spans[0].Name())
-			// http.route always equals the route portion of the span name.
-			assert.Equal(t, strings.TrimPrefix(tc.want, strings.ToUpper(tc.method)+" "),
-				tracerCharAttrs(spans[0])[2].Value.AsString())
+			require.Equal(t, tc.want, buildSpanName(tc.method, tc.route))
 		})
 	}
 }
 
-// Test_TracerContract_ExactAttributeSet pins the complete attribute set —
-// keys, values AND value types — for a matched route.
-func Test_TracerContract_ExactAttributeSet(t *testing.T) {
-	rec := tracerCharInstallRecordingTP(t)
+// spanNameSink defeats dead-code elimination: without a consumed result the
+// compiler may delete the very call being measured, and the benchmark then
+// reports the cost of nothing.
+//
+//nolint:gochecknoglobals // standard Go benchmarking idiom; a local would be optimized away.
+var spanNameSink string
+
+// TestBuildSpanNameAllocs pins the win. fmt.Sprintf costs 3 allocations per
+// request (the result string plus two boxed interface arguments); plain
+// concatenation costs exactly the one unavoidable result string.
+func TestBuildSpanNameAllocs(t *testing.T) {
+	method, route := http.MethodGet, "/users/{id}"
+
+	got := testing.AllocsPerRun(1000, func() {
+		spanNameSink = buildSpanName(method, route)
+	})
+
+	require.LessOrEqual(t, got, 1.0,
+		"span name must cost at most the one unavoidable result-string allocation")
+}
+
+// TestTracerSpanNameEndToEnd proves the span actually emitted through the
+// middleware still carries the route-template name, not a concrete path.
+func TestTracerSpanNameEndToEnd(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(trace.NewTracerProvider(trace.WithSyncer(exporter)))
 
 	router := mux.NewRouter()
-	router.Handle("/users/{id}", Tracer(http.HandlerFunc(
-		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusCreated) },
-	))).Methods(http.MethodGet)
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/users/{id}").
+		HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/users/42", http.NoBody)
-	router.ServeHTTP(httptest.NewRecorder(), req)
+	router.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/users/42", http.NoBody))
 
-	spans := rec.Ended()
+	spans := exporter.GetSpans()
 	require.Len(t, spans, 1)
+	require.Equal(t, "GET /users/{id}", spans[0].Name)
 
-	want := []attribute.KeyValue{
-		attribute.String("http.request.method", "GET"),
-		attribute.Int("http.response.status_code", http.StatusCreated),
-		attribute.String("http.route", "/users/{id}"),
-	}
+	var route string
 
-	got := tracerCharAttrs(spans[0])
-	assert.Equal(t, want, got, "complete attribute set (sorted by key) changed")
-
-	// Pin the value TYPES explicitly so an int->string retype fails loudly.
-	assert.Equal(t, attribute.STRING, got[0].Value.Type())
-	assert.Equal(t, attribute.INT64, got[1].Value.Type())
-	assert.Equal(t, attribute.STRING, got[2].Value.Type())
-	assert.Equal(t, int64(http.StatusCreated), got[1].Value.AsInt64())
-}
-
-// Test_TracerContract_StatusCodeAttribute pins http.response.status_code
-// across the ways a handler can (not) set a status.
-func Test_TracerContract_StatusCodeAttribute(t *testing.T) {
-	tests := []struct {
-		name    string
-		handler http.HandlerFunc
-		want    int64
-	}{
-		{
-			name:    "explicit WriteHeader 404",
-			handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) },
-			want:    http.StatusNotFound,
-		},
-		{
-			name:    "explicit WriteHeader 500",
-			handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusInternalServerError) },
-			want:    http.StatusInternalServerError,
-		},
-		{
-			name:    "body only, implicit 200 via StatusResponseWriter.Write",
-			handler: func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("hello")) },
-			want:    http.StatusOK,
-		},
-		{
-			name:    "handler does nothing, Status() normalizes 0 to 200",
-			handler: func(http.ResponseWriter, *http.Request) {},
-			want:    http.StatusOK,
-		},
-		{
-			name: "WriteHeader then Write keeps the explicit status",
-			handler: func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusAccepted)
-				_, _ = w.Write([]byte("ok"))
-			},
-			want: http.StatusAccepted,
-		},
-		{
-			name: "duplicate WriteHeader keeps the first status",
-			handler: func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusTeapot)
-				w.WriteHeader(http.StatusInternalServerError)
-			},
-			want: http.StatusTeapot,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			rec := tracerCharInstallRecordingTP(t)
-
-			handler := Tracer(tc.handler)
-			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/status", http.NoBody)
-
-			handler.ServeHTTP(httptest.NewRecorder(), req)
-
-			spans := rec.Ended()
-			require.Len(t, spans, 1)
-
-			attrs := tracerCharAttrs(spans[0])
-			require.Len(t, attrs, 3)
-			assert.Equal(t, attribute.Key("http.response.status_code"), attrs[1].Key)
-			assert.Equal(t, tc.want, attrs[1].Value.AsInt64())
-		})
-	}
-}
-
-// Test_TracerContract_SpanKindStatusAndEvents pins that the middleware emits
-// an Internal span with an Unset status and no events — even for a 5xx.
-func Test_TracerContract_SpanKindStatusAndEvents(t *testing.T) {
-	for _, status := range []int{http.StatusOK, http.StatusInternalServerError} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			rec := tracerCharInstallRecordingTP(t)
-
-			handler := Tracer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(status)
-			}))
-			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/kind", http.NoBody)
-
-			handler.ServeHTTP(httptest.NewRecorder(), req)
-
-			spans := rec.Ended()
-			require.Len(t, spans, 1)
-
-			got := spans[0]
-			assert.Equal(t, otelTrace.SpanKindInternal, got.SpanKind(),
-				"middleware never calls trace.WithSpanKind, so the SDK default (Internal) applies")
-			assert.Equal(t, codes.Unset, got.Status().Code, "no SetStatus call anywhere in the middleware")
-			assert.Empty(t, got.Status().Description)
-			assert.Empty(t, got.Events(), "middleware records no events (no RecordError)")
-			assert.Empty(t, got.Links())
-			assert.True(t, got.EndTime().After(got.StartTime()) || got.EndTime().Equal(got.StartTime()))
-		})
-	}
-}
-
-// Test_TracerContract_ReusesStatusResponseWriter pins the ResponseWriter
-// wrapping behavior in all three chain arrangements.
-func Test_TracerContract_ReusesStatusResponseWriter(t *testing.T) {
-	t.Run("chained after Logging it reuses the existing StatusResponseWriter", func(t *testing.T) {
-		tracerCharInstallRecordingTP(t)
-
-		var fromLogging, inHandler http.ResponseWriter
-
-		capture := func(inner http.Handler) http.Handler {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				fromLogging = w
-				inner.ServeHTTP(w, r)
-			})
+	for _, a := range spans[0].Attributes {
+		if a.Key == "http.route" {
+			route = a.Value.AsString()
 		}
-
-		handler := Logging(LogProbes{}, &tracerCharLogger{})(
-			capture(Tracer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				inHandler = w
-			}))))
-
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/reuse", http.NoBody)
-		handler.ServeHTTP(httptest.NewRecorder(), req)
-
-		loggingSRW, ok := fromLogging.(*StatusResponseWriter)
-		require.True(t, ok, "Logging must hand a *StatusResponseWriter to the next middleware")
-
-		handlerSRW, ok := inHandler.(*StatusResponseWriter)
-		require.True(t, ok)
-		assert.Same(t, loggingSRW, handlerSRW, "Tracer must not double-wrap after Logging")
-	})
-
-	t.Run("standalone it wraps locally exactly once", func(t *testing.T) {
-		tracerCharInstallRecordingTP(t)
-
-		var inHandler http.ResponseWriter
-
-		handler := Tracer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			inHandler = w
-		}))
-
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/wrap", http.NoBody)
-		handler.ServeHTTP(rr, req)
-
-		srw, ok := inHandler.(*StatusResponseWriter)
-		require.True(t, ok, "Tracer must wrap when it is not preceded by Logging")
-		assert.NotSame(t, http.ResponseWriter(rr), inHandler)
-		assert.Same(t, rr, srw.Unwrap(), "exactly one layer of wrapping")
-	})
-
-	t.Run("production order (Tracer outer, Logging inner) double-wraps", func(t *testing.T) {
-		tracerCharInstallRecordingTP(t)
-
-		var layers []http.ResponseWriter
-
-		// The unwrap chain must be read INSIDE the handler: Logging returns its
-		// StatusResponseWriter to a sync.Pool on the way out and nils the
-		// embedded ResponseWriter, so the chain is unreadable afterwards.
-		handler := Tracer(Logging(LogProbes{}, &tracerCharLogger{})(
-			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				for cur := w; cur != nil; {
-					layers = append(layers, cur)
-
-					srw, ok := cur.(*StatusResponseWriter)
-					if !ok {
-						break
-					}
-
-					cur = srw.Unwrap()
-				}
-			})))
-
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/double", http.NoBody)
-		handler.ServeHTTP(rr, req)
-
-		// Production wires r.Use(Tracer, Logging, ...), so Tracer is the OUTER
-		// middleware: its type assertion always fails, it wraps locally, and
-		// Logging then wraps that wrapper again. Two StatusResponseWriter
-		// layers are therefore live on every production request — which is what
-		// tracer.go's comment now describes.
-		require.Len(t, layers, 3, "expected raw recorder wrapped by two StatusResponseWriters")
-		assert.IsType(t, &StatusResponseWriter{}, layers[0])
-		assert.IsType(t, &StatusResponseWriter{}, layers[1])
-		assert.Same(t, rr, layers[2])
-	})
-}
-
-// Test_TracerContract_InboundTraceparent pins W3C trace-context continuation.
-func Test_TracerContract_InboundTraceparent(t *testing.T) {
-	installPropagators(t)
-
-	rec := tracerCharInstallRecordingTP(t)
-
-	var handlerBaggage baggage.Baggage
-
-	handler := Tracer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		handlerBaggage = baggage.FromContext(r.Context())
-	}))
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/inbound", http.NoBody)
-	req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
-	req.Header.Set("Baggage", "tenant=acme,region=us-east")
-
-	handler.ServeHTTP(httptest.NewRecorder(), req)
-
-	spans := rec.Ended()
-	require.Len(t, spans, 1)
-
-	got := spans[0]
-
-	// Trace ID is inherited verbatim from the fixture header.
-	assert.Equal(t, w3cFixtureTraceID, got.SpanContext().TraceID().String())
-	// The span's own ID is fresh and non-deterministic — pin validity/shape only.
-	assert.True(t, got.SpanContext().SpanID().IsValid())
-	assert.Len(t, got.SpanContext().SpanID().String(), 16)
-	assert.NotEqual(t, w3cFixtureParentSpan, got.SpanContext().SpanID().String())
-
-	assert.Equal(t, w3cFixtureParentSpan, got.Parent().SpanID().String())
-	assert.Equal(t, w3cFixtureTraceID, got.Parent().TraceID().String())
-	assert.True(t, got.Parent().IsRemote(), "parent must be marked remote")
-	assert.True(t, got.Parent().IsSampled())
-
-	require.Equal(t, 2, handlerBaggage.Len(), "baggage must survive into the handler context")
-	assert.Equal(t, "acme", handlerBaggage.Member("tenant").Value())
-	assert.Equal(t, "us-east", handlerBaggage.Member("region").Value())
-}
-
-// Test_TracerContract_NoInboundTraceparentIsRoot pins that a request without a
-// traceparent produces a fresh root span.
-func Test_TracerContract_NoInboundTraceparentIsRoot(t *testing.T) {
-	installPropagators(t)
-
-	rec := tracerCharInstallRecordingTP(t)
-
-	handler := Tracer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/root", http.NoBody)
-
-	handler.ServeHTTP(httptest.NewRecorder(), req)
-
-	spans := rec.Ended()
-	require.Len(t, spans, 1)
-
-	got := spans[0]
-	assert.False(t, got.Parent().IsValid(), "expected a root span")
-	assert.Equal(t, zeroTraceID, got.Parent().TraceID().String())
-	assert.True(t, got.SpanContext().TraceID().IsValid())
-	assert.Len(t, got.SpanContext().TraceID().String(), 32)
-	assert.NotEqual(t, zeroTraceID, got.SpanContext().TraceID().String())
-}
-
-// Test_TracerContract_NeverSampleKeepsValidIDs is the key regression guard for
-// GoFr's default (no exporter configured) deployment: initTracer installs an
-// sdktrace provider with NeverSample — NOT a noop provider — precisely so the
-// span context handed to handlers still carries a valid TraceID/SpanID that
-// X-Correlation-ID and the trace_id log field can use.
-func Test_TracerContract_NeverSampleKeepsValidIDs(t *testing.T) {
-	installPropagators(t)
-
-	rec := tracerCharInstallNeverSampleTP(t)
-
-	var (
-		sc        otelTrace.SpanContext
-		recording bool
-	)
-
-	handler := Tracer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		span := otelTrace.SpanFromContext(r.Context())
-		sc = span.SpanContext()
-		recording = span.IsRecording()
-	}))
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/never", http.NoBody)
-	handler.ServeHTTP(httptest.NewRecorder(), req)
-
-	require.True(t, sc.IsValid(), "NeverSample must still yield a valid span context")
-	assert.True(t, sc.TraceID().IsValid())
-	assert.True(t, sc.SpanID().IsValid())
-	assert.NotEqual(t, zeroTraceID, sc.TraceID().String())
-	assert.NotEqual(t, zeroSpanID, sc.SpanID().String())
-	assert.Len(t, sc.TraceID().String(), 32)
-	assert.Len(t, sc.SpanID().String(), 16)
-	assert.False(t, sc.IsSampled(), "NeverSample must clear the sampled flag")
-	assert.False(t, recording, "a dropped span must not be recording")
-	assert.Empty(t, rec.Ended(), "nothing may be exported under NeverSample")
-}
-
-// Test_TracerContract_NeverSampleWithInboundTraceparent pins that NeverSample
-// is NOT parent-based: an inbound sampled=01 traceparent still gets dropped,
-// though the trace ID is inherited so the trace stays correlatable.
-func Test_TracerContract_NeverSampleWithInboundTraceparent(t *testing.T) {
-	installPropagators(t)
-
-	rec := tracerCharInstallNeverSampleTP(t)
-
-	var sc otelTrace.SpanContext
-
-	handler := Tracer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		sc = otelTrace.SpanFromContext(r.Context()).SpanContext()
-	}))
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/never-parent", http.NoBody)
-	req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
-
-	handler.ServeHTTP(httptest.NewRecorder(), req)
-
-	require.True(t, sc.IsValid())
-	assert.Equal(t, w3cFixtureTraceID, sc.TraceID().String())
-	assert.False(t, sc.IsSampled())
-	assert.Empty(t, rec.Ended())
-}
-
-// tracerCharChain builds the two possible orderings of Logging and Tracer.
-func tracerCharChain(loggingOuter bool, lg logger, h http.Handler) http.Handler {
-	logging := Logging(LogProbes{}, lg)
-
-	if loggingOuter {
-		return logging(Tracer(h))
 	}
 
-	return Tracer(logging(h))
+	require.Equal(t, "/users/{id}", route, "http.route must stay the template, not the concrete path")
 }
 
-// Test_TracerContract_CorrelationIDWithLogging characterizes the interaction
-// between Tracer and the Logging middleware's X-Correlation-ID header and
-// trace_id/span_id log fields, for BOTH chain orders and BOTH provider
-// configurations.
-//
-// FINDING: production (pkg/gofr/http_server.go) registers
-// r.Use(middleware.Tracer, middleware.Logging(...)) — with gorilla/mux the
-// FIRST registered middleware is the OUTERMOST, so production runs
-// Tracer-outer / Logging-inner. That is the order in which Logging observes
-// the span Tracer just started, and the correlation ID is real. The
-// Logging-outer order (which reads the span context BEFORE Tracer starts a
-// span) yields the all-zeros constants instead.
-func Test_TracerContract_CorrelationIDWithLogging(t *testing.T) {
-	tests := []struct {
-		name         string
-		loggingOuter bool
-		neverSample  bool
-		traceparent  bool
-		wantZeroIDs  bool
-	}{
-		{name: "production order, recording provider", wantZeroIDs: false},
-		{name: "production order, NeverSample provider", neverSample: true, wantZeroIDs: false},
-		{name: "production order, inbound traceparent", traceparent: true, wantZeroIDs: false},
-		{name: "logging outer, recording provider", loggingOuter: true, wantZeroIDs: true},
-		{name: "logging outer, NeverSample provider", loggingOuter: true, neverSample: true, wantZeroIDs: true},
-		{name: "logging outer, inbound traceparent", loggingOuter: true, traceparent: true, wantZeroIDs: true},
+// BenchmarkBuildSpanName is the before/after evidence for this change.
+func BenchmarkBuildSpanName(b *testing.B) {
+	method, route := http.MethodGet, "/users/{id}"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		spanNameSink = buildSpanName(method, route)
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			installPropagators(t)
-
-			if tc.neverSample {
-				tracerCharInstallNeverSampleTP(t)
-			} else {
-				tracerCharInstallRecordingTP(t)
-			}
-
-			lg := &tracerCharLogger{}
-
-			var inHandler otelTrace.SpanContext
-
-			handler := tracerCharChain(tc.loggingOuter, lg,
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					inHandler = otelTrace.SpanFromContext(r.Context()).SpanContext()
-					_, _ = w.Write([]byte("ok"))
-				}))
-
-			rr := httptest.NewRecorder()
-			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/corr", http.NoBody)
-
-			if tc.traceparent {
-				req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
-			}
-
-			handler.ServeHTTP(rr, req)
-
-			rl := lg.last()
-			require.NotNil(t, rl, "Logging must emit a RequestLog")
-			assert.Equal(t, http.StatusOK, rl.Response)
-
-			corr := rr.Header().Get("X-Correlation-ID")
-			assert.Equal(t, rl.TraceID, corr, "header and log field always agree")
-
-			if tc.wantZeroIDs {
-				assert.Equal(t, zeroTraceID, rl.TraceID,
-					"Logging read the span context before Tracer started a span")
-				assert.Equal(t, zeroSpanID, rl.SpanID)
-
-				return
-			}
-
-			require.True(t, inHandler.IsValid())
-			assert.Equal(t, inHandler.TraceID().String(), rl.TraceID,
-				"log trace_id must equal the span Tracer started")
-			assert.Equal(t, inHandler.SpanID().String(), rl.SpanID)
-			assert.Len(t, rl.TraceID, 32)
-			assert.Len(t, rl.SpanID, 16)
-
-			if tc.traceparent {
-				assert.Equal(t, w3cFixtureTraceID, rl.TraceID,
-					"inbound traceparent must surface as the correlation ID")
-			}
-		})
-	}
-}
-
-// Test_TracerContract_StatusFlowsThroughLoggingChain pins that the span's
-// http.response.status_code is correct in the production chain order, where
-// Tracer's own StatusResponseWriter sits outside Logging's.
-func Test_TracerContract_StatusFlowsThroughLoggingChain(t *testing.T) {
-	rec := tracerCharInstallRecordingTP(t)
-
-	lg := &tracerCharLogger{}
-	handler := Tracer(Logging(LogProbes{}, lg)(
-		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusServiceUnavailable)
-		})))
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/chain", http.NoBody)
-	handler.ServeHTTP(httptest.NewRecorder(), req)
-
-	spans := rec.Ended()
-	require.Len(t, spans, 1)
-
-	attrs := tracerCharAttrs(spans[0])
-	assert.Equal(t, int64(http.StatusServiceUnavailable), attrs[1].Value.AsInt64())
-	assert.Equal(t, codes.Unset, spans[0].Status().Code, "5xx does not mark the span as errored")
-
-	require.Len(t, lg.errors, 1, "5xx is logged via Error")
-	assert.Equal(t, http.StatusServiceUnavailable, lg.errors[0].Response)
 }

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -727,3 +727,111 @@ func BenchmarkTracer_Recording(b *testing.B) {
 		router.ServeHTTP(w, req)
 	}
 }
+
+// TestHeaderCarrierIsAFaithfulValuesGetter is the regression test for silent
+// baggage loss.
+//
+// headerCarrier replaces propagation.HeaderCarrier to avoid canonicalizing the
+// lookup key on every request. The stdlib type it replaces satisfies
+// propagation.ValuesGetter, and propagation.Baggage.Extract type-asserts to that
+// interface to combine ALL values of the Baggage header. Implementing only
+// Get/Set/Keys failed the assertion, so Extract fell back to the single-value Get
+// and dropped every baggage member after the first -- silently, and only when a
+// request carried more than one Baggage header, which is legal per W3C and is
+// what proxies and service meshes commonly emit.
+//
+// The pre-existing equivalence test only compared Get and Keys, so it could not
+// catch this.
+func TestHeaderCarrierIsAFaithfulValuesGetter(t *testing.T) {
+	require.Implements(t, (*propagation.ValuesGetter)(nil), headerCarrier{},
+		"a carrier replacing propagation.HeaderCarrier must satisfy every interface it does")
+
+	tests := []struct {
+		name    string
+		values  []string
+		wantLen int
+	}{
+		{"multiple Baggage headers", []string{"k1=v1", "k2=v2", "k3=v3"}, 3},
+		{"two Baggage headers", []string{"a=1", "b=2"}, 2},
+		{"single header carrying several members", []string{"a=1,b=2"}, 2},
+		{"single header single member", []string{"only=1"}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.Header{}
+			for _, v := range tt.values {
+				h.Add("Baggage", v)
+			}
+
+			prop := propagation.Baggage{}
+
+			std := baggage.FromContext(prop.Extract(t.Context(), propagation.HeaderCarrier(h)))
+			got := baggage.FromContext(prop.Extract(t.Context(), headerCarrier(h)))
+
+			require.Len(t, std.Members(), tt.wantLen, "sanity: the stdlib carrier must see every member")
+			assert.Len(t, got.Members(), tt.wantLen,
+				"headerCarrier must extract exactly what the stdlib carrier does")
+
+			// Compare member-by-member, since Baggage.String() ordering is not stable.
+			for _, m := range std.Members() {
+				assert.Equal(t, m.Value(), got.Member(m.Key()).Value(),
+					"member %q must survive extraction", m.Key())
+			}
+		})
+	}
+}
+
+// TestHeaderCarrierValuesMatchesStdlib pins Values itself across the key shapes
+// the propagators actually use, including the canonicalization fast path.
+func TestHeaderCarrierValuesMatchesStdlib(t *testing.T) {
+	h := http.Header{}
+	h.Add("Baggage", "a=1")
+	h.Add("Baggage", "b=2")
+	h.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+	h.Add("X-Custom", "one")
+	h.Add("X-Custom", "two")
+
+	for _, key := range []string{headerBaggage, headerTraceparent, headerTracestate, "x-custom", "absent"} {
+		assert.Equal(t, propagation.HeaderCarrier(h).Values(key), headerCarrier(h).Values(key),
+			"Values(%q) must match the stdlib carrier", key)
+	}
+}
+
+// BenchmarkTracer_WithPropagationHeaders is the variant that actually exercises
+// headerCarrier.
+//
+// BenchmarkTracer and BenchmarkTracer_Recording send a bare request, so the
+// propagators find nothing and the canonicalization this PR avoids never runs --
+// their alloc delta comes from the per-route cache and the IsRecording gate
+// alone. A request carrying traceparent/tracestate/baggage is what a service
+// behind a mesh or an upstream GoFr service actually receives, and it is the only
+// shape where the carrier's saving is visible.
+func BenchmarkTracer_WithPropagationHeaders(b *testing.B) {
+	otel.SetTracerProvider(noop.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{}, propagation.Baggage{}))
+
+	b.Cleanup(func() { otel.SetTracerProvider(noop.NewTracerProvider()) })
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/users/{id}").
+		Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/users/42", http.NoBody)
+	req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+	req.Header.Set("Tracestate", "vendor=value")
+	req.Header.Add("Baggage", "tenant=acme")
+	req.Header.Add("Baggage", "region=eu")
+
+	w := &tracerBenchWriter{h: make(http.Header, 4)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		clear(w.h)
+		router.ServeHTTP(w, req)
+	}
+}


### PR DESCRIPTION
**TL;DR — 8 fewer allocations per request. No behaviour change.**

## The problem

The tracing middleware runs on **every request**. For each one it rebuilt things that never change for a given route:

- the span name (`"GET /users/{id}"`) — via `fmt.Sprintf`
- the attribute slice (`http.request.method`, `http.route`)
- the `trace.WithAttributes` option wrapper **and** the variadic slice holding it
- the status attribute — even when the span was **non-recording** and threw it away
- a response-writer wrapper — even when nothing recorded the status
- propagation headers — recanonicalised on every lookup

For a fixed route table, all of that produces byte-identical results every single time.

## The fix

Build it once per `(method, route)` and reuse it. Six focused commits, one idea each.

Cache key is the **route template** (`/users/{id}`), never the concrete path. Unmatched requests carry a raw, attacker-controlled path and are never cached.

> **Revised after review.** That paragraph used to end "so it is bounded by routes × methods", and **it wasn't**. Neither half of that product bounds itself in a real GoFr app:
>
> - `gofr.go` registers a `PathPrefix("/")` catch-all, so `mux.CurrentRoute` is set for **every** request and `GetPathTemplate()` returns `"/"` even for a path nothing matched. The `templated` guard was therefore **always true** — reproduced with method `ZZZQUUX` on `/totally/unknown`.
> - `net/http` accepts **any RFC 7230 token** as a method, so a client streaming `M00001`, `M00002`, … minted a permanent `*spanMeta` per request. Reproduced: 5000 distinct methods against the catch-all produced 5000 permanent entries.
>
> That is a remotely-triggerable unbounded-memory DoS, and the pre-cache `fmt.Sprintf` path retained **zero** state — so it was introduced here, not inherited. Two things bound it now:
>
> 1. **`cacheableMethod`** restricts the key to the nine defined HTTP methods, which turns "methods × routes" back into the fixed quantity the cache was designed around. A made-up method still works — it just rebuilds its span metadata, exactly as every request did before the cache existed.
> 2. **`routeCache`** caps the whole thing at 4096 entries, because the first bound is an argument about reachability and process memory should rest on a number too.
>
> `routeCache` and `cacheableMethod` live in their own file because the metrics caches in #3972 have the same shape on the same key space, and the review asked for all three to be bounded consistently rather than one at a time. **#3972 is now stacked on this PR.**

## The numbers

Two benchmarks ship with this, because a sampling service runs both paths and neither may regress:

| | before | after |
|---|---|---|
| **non-recording** provider | 21 allocs, 2074 B | **11 allocs, 1568 B** |
| **recording** provider | 23 allocs, 2875 B | **17 allocs, 2658 B** |

Allocation counts only — see *Measurement* below.

> **The non-recording row was re-measured after review**, and it improved: it previously read 13 allocs / 1760 B. `BenchmarkTracer` documented the non-recording path but **did not measure it** — `TestTracerPropagatesIncomingTraceContext` installed a live recording `TracerProvider` and never restored it, and tests run before benchmarks, so the benchmark ran *recording* and fed that test's in-memory exporter. It now pins `noop.NewTracerProvider()` itself, and that test restores both globals it replaces (the provider and the Baggage-less propagator).

## Why it matters

Tracing is on the hot path of every request in every GoFr service. This is the single largest per-request allocation saving in the middleware chain.

## Baggage regression, found in review and fixed

`headerCarrier` replaces `propagation.HeaderCarrier` to avoid canonicalising the lookup key per request — but implemented only `Get`/`Set`/`Keys`. The stdlib type it replaces **also satisfies `propagation.ValuesGetter`**, and `propagation.Baggage.Extract` type-asserts to that interface to combine **all** values of the `Baggage` header. The assertion failed, so `Extract` fell back to the single-value `Get` and **silently dropped every baggage member after the first**.

It only surfaces when a request carries more than one `Baggage` header — legal per W3C, and what proxies and service meshes commonly emit — and GoFr installs `propagation.Baggage` in its default composite propagator, so the path is live. Reproduced against the stdlib carrier with three `Baggage` headers:

```
stdlib HeaderCarrier : members=3  "k2=v2,k3=v3,k1=v1"
gofr   headerCarrier : members=1  "k1=v1"
implements ValuesGetter: gofr=false stdlib=true
```

Fixed by implementing `Values`. It deliberately does **not** use the canonical-key fast path: `baggage` is not one of the keys that map covers, and a carrier replacing a stdlib one has to be a faithful drop-in first and an optimisation second.

The pre-existing equivalence test compared only `Get` and `Keys`, so it could not catch this. The new test compares extracted baggage **member by member** against the stdlib carrier across four header shapes, and asserts the interface is satisfied.

`BenchmarkTracer_WithPropagationHeaders` closes the other gap: the existing benchmarks send a bare request, so the propagators find nothing and the canonicalisation this PR avoids never runs — their delta is the per-route cache and the `IsRecording` gate alone. The new one sends `traceparent`, `tracestate` and two `Baggage` headers, which is what a service behind a mesh actually receives.

## What the cache costs

The saving is bought with resident memory: the cache is process-global and entries are never released, because they are pure functions of their key and stay valid for the life of the process.

Measured with `runtime.MemStats` around a filled cache, stable across three runs:

| Shape | Entries | Heap held |
|---|---|---|
| small app — 25 routes x GET/POST | 50 | **+22 KB** |
| typical app — 100 routes x GET/POST | 200 | **+83 KB** |
| large app — 500 routes x 4 methods | 2000 | **+825 KB** |
| at the `routeCacheLimit` ceiling | 4096 | **+1735 KB** |

So a realistic service holds tens of kilobytes, and the worst case any service can reach is **~1.7 MB**, permanently. That ceiling is the point of `routeCacheLimit` — without it the table has no last row.

It is a genuine trade rather than a free win, and it is the one thing in this PR that costs something. Weigh it against ~9 allocations saved on every request.

## Safety

- **No behaviour change.** Span names, attributes and propagation are identical.
- The `IsRecording()`-gated non-recording branch — the path this PR optimizes — **now has a test**; it had none.
- `buildSpanName`'s godoc no longer quotes a `44.3 → 22.6 ns/op` figure: the `fmt.Sprintf` baseline it was measured against is gone, so nothing in the tree can reproduce it.
- New tests for the bound: an undefined method mints no entry, standard methods still hit the cache, and the cap holds.
- Cached data is pure and provider-independent, so it stays correct across `TracerProvider` replacement.

## Measurement

Only allocations and bytes are quoted. Wall-clock on the machine used varied by **more than 5×** between runs of the same binary, so ns/op there is meaningless. Allocation counts were stable and moved monotonically with each commit in the series.

---
*Independent of the other `perf/*` PRs — touches only `tracer.go` and its test. Merge in any order.*



