### PR TITLE
fix(rbac): compile endpoint patterns once at load, not per rule per request (#3979)

### DIFF
--- a/pkg/gofr/rbac/config.go
+++ b/pkg/gofr/rbac/config.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel/trace"
 	"gopkg.in/yaml.v3"
 
@@ -124,7 +123,6 @@ type Config struct {
 	endpointPermissionMap map[string][]string         `json:"-" yaml:"-"` // Key: "METHOD:/path", Value: []permissions
 	publicEndpointsMap    map[string]bool             `json:"-" yaml:"-"` // Key: "METHOD:/path", Value: true if public
 	endpointMap           map[string]*EndpointMapping `json:"-" yaml:"-"` // Key: "METHOD:/path", Value: endpoint object
-	muxRouter             *mux.Router                 `json:"-" yaml:"-"` // Used for mux pattern matching
 
 	// rules holds every (method, path) rule ordered most-specific-first, and is the
 	// single source of truth for resolving a request that no exact key matches.
@@ -162,10 +160,6 @@ func LoadPermissions(path string, logger datasource.Logger, metrics container.Me
 	config.Logger = logger
 	config.Metrics = metrics
 	config.Tracer = tracer
-
-	// Initialize mux router for pattern matching
-	// Use StrictSlash(false) to match the application router's behavior
-	config.muxRouter = mux.NewRouter().StrictSlash(false)
 
 	// Validate config before processing
 	if err := config.validate(); err != nil {
@@ -282,8 +276,6 @@ func (c *Config) initializeMaps() {
 	c.endpointPermissionMap = make(map[string][]string)
 	c.publicEndpointsMap = make(map[string]bool)
 	c.endpointMap = make(map[string]*EndpointMapping)
-	// Use StrictSlash(false) to match the application router's behavior
-	c.muxRouter = mux.NewRouter().StrictSlash(false)
 }
 
 // buildRolePermissionsMap builds the role permissions map from Roles.

--- a/pkg/gofr/rbac/endpoint_matcher.go
+++ b/pkg/gofr/rbac/endpoint_matcher.go
@@ -30,56 +30,59 @@ var (
 	errInvalidPattern = errors.New("invalid mux pattern")
 )
 
-// matchesHTTPMethod checks if the HTTP method matches the endpoint's allowed methods.
-func matchesHTTPMethod(method string, allowedMethods []string) bool {
-	// Empty methods or "*" means all methods
-	if len(allowedMethods) == 0 {
-		return true
-	}
-
-	for _, m := range allowedMethods {
-		if m == "*" || strings.EqualFold(m, method) {
-			return true
-		}
-	}
-
-	return false
-}
-
 // isMuxPattern detects if a pattern contains mux-style variables.
 // Returns true if pattern contains { and }.
 func isMuxPattern(pattern string) bool {
 	return strings.Contains(pattern, "{") && strings.Contains(pattern, "}")
 }
 
-// matchMuxPattern uses mux Route.Match() to test if a path matches a mux pattern.
-// Creates a temporary mux Route and uses Route.Match() to test the pattern.
-// Handles all mux pattern types: {id}, {id:[0-9]+}, {path:.*}, etc.
-func matchMuxPattern(pattern, method, path string, router *mux.Router) bool {
-	if router == nil {
-		return false
+// compilePattern compiles an endpoint path into a mux route, once, at load time.
+// Returns nil for a literal path, which is cheaper to compare as a string.
+//
+// Each pattern is compiled onto a router of its own. mux.Router.NewRoute appends to the router it
+// is called on, so compiling against a router shared by every request - as this package used to -
+// both mutated that router without synchronization and grew it by one entry per rule per request,
+// for the life of the process. A router built here is never written to again, and Route.Match only
+// reads the route, so the compiled result is safe to share across goroutines.
+func compilePattern(pattern string) *mux.Route {
+	if pattern == "" || !isMuxPattern(pattern) {
+		return nil
 	}
 
-	// Create a temporary route with the pattern
-	route := router.NewRoute().Path(pattern)
+	// StrictSlash(false) matches the application router's behavior.
+	return mux.NewRouter().StrictSlash(false).NewRoute().Path(pattern)
+}
 
-	// If method is specified, add it to the route
-	if method != "" {
-		route = route.Methods(method)
-	}
+// matchContext carries the values one resolution scan matches its compiled routes against.
+//
+// mux writes its result into the RouteMatch, so a single one is reused across the scan and reset
+// before each use; nothing here reads it. Hoisting it out of the per-rule call keeps the scan's
+// allocation count flat instead of growing with the number of rules in the config.
+type matchContext struct {
+	req   *http.Request
+	match mux.RouteMatch
+}
 
-	// Create a mock request for matching
-	req := &http.Request{
-		Method: method,
-		URL: &url.URL{
-			Path: path,
+// newMatchContext builds the context for resolving one request. mux matchers only read the
+// request, so one value serves the whole scan.
+func newMatchContext(methodUpper, path string) *matchContext {
+	return &matchContext{
+		req: &http.Request{
+			Method: methodUpper,
+			URL: &url.URL{
+				Path: path,
+			},
 		},
 	}
+}
 
-	// Use Route.Match() to test if the request matches the pattern
-	var match mux.RouteMatch
+// matches reports whether the context's request matches a route returned by compilePattern.
+// A pattern mux could not compile carries the error on the route and matches nothing, which is the
+// unguarded-endpoint case logUncompilablePattern reports at load.
+func (m *matchContext) matches(route *mux.Route) bool {
+	m.match = mux.RouteMatch{}
 
-	return route.Match(req, &match)
+	return route.Match(m.req, &m.match)
 }
 
 // validateMuxPattern validates mux pattern syntax.
@@ -125,26 +128,6 @@ func (c *Config) logUncompilablePattern(pattern string, index int) {
 	c.Logger.Errorf("RBAC: endpoint[%d]: %v: %q: %v. This endpoint will never match a request, "+
 		"so it is NOT enforced - any route it was meant to govern is currently unguarded.",
 		index, errInvalidPattern, pattern, err)
-}
-
-// matchesEndpointPattern checks if the route matches the endpoint pattern.
-// Method matching is handled separately by endpointRule.matchesMethod before this is called.
-// Uses mux Route.Match() for mux patterns, exact match for non-pattern paths.
-func matchesEndpointPattern(endpoint *EndpointMapping, route string, config *Config) bool {
-	if endpoint.Path == "" {
-		return false
-	}
-
-	pattern := endpoint.Path
-
-	// Exact match for non-pattern paths
-	if !isMuxPattern(pattern) {
-		return pattern == route
-	}
-
-	// Use mux Route.Match() for patterns
-	// Method is handled separately, so pass empty string here
-	return matchMuxPattern(pattern, "", route, config.muxRouter)
 }
 
 // checkEndpointAuthorization checks if the user's role is authorized for the endpoint.

--- a/pkg/gofr/rbac/endpoint_matcher_test.go
+++ b/pkg/gofr/rbac/endpoint_matcher_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -100,60 +99,6 @@ func TestConfig_resolve_Cases(t *testing.T) {
 	}
 }
 
-func TestMatchesHTTPMethod(t *testing.T) {
-	testCases := []struct {
-		desc           string
-		method         string
-		allowedMethods []string
-		expected       bool
-	}{
-		{
-			desc:           "matches exact method",
-			method:         "GET",
-			allowedMethods: []string{"GET"},
-			expected:       true,
-		},
-		{
-			desc:           "matches case-insensitive method",
-			method:         "get",
-			allowedMethods: []string{"GET"},
-			expected:       true,
-		},
-		{
-			desc:           "matches wildcard method",
-			method:         "POST",
-			allowedMethods: []string{"*"},
-			expected:       true,
-		},
-		{
-			desc:           "matches empty methods as all",
-			method:         "DELETE",
-			allowedMethods: []string{},
-			expected:       true,
-		},
-		{
-			desc:           "does not match different method",
-			method:         "POST",
-			allowedMethods: []string{"GET"},
-			expected:       false,
-		},
-		{
-			desc:           "matches one of multiple methods",
-			method:         "PUT",
-			allowedMethods: []string{"GET", "PUT", "POST"},
-			expected:       true,
-		},
-	}
-
-	for i, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			result := matchesHTTPMethod(tc.method, tc.allowedMethods)
-
-			assert.Equal(t, tc.expected, result, "TEST[%d], Failed.\n%s", i, tc.desc)
-		})
-	}
-}
-
 func TestMatchesEndpointPattern(t *testing.T) {
 	testCases := []struct {
 		desc     string
@@ -227,12 +172,14 @@ func TestMatchesEndpointPattern(t *testing.T) {
 		},
 	}
 
-	config := &Config{}
-	_ = config.processUnifiedConfig()
-
 	for i, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			result := matchesEndpointPattern(tc.endpoint, tc.route, config)
+			rule := endpointRule{
+				pattern: tc.endpoint.Path,
+				route:   compilePattern(tc.endpoint.Path),
+			}
+
+			result := rule.matchesPath(tc.route, newMatchContext(http.MethodGet, tc.route))
 
 			assert.Equal(t, tc.expected, result, "TEST[%d], Failed.\n%s", i, tc.desc)
 		})
@@ -523,85 +470,58 @@ func TestIsMuxPattern(t *testing.T) {
 	}
 }
 
-func TestMatchMuxPattern(t *testing.T) {
-	router := mux.NewRouter()
-
+func TestCompilePattern(t *testing.T) {
 	testCases := []struct {
 		desc     string
 		pattern  string
-		method   string
 		path     string
+		compiled bool
 		expected bool
 	}{
-		{
-			desc:     "matches single variable",
-			pattern:  "/api/users/{id}",
-			method:   "GET",
-			path:     "/api/users/123",
-			expected: true,
-		},
-		{
-			desc:     "matches variable with constraint",
-			pattern:  "/api/users/{id:[0-9]+}",
-			method:   "GET",
-			path:     "/api/users/123",
-			expected: true,
-		},
-		{
-			desc:     "does not match constraint violation",
-			pattern:  "/api/users/{id:[0-9]+}",
-			method:   "GET",
-			path:     "/api/users/abc",
-			expected: false,
-		},
-		{
-			desc:     "matches multi-level pattern",
-			pattern:  "/api/{path:.*}",
-			method:   "GET",
-			path:     "/api/users/123",
-			expected: true,
-		},
-		{
-			desc:     "matches middle variable",
-			pattern:  "/api/{category}/posts",
-			method:   "GET",
-			path:     "/api/tech/posts",
-			expected: true,
-		},
-		{
-			desc:     "matches multiple variables",
-			pattern:  "/api/{category}/posts/{id:[0-9]+}",
-			method:   "GET",
-			path:     "/api/tech/posts/123",
-			expected: true,
-		},
-		{
-			desc:     "does not match different path",
-			pattern:  "/api/users/{id}",
-			method:   "GET",
-			path:     "/api/posts/123",
-			expected: false,
-		},
-		{
-			desc:     "returns false for nil router",
-			pattern:  "/api/users/{id}",
-			method:   "GET",
-			path:     "/api/users/123",
-			expected: false,
-		},
+		{"matches single variable", "/api/users/{id}", "/api/users/123", true, true},
+		{"matches variable with constraint", "/api/users/{id:[0-9]+}", "/api/users/123", true, true},
+		{"does not match constraint violation", "/api/users/{id:[0-9]+}", "/api/users/abc", true, false},
+		{"matches multi-level pattern", "/api/{path:.*}", "/api/users/123", true, true},
+		{"matches middle variable", "/api/{category}/posts", "/api/tech/posts", true, true},
+		{"matches multiple variables", "/api/{category}/posts/{id:[0-9]+}", "/api/tech/posts/123", true, true},
+		{"does not match different path", "/api/users/{id}", "/api/posts/123", true, false},
+		{"literal path is not compiled", "/api/users", "/api/users", false, false},
+		{"empty path is not compiled", "", "/api/users", false, false},
+		{"uncompilable pattern matches nothing", "/api/{id:[}", "/api/users", true, false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			var testRouter *mux.Router
+			route := compilePattern(tc.pattern)
 
-			if tc.desc != "returns false for nil router" {
-				testRouter = router
+			if !tc.compiled {
+				assert.Nil(t, route, "a literal path carries no compiled route")
+
+				return
 			}
 
-			result := matchMuxPattern(tc.pattern, tc.method, tc.path, testRouter)
-			assert.Equal(t, tc.expected, result)
+			require.NotNil(t, route)
+			assert.Equal(t, tc.expected, newMatchContext(http.MethodGet, tc.path).matches(route))
 		})
+	}
+}
+
+// TestCompilePattern_routeIsNotShared pins the fix for the unbounded router growth: compiling a
+// pattern must not append to any router that outlives the call.
+func TestCompilePattern_routeIsNotShared(t *testing.T) {
+	const pattern = "/api/users/{id}"
+
+	first, second := compilePattern(pattern), compilePattern(pattern)
+
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+	assert.NotSame(t, first, second, "each pattern must compile onto a router of its own")
+
+	mc := newMatchContext(http.MethodGet, "/api/users/123")
+
+	// Matching repeatedly must be a pure read - the same answer, every time.
+	for range 3 {
+		assert.True(t, mc.matches(first))
 	}
 }
 

--- a/pkg/gofr/rbac/resolver.go
+++ b/pkg/gofr/rbac/resolver.go
@@ -3,6 +3,8 @@ package rbac
 import (
 	"sort"
 	"strings"
+
+	"github.com/gorilla/mux"
 )
 
 // Segment specificity scores, compared segment by segment to order overlapping rules.
@@ -24,6 +26,9 @@ type endpointRule struct {
 	// pattern is the endpoint path, which may contain mux variables.
 	pattern string
 
+	// route is pattern compiled once at load time, or nil when pattern is a literal path.
+	route *mux.Route
+
 	// method is the upper-cased declared method, or "*" for all methods.
 	method string
 
@@ -44,12 +49,27 @@ type endpointRule struct {
 // permission requirement rather than granting access, covering an unknown verb tightens
 // enforcement rather than loosening it.
 func (r *endpointRule) matchesMethod(methodUpper string) bool {
-	return matchesHTTPMethod(methodUpper, []string{r.method})
+	return r.method == "*" || strings.EqualFold(r.method, methodUpper)
+}
+
+// matchesPath reports whether the rule's path covers the request carried by mc, which is shared
+// across the whole scan.
+func (r *endpointRule) matchesPath(path string, mc *matchContext) bool {
+	if r.pattern == "" {
+		return false
+	}
+
+	// A literal path is compared directly; only mux patterns carry a compiled route.
+	if r.route == nil {
+		return r.pattern == path
+	}
+
+	return mc.matches(r.route)
 }
 
 // matches reports whether the rule covers the given request.
-func (r *endpointRule) matches(methodUpper, path string, config *Config) bool {
-	return r.matchesMethod(methodUpper) && matchesEndpointPattern(r.endpoint, path, config)
+func (r *endpointRule) matches(methodUpper, path string, mc *matchContext) bool {
+	return r.matchesMethod(methodUpper) && r.matchesPath(path, mc)
 }
 
 // buildEndpointRules expands endpoints into one rule per declared method and orders them
@@ -89,6 +109,7 @@ func buildEndpointRules(endpoints []EndpointMapping) []endpointRule {
 			byKey[key] = endpointRule{
 				endpoint:    endpoint,
 				pattern:     endpoint.Path,
+				route:       compilePattern(endpoint.Path),
 				method:      methodUpper,
 				isPublic:    endpoint.Public,
 				pathScore:   pathSpecificity(endpoint.Path),
@@ -212,9 +233,11 @@ func compareSpecificity(a, b []int) int {
 }
 
 // resolveEndpoint returns the most specific rule covering the request, and whether it is public.
-func resolveEndpoint(methodUpper, path string, rules []endpointRule, config *Config) (*EndpointMapping, bool) {
+func resolveEndpoint(methodUpper, path string, rules []endpointRule) (*EndpointMapping, bool) {
+	mc := newMatchContext(methodUpper, path)
+
 	for i := range rules {
-		if rules[i].matches(methodUpper, path, config) {
+		if rules[i].matches(methodUpper, path, mc) {
 			return rules[i].endpoint, rules[i].isPublic
 		}
 	}
@@ -236,5 +259,5 @@ func (c *Config) resolve(methodUpper, path string) (*EndpointMapping, bool) {
 		return endpoint, isPublic
 	}
 
-	return resolveEndpoint(methodUpper, path, c.rules, c)
+	return resolveEndpoint(methodUpper, path, c.rules)
 }

--- a/pkg/gofr/rbac/resolver_concurrency_test.go
+++ b/pkg/gofr/rbac/resolver_concurrency_test.go
@@ -1,0 +1,175 @@
+package rbac
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// patternEndpoints builds a config body of `count` mux-pattern rules, none of which match the
+// path used by the tests below, followed by one that does. Pattern rules are what force the
+// ordered scan; a config of literal paths never reaches it.
+func patternEndpoints(count int) []EndpointMapping {
+	endpoints := make([]EndpointMapping, 0, count+1)
+
+	for i := range count {
+		endpoints = append(endpoints, EndpointMapping{
+			Path:                fmt.Sprintf("/other%d/{id}/sub/{sub}", i),
+			Methods:             []string{"*"},
+			RequiredPermissions: []string{"other:read"},
+		})
+	}
+
+	return append(endpoints, EndpointMapping{
+		Path:                "/admin/{path:.*}",
+		Methods:             []string{"*"},
+		RequiredPermissions: []string{"admin:read"},
+	})
+}
+
+// TestConfig_resolve_concurrent drives the resolver from many goroutines at once, which is the
+// only way a server ever runs it. Under -race this fails before the fix: resolving a pattern
+// appended a route to the config's shared mux.Router on every call.
+func TestConfig_resolve_concurrent(t *testing.T) {
+	const (
+		goroutines = 50
+		iterations = 20
+	)
+
+	config := newTestConfig(t, patternEndpoints(5), nil)
+
+	var wg sync.WaitGroup
+
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+
+			for range iterations {
+				endpoint, isPublic := config.resolve(http.MethodDelete, "/admin/orgs/123")
+
+				assert.False(t, isPublic)
+				assert.NotNil(t, endpoint)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestMiddleware_concurrent is the same check one layer up, through the exported entry point
+// an application actually mounts.
+func TestMiddleware_concurrent(t *testing.T) {
+	const (
+		goroutines = 50
+		iterations = 20
+	)
+
+	config := newTestConfig(t, patternEndpoints(5),
+		[]RoleDefinition{{Name: "admin", Permissions: []string{"admin:read"}}})
+
+	handler := Middleware(config)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var wg sync.WaitGroup
+
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+
+			for range iterations {
+				req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/admin/orgs/123", http.NoBody)
+				req.Header.Set("X-User-Role", "admin")
+
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+
+				assert.Equal(t, http.StatusOK, rec.Code)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestConfig_resolve_allocations pins the per-request cost of the ordered scan to the size of the
+// request rather than the size of the config. RBAC runs on every request of every route, so an
+// allocation here lands on the whole application's hot path.
+//
+// The assertion is comparative rather than an absolute count: the scan allocates a small fixed set
+// of per-request values, and exactly what that comes to varies with the Go version and with
+// whether the race detector is on. What must not vary is that it stays flat as rules are added.
+// Before the fix each rule's pattern was recompiled per request, so this ran to 1064, 3924 and
+// 9684 allocations for the three sizes below.
+func TestConfig_resolve_allocations(t *testing.T) {
+	measure := func(rules int) float64 {
+		config := newTestConfig(t, patternEndpoints(rules), nil)
+
+		// Warm up, so any first-call lazy work is not counted.
+		config.resolve(http.MethodDelete, "/admin/orgs/123")
+
+		return testing.AllocsPerRun(100, func() {
+			config.resolve(http.MethodDelete, "/admin/orgs/123")
+		})
+	}
+
+	baseline := measure(5)
+
+	// Generous: a scan that recompiles patterns costs hundreds of allocations per added rule, so
+	// any real regression clears this by orders of magnitude.
+	const tolerance = 4
+
+	for _, rules := range []int{20, 50} {
+		t.Run(fmt.Sprintf("%d_rules", rules+1), func(t *testing.T) {
+			assert.LessOrEqual(t, measure(rules), baseline+tolerance,
+				"resolve allocates per rule scanned; cost must not scale with config size")
+		})
+	}
+}
+
+func TestEndpointRule_matchesMethod(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		ruleMethod   string
+		requestUpper string
+		expected     bool
+	}{
+		{"explicit method matches itself", http.MethodGet, http.MethodGet, true},
+		{"explicit method rejects another", http.MethodGet, http.MethodDelete, false},
+		{"explicit method matches case-insensitively", http.MethodGet, "get", true},
+		{"wildcard matches any known method", "*", http.MethodDelete, true},
+		{"wildcard matches unknown method", "*", "PROPFIND", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rule := endpointRule{method: tc.ruleMethod}
+			assert.Equal(t, tc.expected, rule.matchesMethod(tc.requestUpper))
+		})
+	}
+}
+
+func BenchmarkConfig_resolve(b *testing.B) {
+	for _, rules := range []int{5, 20, 50} {
+		b.Run(fmt.Sprintf("%d_rules", rules+1), func(b *testing.B) {
+			config := newTestConfig(b, patternEndpoints(rules), nil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for range b.N {
+				endpoint, _ := config.resolve(http.MethodDelete, "/admin/orgs/123")
+				require.NotNil(b, endpoint)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

Fixes items 1 and 2 of #3979: the RBAC matcher's data race, its unbounded router growth, and its
per-request allocation cost. Item 3 of that issue (multi-role JWT claim arrays) is independent and
needs a semantics decision first, so it is left for a separate PR.

`matchMuxPattern` built a route per rule, per request, on the `Config`'s shared `muxRouter`:

```go
route := router.NewRoute().Path(pattern)
```

`mux.Router.NewRoute` appends to the router it is called on (`mux@v1.8.1/mux.go:279-284`), and
`config.muxRouter` is created once at load and shared by every request. So each pattern test both
mutated shared state without synchronization and left its entry behind permanently.

Each pattern is now compiled **once at load**, onto a router of its own, and stored on `endpointRule`.
`Route.Match` only reads the route and writes into the caller's `RouteMatch`, so a route that is never
written to again is safe to share across goroutines. The shared `muxRouter` is gone.

A per-scan `matchContext` carries the request and a single reused `RouteMatch`. Without it one
`RouteMatch` escaped per rule scanned, so cost still grew with config size.

**This does not change which requests match which rules.** #3979 suggests reading
`mux.CurrentRoute(r).GetPathTemplate()` instead. That works, but it compares config paths against
registered route *templates* rather than request paths — the breaking change #3935 defers to its own
item 3 and argues should not be the default, since a rule like `/admin/{path:.*}` deliberately spans
many registered routes today. That belongs in #3935 on its own merits, not smuggled into a bug fix.

**Root cause analysis:**

- **Symptom.** Under concurrency, `-race` reports a race on `mux.(*Router).NewRoute` reached through
  `rbac.matchMuxPattern`. Separately, a long-lived process accumulates router entries without bound
  (0 → 114 routes after 100 requests, per #3979), and authorizing one request costs hundreds to
  thousands of allocations, on the hot path of every route in the application.
- **Root cause.** `Config` is documented as read-only after initialization — `getExactEndpoint` and
  `GetEndpointPermission` both carry the comment "Config is read-only after initialization, so no mutex
  is needed." `matchMuxPattern` broke that invariant: `NewRoute` is a mutating call, and it was being
  made on a shared field on every request. The pattern compilation it performed is fully determined by
  the config, so it never needed to happen at request time at all.
- **Why it wasn't caught.** The existing suites drive requests sequentially, and the package had no
  `-race` concurrency test and no benchmark. A sequential test cannot observe either failure: the race
  needs two goroutines, and the growth is invisible without counting routes or allocations.
- **Fix.** Compile at load onto a per-pattern router; store the compiled `*mux.Route` on the rule; reuse
  one `RouteMatch` per scan. `matchesHTTPMethod` is deleted — `endpointRule.matchesMethod` was its only
  caller and allocated a one-element slice per rule per request to reach it, and its list handling is
  unreachable now that `buildEndpointRules` expands methods into one rule each.
- **Prevention.** Three regression tests added, described below. The concurrency tests fail on the base
  branch with exactly the stack #3979 reported.

**Verification:**

`TestConfig_resolve_concurrent` and `TestMiddleware_concurrent` drive 50 goroutines × 20 requests
through the resolver and through the mounted middleware. Both fail `-race` on the base branch and pass
here; `go test -race -count=2 ./pkg/gofr/rbac/` is clean.

`BenchmarkConfig_resolve` (Apple M4), before → after:

| rules in config | before | after |
| --- | --- | --- |
| 6 | 36,730 ns/op, 1,064 allocs/op | 927 ns/op, 6 allocs/op |
| 21 | 131,730 ns/op, 3,924 allocs/op | 1,026 ns/op, 6 allocs/op |
| 51 | 373,669 ns/op, 9,684 allocs/op | 1,717 ns/op, 6 allocs/op |

`TestConfig_resolve_allocations` guards that flatness. It compares a small config against larger ones
rather than asserting an absolute count: the race detector adds three allocations, so a bound tuned
without `-race` fails CI with it and one tuned for `-race` is slack. The property the fix establishes
is that per-request cost does not scale with rule count, so that is what the test measures.

Package coverage is 94.3%.

**Breaking Changes (if applicable):**

None. Matching semantics are unchanged, and no exported API is touched — `muxRouter`,
`matchMuxPattern`, `matchesEndpointPattern` and `matchesHTTPMethod` are all unexported.

**Additional Information:**

No new dependencies. `endpoint_matcher_test.go` shrinks because `TestMatchesHTTPMethod` is removed with
the function it covered (superseded by `TestEndpointRule_matchesMethod`) and `TestMatchMuxPattern` is
retargeted at `compilePattern` as `TestCompilePattern`, which also gains cases for literal paths,
empty paths and patterns mux cannot compile.

Three pre-existing `noctx` lint findings remain in `endpoint_matcher_test.go` (`httptest.NewRequest`
rather than `NewRequestWithContext`). They are present on `development`, untouched here, and part of the
mechanical golangci-lint backlog.

**Checklist:**

-   [x] I have formatted my code using  `goimport`  and  `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

