### PR TITLE
fix(test): stop pinning the tracer scope name to a development build

### DIFF
--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -326,10 +326,6 @@ func TestTracer_EmitsOTelHTTPSemconvAttributes(t *testing.T) {
 // unmodified source.
 // ---------------------------------------------------------------------------
 
-// tracerCharScopeName returns the exact instrumentation-scope (tracer) name
-// the middleware resolves at chain-build time.
-func tracerCharScopeName() string { return "gofr-" + version.Framework }
-
 // tracerCharInstallRecordingTP installs an sdktrace provider with an in-memory
 // span recorder and restores the previously installed global provider on
 // cleanup. The provider MUST be installed before Tracer() is called because
@@ -433,9 +429,14 @@ func Test_TracerContract_InstrumentationScopeName(t *testing.T) {
 	spans := rec.Ended()
 	require.Len(t, spans, 1)
 
-	assert.Equal(t, "gofr-dev", tracerCharScopeName(),
-		"version.Framework changed; the scope name below moves with it")
-	assert.Equal(t, tracerCharScopeName(), spans[0].InstrumentationScope().Name)
+	// The scope name embeds version.Framework: "gofr-dev" on a development build, "gofr-v1.60.0" on
+	// a release build. That moving part is the contract — a consumer filtering on the scope name has
+	// to expect it to change every release — so the assertion derives the expected value rather than
+	// pinning a literal, which would fail on every release branch.
+	assert.Equal(t, "gofr-"+version.Framework, spans[0].InstrumentationScope().Name,
+		"scope name is the gofr- prefix plus version.Framework")
+	assert.NotEqual(t, "gofr-", spans[0].InstrumentationScope().Name,
+		"the version must actually be appended, not an empty string")
 	assert.Empty(t, spans[0].InstrumentationScope().Version,
 		"middleware passes no WithInstrumentationVersion")
 	assert.Empty(t, spans[0].InstrumentationScope().SchemaURL)


### PR DESCRIPTION
**Description:**

`Test_TracerContract_InstrumentationScopeName` asserts the instrumentation scope name equals the literal `"gofr-dev"`. The middleware builds that name as `"gofr-" + version.Framework` (`tracer.go:64`), and `version.Framework` is `"dev"` only on a development build — a release branch sets it to the version being cut.

So the test passes on `development` and **fails on every release branch**:

```
    tracer_test.go:436
    Error:      Not equal:
                expected: "gofr-dev"
                actual  : "gofr-v1.60.0"
--- FAIL: Test_TracerContract_InstrumentationScopeName (0.00s)
FAIL	gofr.dev/pkg/gofr/http/middleware
```

Found while cutting v1.60.0 (#4107), where it failed **all three** `PKG Unit Testing` shards — v1.24, v1.25 and v1.26. It is the only failure in `./pkg/...`.

**This is a same-cycle regression, not inherited debt.** The assertion arrived with #3770 (`7cbb41a3`), which is itself part of the v1.60.0 release:

| | v1.59.0 | v1.60.0 (development) |
|---|---|---|
| `"gofr-dev"` literal in `tracer_test.go` | absent | present |
| `version.Framework` referenced by that test | never | yes |

`tracer_test.go` predates this cycle, but nothing in it depended on the version until #3770, so v1.59.0's release branch could not have hit this. v1.60.0 is the first release that would fail — and so would every release after it, if this shipped as is. Fixing it at the source rather than patching the release branch keeps the next cut clean.

**Why the literal was never load-bearing**

The two assertions were:

```go
assert.Equal(t, "gofr-dev", tracerCharScopeName(),
    "version.Framework changed; the scope name below moves with it")
assert.Equal(t, tracerCharScopeName(), spans[0].InstrumentationScope().Name)
```

with `tracerCharScopeName()` defined as `"gofr-" + version.Framework`. The second line already pinned the contract — the span's scope name is the gofr prefix plus the framework version. The first only asserted that *this particular build* happens to be a development build, which is a property of the branch, not of the middleware.

Its comment shows the intent was a tripwire for the name moving. But the name is *designed* to move with every release, so the tripwire fires on exactly the occasions when nothing is wrong.

**The change**

The expected value is derived the way production derives it, and a second assertion pins that the version is actually appended rather than resolving to an empty string — the one failure mode a derived expectation could otherwise hide:

```go
assert.Equal(t, "gofr-"+version.Framework, spans[0].InstrumentationScope().Name,
    "scope name is the gofr- prefix plus version.Framework")
assert.NotEqual(t, "gofr-", spans[0].InstrumentationScope().Name,
    "the version must actually be appended, not an empty string")
```

`tracerCharScopeName` is removed; it had no other caller.

**Breaking Changes (if applicable):**

None. Test-only change; no production file is touched.

**Additional Information:**

The assertion was checked in both directions rather than assumed to work.

Mutation-verified against the production expression in `tracer.go`:

| production expression | result |
|---|---|
| `"gofrx-" + version.Framework` | **FAIL** |
| `"gofr-" + ""` | **FAIL** |
| unmodified | PASS |

(A third mutation — deleting `version.Framework` outright — was discarded because it leaves the import unused and fails to build, so it tests nothing.)

Verified under both builds, which is the point of the change:

- `Framework = "dev"` → `go test ./pkg/gofr/http/middleware/ -run Test_TracerContract` green.
- `Framework = "v1.60.0"` → green (fails on `development` today).

`go vet ./pkg/gofr/http/middleware/` is clean.

`golangci-lint run ./pkg/gofr/http/middleware/...` reports 5 findings, **none in the changed file** — 2 `goconst` in `logger.go` and 3 `noctx` in `apikey_auth_test.go` / `auth_test.go`, all pre-existing in files this PR does not touch (the diff is `tracer_test.go` alone, +8/-7). CI runs with `only-new-issues`, and `Code Quality` passes.

On the full local `go test ./pkg/...`: one package fails on my machine, `pkg/gofr/datasource/pubsub/mqtt`, which hangs to a `test timed out` panic at both the default and a 5m timeout. It talks to a public MQTT broker, this PR does not touch it (the diff is `tracer_test.go` alone), and it passes in CI. I am citing CI as the authority rather than my own run: all three `PKG Unit Testing` shards pass on this branch, which is precisely the check that was red on the release branch.

**Checklist:**

- [x] I have formatted my code using `goimport` and `golangci-lint`.
- [x] All new code is covered by unit tests. — the change *is* the test; verified by mutation in both directions
- [x] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.
