### PR TITLE
chore(deps): bump tj-actions/changed-files 47.0.0 → 47.0.6

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -572,7 +572,7 @@ jobs:
       # This implements a changed-files based approach as suggested by the maintainer
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             pkg/**/*.go


### PR DESCRIPTION
Patch bump of the `tj-actions/changed-files` GitHub Action (actions group), consolidated from Dependabot #3980.

- `.github/workflows/go.yml`: `tj-actions/changed-files` `v47.0.0` → `v47.0.6`, SHA-pinned to `9426d40962ed5378910ee2e21d5f8c6fcbf2dd96`.

Patch-level within v47; no workflow logic changes.

Closes #3980

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)