### PR TITLE
fix(http): respond with 405 Method Not Allowed and harden static file symlinks

### DIFF
--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -176,13 +176,21 @@ func (a *App) httpServerSetup() {
 
 	a.setupGraphQL()
 
-	if a.container.Logger != nil {
-		a.container.Logger.Infof("Registered HTTP server on port: %d", a.httpServer.port)
-	}
-
-	a.httpServer.router.PathPrefix("/").Handler(handler{
+	a.httpServer.router.NotFoundHandler = handler{
 		function:  catchAllHandler,
 		container: a.container,
+	}
+
+	a.httpServer.router.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methods := a.httpServer.router.AllowedMethods(r)
+		if len(methods) > 0 {
+			w.Header().Set("Allow", strings.Join(methods, ", "))
+		}
+
+		handler{
+			function:  methodNotAllowedHandler,
+			container: a.container,
+		}.ServeHTTP(w, r)
 	})
 
 	var registeredMethods []string
@@ -455,7 +463,7 @@ func (a *App) setupGraphQL() {
 		}
 
 		// Functional endpoint: served via POST per spec to ensure data safety and consistency.
-		a.httpServer.router.NewRoute().Methods(http.MethodPost).Path("/graphql").Handler(a.graphqlManager.GetHandler())
+		a.httpServer.router.NewRoute().Path("/graphql").Methods(http.MethodPost).Handler(a.graphqlManager.GetHandler())
 	}
 }
 

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -1935,3 +1935,91 @@ func Test_HTTPMethods(t *testing.T) {
 		})
 	}
 }
+
+func Test_HTTPMethodNotAllowed_And_NotFound(t *testing.T) {
+	testutil.NewServerConfigs(t)
+
+	app := New()
+	app.GET("/thing", func(*Context) (any, error) {
+		return "ok", nil
+	})
+	app.POST("/multi", func(*Context) (any, error) {
+		return "multi-post", nil
+	})
+	app.PUT("/multi", func(*Context) (any, error) {
+		return "multi-put", nil
+	})
+
+	app.httpServerSetup()
+
+	tests := []struct {
+		name          string
+		method        string
+		path          string
+		expectedCode  int
+		expectedAllow string
+		expectedBody  string
+	}{
+		{
+			name:          "GET registered route returns 200",
+			method:        http.MethodGet,
+			path:          "/thing",
+			expectedCode:  http.StatusOK,
+			expectedAllow: "",
+			expectedBody:  `{"data":"ok"}`,
+		},
+		{
+			name:          "POST on GET-only route returns 405 with Allow header",
+			method:        http.MethodPost,
+			path:          "/thing",
+			expectedCode:  http.StatusMethodNotAllowed,
+			expectedAllow: "GET",
+			expectedBody:  `{"error":{"message":"method not allowed"}}`,
+		},
+		{
+			name:          "DELETE on GET-only route returns 405 with Allow header",
+			method:        http.MethodDelete,
+			path:          "/thing",
+			expectedCode:  http.StatusMethodNotAllowed,
+			expectedAllow: "GET",
+			expectedBody:  `{"error":{"message":"method not allowed"}}`,
+		},
+		{
+			name:          "GET on multi-method route (POST, PUT) returns 405 with sorted Allow header",
+			method:        http.MethodGet,
+			path:          "/multi",
+			expectedCode:  http.StatusMethodNotAllowed,
+			expectedAllow: "POST, PUT",
+			expectedBody:  `{"error":{"message":"method not allowed"}}`,
+		},
+		{
+			name:          "GET on unregistered route returns 404",
+			method:        http.MethodGet,
+			path:          "/unregistered",
+			expectedCode:  http.StatusNotFound,
+			expectedAllow: "",
+			expectedBody:  `{"error":{"message":"route not registered"}}`,
+		},
+		{
+			name:          "POST on unregistered route returns 404",
+			method:        http.MethodPost,
+			path:          "/unregistered",
+			expectedCode:  http.StatusNotFound,
+			expectedAllow: "",
+			expectedBody:  `{"error":{"message":"route not registered"}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(t.Context(), tc.method, tc.path, http.NoBody)
+
+			app.httpServer.router.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.expectedCode, w.Code)
+			assert.Equal(t, tc.expectedAllow, w.Header().Get("Allow"))
+			assert.JSONEq(t, tc.expectedBody, w.Body.String())
+		})
+	}
+}

--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -230,6 +230,10 @@ func catchAllHandler(*Context) (any, error) {
 	return nil, gofrHTTP.ErrorInvalidRoute{}
 }
 
+func methodNotAllowedHandler(*Context) (any, error) {
+	return nil, gofrHTTP.ErrorMethodNotAllowed{}
+}
+
 func panicRecoveryHandler(re any, log logging.Logger, panicked chan struct{}) {
 	if re == nil {
 		return

--- a/pkg/gofr/handler_test.go
+++ b/pkg/gofr/handler_test.go
@@ -237,6 +237,18 @@ func TestHandler_catchAllHandler(t *testing.T) {
 	assert.Equal(t, gofrHTTP.ErrorInvalidRoute{}, err, "TEST Failed.\n")
 }
 
+func TestHandler_methodNotAllowedHandler(t *testing.T) {
+	c := Context{
+		Context: t.Context(),
+	}
+
+	data, err := methodNotAllowedHandler(&c)
+
+	assert.Nil(t, data, "TEST Failed.\n")
+
+	assert.Equal(t, gofrHTTP.ErrorMethodNotAllowed{}, err, "TEST Failed.\n")
+}
+
 func TestHandler_livelinessHandler(t *testing.T) {
 	resp, err := liveHandler(&Context{})
 
@@ -1130,6 +1142,7 @@ func TestHandler_Char_ErrorLogging(t *testing.T) {
 		{"entity-not-found-is-INFO", gofrHTTP.ErrorEntityNotFound{}, "INFO", false},
 		{"already-exists-is-WARN", gofrHTTP.ErrorEntityAlreadyExist{}, "WARN", false},
 		{"invalid-route-is-INFO", gofrHTTP.ErrorInvalidRoute{}, "INFO", false},
+		{"method-not-allowed-is-INFO", gofrHTTP.ErrorMethodNotAllowed{}, "INFO", false},
 		{"panic-recovery-is-ERROR", gofrHTTP.ErrorPanicRecovery{}, "ERROR", true},
 		{"too-many-requests-is-WARN", gofrHTTP.ErrorTooManyRequests{}, "WARN", false},
 		{"client-closed-is-DEBUG", gofrHTTP.ErrorClientClosedRequest{}, "DEBUG", false},

--- a/pkg/gofr/http/errors.go
+++ b/pkg/gofr/http/errors.go
@@ -97,6 +97,21 @@ func (ErrorInvalidRoute) StatusCode() int {
 	return http.StatusNotFound
 }
 
+// ErrorMethodNotAllowed represents an error when the HTTP method is not allowed for a route.
+type ErrorMethodNotAllowed struct{}
+
+func (ErrorMethodNotAllowed) Error() string {
+	return "method not allowed"
+}
+
+func (ErrorMethodNotAllowed) LogLevel() logging.Level {
+	return logging.INFO
+}
+
+func (ErrorMethodNotAllowed) StatusCode() int {
+	return http.StatusMethodNotAllowed
+}
+
 // ErrorRequestTimeout represents an error for request which timed out.
 type ErrorRequestTimeout struct{}
 
@@ -185,6 +200,7 @@ var (
 	_ StatusCodeResponder = ErrorInvalidParam{}
 	_ StatusCodeResponder = ErrorMissingParam{}
 	_ StatusCodeResponder = ErrorInvalidRoute{}
+	_ StatusCodeResponder = ErrorMethodNotAllowed{}
 	_ StatusCodeResponder = ErrorRequestTimeout{}
 	_ StatusCodeResponder = ErrorPanicRecovery{}
 	_ StatusCodeResponder = ErrorServiceUnavailable{}
@@ -197,6 +213,7 @@ var (
 	_ logging.LogLevelResponder = ErrorInvalidParam{}
 	_ logging.LogLevelResponder = ErrorMissingParam{}
 	_ logging.LogLevelResponder = ErrorInvalidRoute{}
+	_ logging.LogLevelResponder = ErrorMethodNotAllowed{}
 	_ logging.LogLevelResponder = ErrorRequestTimeout{}
 	_ logging.LogLevelResponder = ErrorPanicRecovery{}
 	_ logging.LogLevelResponder = ErrorServiceUnavailable{}

--- a/pkg/gofr/http/errors_test.go
+++ b/pkg/gofr/http/errors_test.go
@@ -105,6 +105,14 @@ func TestErrorInvalidRoute(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, err.StatusCode(), "TEST Failed.\n")
 }
 
+func TestErrorMethodNotAllowed(t *testing.T) {
+	err := ErrorMethodNotAllowed{}
+
+	require.ErrorContainsf(t, err, "method not allowed", "TEST Failed.\n")
+
+	assert.Equal(t, http.StatusMethodNotAllowed, err.StatusCode(), "TEST Failed.\n")
+}
+
 func Test_ErrorRequestTimeout(t *testing.T) {
 	err := ErrorRequestTimeout{}
 

--- a/pkg/gofr/http/responder_test.go
+++ b/pkg/gofr/http/responder_test.go
@@ -124,6 +124,8 @@ func TestResponder_getStatusCode(t *testing.T) {
 		{"success delete", http.MethodDelete, nil, nil, http.StatusNoContent, nil},
 		{"invalid route error", http.MethodGet, nil, ErrorInvalidRoute{}, http.StatusNotFound,
 			map[string]any{"message": ErrorInvalidRoute{}.Error()}},
+		{"method not allowed error", http.MethodPost, nil, ErrorMethodNotAllowed{}, http.StatusMethodNotAllowed,
+			map[string]any{"message": ErrorMethodNotAllowed{}.Error()}},
 		{"internal server error", http.MethodGet, nil, http.ErrHandlerTimeout, http.StatusInternalServerError,
 			map[string]any{"message": http.ErrHandlerTimeout.Error()}},
 		{"partial content with error", http.MethodGet, "partial response", ErrorInvalidRoute{},

--- a/pkg/gofr/http/router.go
+++ b/pkg/gofr/http/router.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"sync"
 
@@ -323,7 +325,38 @@ func isDotSegment(p string, idx int) bool {
 // directly, avoiding the per-request child span and attribute slice grow
 // that an otelhttp.NewHandler wrap would add.
 func (rou *Router) Add(method, pattern string, handler http.Handler) {
-	rou.Router.NewRoute().Methods(method).Path(pattern).Handler(handler)
+	rou.Router.NewRoute().Path(pattern).Methods(method).Handler(handler)
+}
+
+// AllowedMethods returns the sorted list of HTTP methods accepted for the given request's path.
+func (rou *Router) AllowedMethods(r *http.Request) []string {
+	var allowed []string
+
+	testReq := r.Clone(r.Context())
+
+	_ = rou.Router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		methods, err := route.GetMethods()
+		if err != nil || len(methods) == 0 {
+			return nil
+		}
+
+		var match mux.RouteMatch
+
+		for _, m := range methods {
+			testReq.Method = m
+			if route.Match(testReq, &match) {
+				if !slices.Contains(allowed, m) {
+					allowed = append(allowed, m)
+				}
+			}
+		}
+
+		return nil
+	})
+
+	sort.Strings(allowed)
+
+	return allowed
 }
 
 // UseMiddleware registers middlewares to the router.
@@ -353,17 +386,24 @@ func (rou *Router) AddStaticFiles(logger logging.Logger, endpoint, dirName strin
 		return
 	}
 
-	// App.AddStaticFiles only stats the path, so a regular file passes registration. The containment
-	// check admits the served path itself now that the endpoint root has to resolve to it, which
-	// would turn that misconfiguration into the file being served verbatim at the endpoint. Refusing
-	// to register a non-directory keeps that guard closed where the prefix comparison used to.
-	if info, statErr := os.Stat(absDir); statErr != nil || !info.IsDir() {
-		logger.Errorf("error in registering '%v' static endpoint, %v is not a directory", endpoint, absDir)
+	evalDir, err := filepath.EvalSymlinks(absDir)
+	if err != nil {
+		logger.Errorf("error in registering '%v' static endpoint, cannot evaluate directory %v: %v", endpoint, absDir, err)
 
 		return
 	}
 
-	cfg := staticFileConfig{directoryName: absDir, logger: logger}
+	// App.AddStaticFiles only stats the path, so a regular file passes registration. The containment
+	// check admits the served path itself now that the endpoint root has to resolve to it, which
+	// would turn that misconfiguration into the file being served verbatim at the endpoint. Refusing
+	// to register a non-directory keeps that guard closed where the prefix comparison used to.
+	if info, statErr := os.Stat(evalDir); statErr != nil || !info.IsDir() {
+		logger.Errorf("error in registering '%v' static endpoint, %v is not a directory", endpoint, evalDir)
+
+		return
+	}
+
+	cfg := staticFileConfig{directoryName: evalDir, logger: logger}
 
 	handler := cfg.staticHandler()
 
@@ -483,8 +523,17 @@ func (staticConfig staticFileConfig) isWithinDirectory(absPath string) bool {
 
 // Validates file existence and permissions, and resolves a directory to the file that represents
 // it. The returned path is absPath for an ordinary file, and absPath's index file for a directory.
-func (staticFileConfig) validateFile(absPath string) (resolvedPath string, err error) {
-	fileInfo, err := os.Stat(absPath)
+func (staticConfig staticFileConfig) validateFile(absPath string) (resolvedPath string, err error) {
+	evalPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", err
+	}
+
+	if !staticConfig.isWithinDirectory(evalPath) {
+		return "", fs.ErrNotExist
+	}
+
+	fileInfo, err := os.Stat(evalPath)
 	if err != nil {
 		return "", err
 	}
@@ -494,9 +543,20 @@ func (staticFileConfig) validateFile(absPath string) (resolvedPath string, err e
 	// business disclosing. Without an index, os.Stat reports the same not-exist error a missing
 	// file gives, so the request takes the ordinary 404 path.
 	if fileInfo.IsDir() {
-		absPath = filepath.Join(absPath, staticServerIndexFileName)
+		indexPath := filepath.Join(evalPath, staticServerIndexFileName)
 
-		fileInfo, err = os.Stat(absPath)
+		evalIndexPath, err := filepath.EvalSymlinks(indexPath)
+		if err != nil {
+			return "", err
+		}
+
+		if !staticConfig.isWithinDirectory(evalIndexPath) {
+			return "", fs.ErrNotExist
+		}
+
+		evalPath = evalIndexPath
+
+		fileInfo, err = os.Stat(evalPath)
 		if err != nil {
 			return "", err
 		}
@@ -523,7 +583,7 @@ func (staticFileConfig) validateFile(absPath string) (resolvedPath string, err e
 		return "", errReadPermissionDenied
 	}
 
-	return absPath, nil
+	return evalPath, nil
 }
 
 // Handles different file-related errors.

--- a/pkg/gofr/http/router_test.go
+++ b/pkg/gofr/http/router_test.go
@@ -969,3 +969,98 @@ func BenchmarkRouter_Get_PathParam(b *testing.B) {
 		r.ServeHTTP(w, req)
 	}
 }
+
+func Test_Router_AllowedMethods(t *testing.T) {
+	r := NewRouter()
+	r.Add(http.MethodGet, "/users", noopHandler())
+	r.Add(http.MethodPost, "/users", noopHandler())
+	r.Add(http.MethodPut, "/users/{id}", noopHandler())
+	r.Add(http.MethodDelete, "/users/{id}", noopHandler())
+
+	tests := []struct {
+		name     string
+		path     string
+		expected []string
+	}{
+		{"exact match with GET and POST", "/users", []string{"GET", "POST"}},
+		{"path param match with PUT and DELETE", "/users/123", []string{"DELETE", "PUT"}},
+		{"unregistered path", "/unknown", nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPatch, tc.path, http.NoBody)
+			allowed := r.AllowedMethods(req)
+			assert.Equal(t, tc.expected, allowed)
+		})
+	}
+}
+
+func Test_StaticFileServing_Symlinks(t *testing.T) {
+	baseDir := t.TempDir()
+
+	publicDir := filepath.Join(baseDir, "public")
+	require.NoError(t, os.MkdirAll(publicDir, 0755))
+
+	assetsDir := filepath.Join(publicDir, "assets")
+	require.NoError(t, os.MkdirAll(assetsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(assetsDir, "logo.png"), []byte("PNGDATA"), 0644))
+
+	secretsDir := filepath.Join(baseDir, "secrets")
+	require.NoError(t, os.MkdirAll(secretsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(secretsDir, "passwords.txt"), []byte("SUPERSECRET"), 0644))
+
+	require.NoError(t, os.Symlink(filepath.Join(secretsDir, "passwords.txt"), filepath.Join(publicDir, "evil.txt")))
+	require.NoError(t, os.Symlink(secretsDir, filepath.Join(publicDir, "evildir")))
+	require.NoError(t, os.Symlink(filepath.Join("assets", "logo.png"), filepath.Join(publicDir, "rel-inside.png")))
+
+	subDir := filepath.Join(publicDir, "sub")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+	require.NoError(t, os.Symlink(filepath.Join("..", "assets", "logo.png"), filepath.Join(subDir, "dotdot-inside.png")))
+
+	tests := []struct {
+		name         string
+		path         string
+		expectedCode int
+		expectedBody string
+	}{
+		{
+			name:         "symlink pointing outside is rejected with 404",
+			path:         "/static/evil.txt",
+			expectedCode: http.StatusNotFound,
+			expectedBody: "404 Not Found",
+		},
+		{
+			name:         "directory symlink pointing outside is rejected with 404",
+			path:         "/static/evildir/passwords.txt",
+			expectedCode: http.StatusNotFound,
+			expectedBody: "404 Not Found",
+		},
+		{
+			name:         "relative symlink inside root is served",
+			path:         "/static/rel-inside.png",
+			expectedCode: http.StatusOK,
+			expectedBody: "PNGDATA",
+		},
+		{
+			name:         "relative symlink with dotdot inside root is served",
+			path:         "/static/sub/dotdot-inside.png",
+			expectedCode: http.StatusOK,
+			expectedBody: "PNGDATA",
+		},
+	}
+
+	router := NewRouter()
+	router.AddStaticFiles(logging.NewMockLogger(logging.DEBUG), "/static", publicDir)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, tc.path, http.NoBody))
+
+			assert.Equal(t, tc.expectedCode, w.Code)
+			assert.Equal(t, tc.expectedBody, strings.TrimSpace(w.Body.String()))
+			assert.NotContains(t, w.Body.String(), "SUPERSECRET")
+		})
+	}
+}

--- a/pkg/gofr/http/trie_router_test.go
+++ b/pkg/gofr/http/trie_router_test.go
@@ -288,8 +288,8 @@ func TestTrieDifferential_MethodMismatchParity(t *testing.T) {
 	muxStatus, _ := serve(muxR, http.MethodGet, "/a/xyz")
 	trieStatus, _ := serve(trieR, http.MethodGet, "/a/xyz")
 
-	assert.Equal(t, http.StatusNotFound, muxStatus, "mux baseline: registration-order 404")
-	assert.Equal(t, muxStatus, trieStatus, "trie must reproduce mux's order-dependent status, not a 405")
+	assert.Equal(t, http.StatusMethodNotAllowed, muxStatus, "mux baseline: 405 Method Not Allowed")
+	assert.Equal(t, muxStatus, trieStatus, "trie must match mux status")
 }
 
 // TestTrieRouter_UnmatchedFallsBackToMux asserts the safety property that the


### PR DESCRIPTION
## Pull Request Template

**Description:**

- Addressed Issue #3853: When a request arrives for a registered route with an unsupported HTTP method, the router responds with `405 Method Not Allowed` with the `Allow` header populated with accepted methods (e.g. `Allow: GET, POST`) and GoFr error JSON envelope `{"error":{"message":"method not allowed"}}`, rather than `404 Not Found`.
- Configured `NotFoundHandler` and `MethodNotAllowedHandler` on the router and registered routes with `Path` before `Methods` so Gorilla Mux accurately tracks method mismatches.
- Added `AllowedMethods(r *http.Request) []string` to inspect allowed HTTP methods for the requested path.
- Addressed Issue #3855: Hardened static file serving by verifying `filepath.EvalSymlinks` remains within the root directory before opening/serving files. Symlinks pointing outside the served root return `404 Not Found`.
- Added unit tests covering 405/404 handling, `Allow` header formatting, and symlink containment scenarios.

Fixes #3853
Fixes #3855

**Breaking Changes (if applicable):**

- None. Requests to existing routes with unsupported HTTP methods will now receive standard `405 Method Not Allowed` instead of `404 Not Found`.

**Additional Information:**

- All new code is covered by unit tests.
- Code is formatted with `gofmt`.

**Checklist:**

- [x] I have formatted my code using `goimport` and `golangci-lint`.
- [x] All new code is covered by unit tests.
- [x] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.