### PR TITLE
fix(websocket): prevent panic on plain HTTP requests

### DIFF
--- a/pkg/gofr/websocket.go
+++ b/pkg/gofr/websocket.go
@@ -29,10 +29,13 @@ func (a *App) OverrideWebsocketUpgrader(wsUpgrader websocket.Upgrader) {
 // within the handler context. User can access the underlying WebSocket connection using `ctx.GetWebsocketConnection()`.
 func (a *App) WebSocket(route string, handler Handler) {
 	a.GET(route, func(ctx *Context) (any, error) {
-		connID := ctx.Request.Context().Value(websocket.WSConnectionKey).(string)
+		connID, ok := ctx.Request.Context().Value(websocket.WSConnectionKey).(string)
+		if !ok {
+			return nil, websocket.ErrorConnection
+		}
 
 		conn := a.httpServer.ws.GetWebsocketConnection(connID)
-		if conn.Conn == nil {
+		if conn == nil || conn.Conn == nil {
 			return nil, websocket.ErrorConnection
 		}
 

--- a/pkg/gofr/websocket_test.go
+++ b/pkg/gofr/websocket_test.go
@@ -182,3 +182,21 @@ func TestSerializeMessage(t *testing.T) {
 		})
 	}
 }
+func Test_WebSocket_PlainHTTPRequest(t *testing.T) {
+	testutil.NewServerConfigs(t)
+
+	app := New()
+
+	app.WebSocket("/ws", func(ctx *Context) (any, error) {
+		return "ok", nil
+	})
+
+	server := httptest.NewServer(app.httpServer.router)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/ws")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}


### PR DESCRIPTION
## Description

Prevents a panic when a WebSocket route receives a normal HTTP request instead of a WebSocket handshake.

## Changes

- Safely check the WebSocket connection ID type assertion.
- Safely handle a nil WebSocket connection.
- Added a regression test for plain HTTP requests to a WebSocket route.

## Testing

- `go test ./pkg/gofr -run Test_WebSocket_PlainHTTPRequest -count=1 -v`
- `gofmt`
- `git diff --check`

The full repository test suite was also checked. The `examples/http-server` integration test requires Redis on port 2002 and MySQL on port 2001; those services were unavailable in the local environment.