### PR TITLE
Fix typos: serup -> setup, unadressable -> unaddressable

### DIFF
--- a/docs/datasources/couchbase/page.md
+++ b/docs/datasources/couchbase/page.md
@@ -38,7 +38,7 @@ type Couchbase interface {
 ```
 
 Users can easily inject a driver that supports this interface, providing usability without compromising the extensibility to use multiple databases.
-Don't forget to serup the Couchbase cluster in Couchbase Web Console first. [Follow for more details](https://docs.couchbase.com/server/current/install/getting-started-docker.html#section_jvt_zvj_42b).
+Don't forget to setup the Couchbase cluster in Couchbase Web Console first. [Follow for more details](https://docs.couchbase.com/server/current/install/getting-started-docker.html#section_jvt_zvj_42b).
 To begin using Couchbase in your GoFr application, you need to import the Couchbase datasource package:
 
 ```shell

--- a/pkg/gofr/grpc_test.go
+++ b/pkg/gofr/grpc_test.go
@@ -299,7 +299,7 @@ func Test_injectContainer_Fails(t *testing.T) {
 	require.ErrorIs(t, err, errNonAddressable)
 	require.Nil(t, srv1.c1)
 
-	// Case: server is passed as unadressable(non-pointer)
+	// Case: server is passed as unaddressable(non-pointer)
 	srv3 := fail{}
 	out := testutil.StdoutOutputForFunc(func() {
 		cont, _ := container.NewMockContainer(t)


### PR DESCRIPTION
## Description

- Fix two small spelling typos (docs + test comment). No behavior change.
- Closes #3861

### Changes:
- `docs/datasources/couchbase/page.md`: "serup" → "setup"
- `pkg/gofr/grpc_test.go`: "unadressable" → "unaddressable" (consistent with existing correct spelling on line 286)

### Checklist:
- [x] I have formatted my code using `goimports` and `golangci-lint`.
- [x] All new code is covered by unit tests.
- [x] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.

**Thank you for your contribution!**