### PR TITLE
fix(gofr): stop racing c.Context between serveWithGoroutine and App.WebSocket

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -287,8 +287,16 @@ jobs:
             export APP_ENV=test
 
             # Run tests for root gofr package
+            #
+            # -race here specifically (not the sub-packages run below, which is
+            # slower and heavier on external services) is what makes concurrency
+            # fixes in this package durable: the WebSocket/serveWithGoroutine
+            # data race fixed alongside this line had no CI signal until now
+            # (#3930) — go test -race stayed a claim in a doc comment nobody
+            # could fail on. -race requires cgo, which ubuntu-latest provides by
+            # default.
             exit_code=0
-            go test -v -short -covermode=atomic \
+            go test -v -short -race -covermode=atomic \
               -coverpkg=./pkg/gofr -coverprofile=gofr_only.cov ./pkg/gofr || exit_code=$?
             if [ $exit_code -eq 2 ]; then
               echo "::error::Panic detected in root gofr package tests"

--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -175,6 +175,14 @@ func (h handler) serveWithGoroutine(c *Context, spanCtx trace.SpanContext, r *ht
 	done := make(chan handlerOutcome, 1)
 	panicked := make(chan struct{})
 
+	// Snapshot the context to watch for cancellation before spawning the
+	// handler goroutine below. h.function may reassign c.Context while it
+	// runs (App.WebSocket does, to thread the connection through it) —
+	// reading c.Context in the select instead of here would race that
+	// write. watchCtx is a local copy this goroutine alone reads, so the
+	// write in the spawned goroutine and this read never overlap.
+	watchCtx := c.Context
+
 	go func() {
 		defer func() {
 			panicRecoveryHandler(recover(), h.container.Logger, panicked)
@@ -187,13 +195,13 @@ func (h handler) serveWithGoroutine(c *Context, spanCtx trace.SpanContext, r *ht
 	}()
 
 	select {
-	case <-c.Context.Done():
+	case <-watchCtx.Done():
 		// Server-side timeout or client cancellation. Map to the matching
 		// gofrHTTP error so Respond emits 408 (timeout) or 499 (client
 		// closed).
 		err = gofrHTTP.ErrorRequestTimeout{}
 
-		if errors.Is(c.Context.Err(), context.Canceled) {
+		if errors.Is(watchCtx.Err(), context.Canceled) {
 			err = gofrHTTP.ErrorClientClosedRequest{}
 		}
 	case out := <-done:

--- a/pkg/gofr/handler.go
+++ b/pkg/gofr/handler.go
@@ -167,10 +167,17 @@ func (h handler) serveInline(c *Context, spanCtx trace.SpanContext) (result any,
 // after the handler hijacks the connection).
 //
 // The handler outcome is sent through a buffered channel rather than to
-// shared variables, so the goroutine never writes a memory location the
-// main goroutine reads — `go test -race` stays clean. Buffer size 1 lets
-// the handler goroutine finish writing and exit even after the main
-// goroutine has already taken the ctx.Done or panicked branch.
+// shared variables, so its (result, err) pair never becomes a location
+// both goroutines touch. Buffer size 1 lets the handler goroutine finish
+// writing and exit even after the main goroutine has already taken the
+// ctx.Done or panicked branch.
+//
+// c.Context is a location both goroutines DO touch: h.function runs in the
+// spawned goroutine and is free to reassign it (App.WebSocket does, to
+// thread the connection through it), while this goroutine's select used to
+// read c.Context.Done() directly — a data race, since nothing ordered the
+// two accesses. See the watchCtx snapshot below, taken before the goroutine
+// is spawned, for the fix.
 func (h handler) serveWithGoroutine(c *Context, spanCtx trace.SpanContext, r *http.Request) (result any, err error) {
 	done := make(chan handlerOutcome, 1)
 	panicked := make(chan struct{})


### PR DESCRIPTION
## Summary

Fixes #3930.

serveWithGoroutine's select reads `c.Context.Done()` on the parent goroutine while the spawned handler goroutine can concurrently reassign `ctx.Context` via `context.WithValue(...)` - `App.WebSocket` does exactly this to thread the connection through the context. Both goroutines touching the same `*Context.Context` field is a data race.

Reproduces on clean development:

```
go test ./pkg/gofr/ -race -count=1 -short -run 'Test_WebSocket_Success'
```

## Fix

Snapshot the context to watch into a local variable (`watchCtx`) before spawning the handler goroutine, so the parent goroutine never reads the shared `c.Context` field again after that point. The child goroutine is still free to reassign `c.Context`; nothing else reads it concurrently after this change.

This is behavior-preserving for the non-WebSocket `requestTimeout > 0` path too, since a normal handler does not reassign `c.Context` mid-flight - `watchCtx` and `c.Context` are the same object there.

## CI

`-race` is now enabled on the root `./pkg/gofr` test run in the `PKG Unit Testing` job, across all three Go version legs, so this fix (and any future concurrency fix in this package) has an actual CI signal instead of relying on someone running `-race` by hand. Verified locally: `go test -short -race ./pkg/gofr` passes 15/15 runs with the exact flags CI uses.

## Related: self-referential context

Found while verifying this fix: the same line this PR touches, `ctx.Context = context.WithValue(ctx, websocket.WSConnectionKey, conn)`, passes `ctx` (a `*Context`, which embeds `context.Context`) as the parent instead of `ctx.Context`, making the resulting context self-referential. Any call that walks the parent chain other than the one lookup that resolves immediately recurses forever into an unrecoverable stack overflow. Independent of the race fixed here - this PR's fix stops the race's reader from ever calling `.Done()` on the poisoned context, which closes one crash path, but leaves the self-reference itself in place for the handler and anything downstream of it.

Filed as #4169, fixed in #4170.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] The repro command above is race-clean after this change
- [x] `go test ./pkg/gofr/ -race -count=1` passes in full
- [x] `go test ./pkg/gofr/ -run TestHandler` - all existing handler characterization tests pass unchanged, confirming the timeout/cancellation/panic paths are behaviorally identical
