### PR TITLE
chore(deps): bump golang 1.26-alpine -> 1.27-alpine in examples/http-server

### DIFF
--- a/examples/http-server/Dockerfile
+++ b/examples/http-server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine AS build
+FROM golang:1.27-alpine AS build
 RUN apk add --no-cache build-base
 
 WORKDIR /src


### PR DESCRIPTION
## Docker base image bump

Bumps the Go base image in `examples/http-server/Dockerfile` from `golang:1.26-alpine` to `golang:1.27-alpine`.

Split out from the weekly Dependabot batch because it's a Dockerfile change, not a `go.mod` update.

### Original Dependabot PR (now closed)
#4064