### PR TITLE
fix(metrics): supply the instance label Google's OTLP ingest requires

### DIFF
--- a/docs/references/configs/page.md
+++ b/docs/references/configs/page.md
@@ -104,6 +104,11 @@ This document lists all the configuration options supported by the GoFr framewor
 
 ---
 
+-  OTEL_RESOURCE_ATTRIBUTES
+-  Standard OpenTelemetry resource attributes, comma-separated key=value. Merged into the resource attached to every exported metric. Required for the gcp exporter outside Google Cloud: its ingest rejects any point whose prometheus_target has no location (e.g. "location=us-central1").
+
+---
+
 -  HTTP_PORT
 -  Port on which the HTTP server listens
 -  8000

--- a/examples/using-gcp-metrics/README.md
+++ b/examples/using-gcp-metrics/README.md
@@ -83,6 +83,15 @@ OTEL_RESOURCE_ATTRIBUTES=location=us-central1
 
 `location` also accepts `cloud.region` or `cloud.availability_zone`.
 
+`instance` is filled from `host.id`, which GoFr detects automatically. Some
+environments -- minimal containers and some CI runners -- have no machine ID, and
+there `instance` has no source either and points are dropped for the same reason.
+Supply one the same way:
+
+```
+OTEL_RESOURCE_ATTRIBUTES=location=us-central1,service.instance.id=${HOSTNAME}
+```
+
 ## Local run
 
 Locally, ADC comes from `gcloud auth application-default login`. To avoid a real

--- a/examples/using-gcp-metrics/README.md
+++ b/examples/using-gcp-metrics/README.md
@@ -83,14 +83,35 @@ OTEL_RESOURCE_ATTRIBUTES=location=us-central1
 
 `location` also accepts `cloud.region` or `cloud.availability_zone`.
 
-`instance` is filled from `host.id`, which GoFr detects automatically. Some
-environments -- minimal containers and some CI runners -- have no machine ID, and
-there `instance` has no source either and points are dropped for the same reason.
-Supply one the same way:
+`instance` is filled from `host.id`, which GoFr detects automatically. **In a
+container it usually cannot be.** The OpenTelemetry SDK reads `/etc/machine-id`
+and `/var/lib/dbus/machine-id` from the container's own filesystem, and those come
+from the image, not from the node — nothing bind-mounts the host's copy in. So:
 
+| Base image | `/etc/machine-id` | `host.id` |
+|---|---|---|
+| `debian:12-slim`, `alpine` | absent | not detected |
+| `ubuntu:24.04` | present, **empty** | detected but blank |
+
+Either way `instance` has no source and every point is dropped, so on Kubernetes
+supply one explicitly. The pod name is unique per replica and available from the
+downward API:
+
+```yaml
+env:
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: location=us-central1,service.instance.id=$(POD_NAME)
 ```
-OTEL_RESOURCE_ATTRIBUTES=location=us-central1,service.instance.id=${HOSTNAME}
-```
+
+`instance` also accepts `k8s.pod.name`. Cloud Run needs none of this: the GCP
+detector supplies `faas.instance` per revision instance, and the region for
+`location`, so both labels resolve with no configuration.
+
+The exporter warns separately at startup for whichever of the two is missing.
 
 ## Local run
 

--- a/examples/using-gcp-metrics/README.md
+++ b/examples/using-gcp-metrics/README.md
@@ -29,13 +29,25 @@ GMP requires.
 
 ## Deploy to Cloud Run (keyless)
 
-1. Grant the service's runtime service account permission to write metrics:
+1. Grant the service's runtime service account permission to write telemetry:
 
    ```bash
    gcloud projects add-iam-policy-binding <PROJECT_ID> \
      --member="serviceAccount:<RUNTIME_SA>@<PROJECT_ID>.iam.gserviceaccount.com" \
-     --role="roles/monitoring.metricWriter"
+     --role="roles/telemetry.writer"
    ```
+
+   `roles/telemetry.writer` is the role for `telemetry.googleapis.com`, which is
+   what this exporter pushes to. `roles/monitoring.metricWriter` grants
+   `monitoring.timeSeries.create` on `monitoring.googleapis.com` — a different
+   API that this exporter never calls — so granting it alone leaves the push
+   unauthorized.
+
+   With a service account attached, the quota project is resolved automatically.
+   If you authenticate with **user** credentials instead, also grant
+   `roles/serviceusage.serviceUsageConsumer` on the quota project and set
+   `GOOGLE_CLOUD_QUOTA_PROJECT`. Do not pass `x-goog-user-project` as a metrics
+   header; Google documents that this is not the supported route.
 
 2. Deploy — no credentials mounted, no `GOOGLE_APPLICATION_CREDENTIALS`:
 
@@ -46,10 +58,30 @@ GMP requires.
 3. On Cloud Run the app resolves ADC from the metadata server automatically.
    Metrics appear in Cloud Monitoring / Managed Service for Prometheus.
 
-> Cross-project GMP: grant `roles/monitoring.metricWriter` on the **destination**
+> Cross-project GMP: grant `roles/telemetry.writer` on the **destination**
 > project. No Workload Identity Federation is needed on Cloud Run itself — the
 > attached service account is sufficient. WIF only applies to workloads running
 > outside Google Cloud.
+
+## Required resource labels
+
+Google maps every point onto the `prometheus_target` monitored resource, which
+requires a **`location`** and an **`instance`**, and *rejects the point* when
+either is empty. A push that is missing them still authenticates and still
+succeeds — the points are discarded afterwards, server-side, so nothing on the
+client says the data went nowhere.
+
+On Google Cloud both are detected for you: the metadata server supplies the
+region/zone, and `host.id` backs `instance`.
+
+Anywhere else — local runs, other clouds, CI — `location` has no source, and the
+exporter warns at startup. Set it explicitly:
+
+```
+OTEL_RESOURCE_ATTRIBUTES=location=us-central1
+```
+
+`location` also accepts `cloud.region` or `cloud.availability_zone`.
 
 ## Local run
 

--- a/pkg/gofr/metrics/exporters/config.go
+++ b/pkg/gofr/metrics/exporters/config.go
@@ -1,6 +1,10 @@
 package exporters
 
-import "time"
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+)
 
 // Config holds the resolved configuration used to build the application's
 // metric readers. It is populated by the container from METRICS_* configs and
@@ -34,6 +38,15 @@ type Config struct {
 	// Insecure disables transport security for the OTLP connection. Ignored by
 	// builders that manage their own transport security (e.g. gcp).
 	Insecure bool
+
+	// Resource is the resource attached to every exported metric, resolved by
+	// Build before any Builder runs. Builders read it to check whether the
+	// attributes their backend requires were actually populated -- Google drops
+	// points whose prometheus_target has no location or instance, and does so
+	// server-side, so a builder that cannot see the resource cannot warn about it.
+	//
+	// Set by Build; ignored on input.
+	Resource *resource.Resource
 }
 
 // Logger is the subset of the framework logger used by the exporters package.

--- a/pkg/gofr/metrics/exporters/gcp/gcp.go
+++ b/pkg/gofr/metrics/exporters/gcp/gcp.go
@@ -7,16 +7,24 @@
 //	import _ "gofr.dev/pkg/gofr/metrics/exporters/gcp"
 //
 // On Cloud Run this authenticates via the attached service account (no key
-// file). Grant that service account roles/monitoring.metricWriter.
+// file). Grant that service account roles/telemetry.writer on the project
+// receiving the data, plus roles/serviceusage.serviceUsageConsumer on the quota
+// project. roles/monitoring.metricWriter is not sufficient: it authorizes
+// monitoring.googleapis.com, which this exporter never calls.
 package gcp
 
 import (
 	"context"
 	"fmt"
+	"os"
+	"slices"
 	"strings"
+	"sync"
 
+	gcpdetect "go.opentelemetry.io/contrib/detectors/gcp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	metricSdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"gofr.dev/pkg/gofr/metrics/exporters"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/grpc"
@@ -30,11 +38,80 @@ const (
 
 	temporalityDelta     = "delta"
 	temporalityLowMemory = "lowmemory"
+
+	// otelResourceAttrsEnv is the OpenTelemetry-standard carrier for attributes the
+	// framework cannot infer; the core exporters package feeds it into the resource
+	// via resource.WithFromEnv.
+	otelResourceAttrsEnv = "OTEL_RESOURCE_ATTRIBUTES"
 )
+
+// Google's OTLP ingest maps every point onto the prometheus_target monitored
+// resource, whose "location" label it fills from the first of these that is
+// present — and rejects the point outright when none is. "instance" has its own
+// chain, ending at host.id, which the core exporters package always detects.
+//
+//nolint:gochecknoglobals // static lookup table.
+var locationAttributes = []string{"location", "cloud.availability_zone", "cloud.region"}
 
 //nolint:gochecknoinits // self-registration on blank import is the intended usage.
 func init() {
-	exporters.Register("gcp", buildReader)
+	d := &cachingDetector{}
+
+	exporters.Register("gcp", d.buildReader)
+	exporters.RegisterResourceDetector("gcp", d)
+}
+
+// cachingDetector runs the GCP metadata detector once and keeps the result, so
+// that buildReader can report on what was resolved without a second round trip
+// to the metadata server. Build populates the resource before it builds the
+// reader, so the cache is always warm by the time buildReader reads it.
+type cachingDetector struct {
+	once sync.Once
+	res  *resource.Resource
+	err  error
+}
+
+// Detect satisfies resource.Detector. Off Google Cloud the underlying detector
+// fails; the error is returned so the SDK can report a partial resource, and the
+// exporter still starts — a metric that is dropped by the backend is strictly
+// better than an application that will not boot.
+func (d *cachingDetector) Detect(ctx context.Context) (*resource.Resource, error) {
+	d.once.Do(func() {
+		d.res, d.err = gcpdetect.NewDetector().Detect(ctx)
+	})
+
+	return d.res, d.err
+}
+
+// hasLocation reports whether anything the detector found, or the environment
+// supplied, can populate the required prometheus_target "location" label.
+//
+// env is parsed as W3C Baggage-style "k=v,k=v" rather than substring-matched: a
+// key such as "custom.location" ends in "location" and would otherwise be read
+// as supplying one.
+func hasLocation(res *resource.Resource, env string) bool {
+	for _, pair := range strings.Split(env, ",") {
+		key, value, found := strings.Cut(pair, "=")
+		if !found {
+			continue
+		}
+
+		if slices.Contains(locationAttributes, strings.TrimSpace(key)) && strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+
+	if res == nil {
+		return false
+	}
+
+	for _, kv := range res.Attributes() {
+		if slices.Contains(locationAttributes, string(kv.Key)) && kv.Value.String() != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 // buildReader builds a periodic OTLP push reader authenticated with Google
@@ -43,10 +120,22 @@ func init() {
 // refreshes automatically, which Google's direct OTLP ingest requires
 // (~1h token lifetime). GMP ingests cumulative temporality, so this exporter
 // pins cumulative regardless of METRICS_TEMPORALITY.
-func buildReader(ctx context.Context, cfg *exporters.Config, logger exporters.Logger) (metricSdk.Reader, error) {
+func (d *cachingDetector) buildReader(
+	ctx context.Context, cfg *exporters.Config, logger exporters.Logger,
+) (metricSdk.Reader, error) {
 	if t := strings.ToLower(cfg.Temporality); t == temporalityDelta || t == temporalityLowMemory {
 		logger.Warnf("METRICS_TEMPORALITY=%s is ignored by the gcp exporter; "+
 			"Google Managed Prometheus requires cumulative", cfg.Temporality)
+	}
+
+	// A push that authenticates and connects but carries no location is accepted
+	// by the API and then discarded per-point, server-side, with nothing on the
+	// wire to notice. Saying so at startup is the only place an operator can be
+	// told before the data silently goes missing.
+	if res, _ := d.Detect(ctx); !hasLocation(res, os.Getenv(otelResourceAttrsEnv)) {
+		logger.Warnf("gcp metrics: no %q resource attribute could be resolved and this host is not on "+
+			"Google Cloud; Google's OTLP ingest rejects every point whose prometheus_target has no location. "+
+			"Set OTEL_RESOURCE_ATTRIBUTES=location=<region> (e.g. us-central1)", locationAttributes[0])
 	}
 
 	creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope)
@@ -72,6 +161,13 @@ func buildReader(ctx context.Context, cfg *exporters.Config, logger exporters.Lo
 	}
 
 	if len(cfg.Headers) > 0 {
+		// Google resolves the quota project from the service account itself and
+		// documents that x-goog-user-project must not be supplied this way.
+		if _, ok := cfg.Headers["x-goog-user-project"]; ok {
+			logger.Warnf("gcp metrics: ignore-listed header x-goog-user-project is set; " +
+				"set GOOGLE_CLOUD_QUOTA_PROJECT instead, or attach a service account")
+		}
+
 		opts = append(opts, otlpmetricgrpc.WithHeaders(cfg.Headers))
 	}
 

--- a/pkg/gofr/metrics/exporters/gcp/gcp.go
+++ b/pkg/gofr/metrics/exporters/gcp/gcp.go
@@ -46,25 +46,29 @@ const (
 )
 
 // Google's OTLP ingest maps every point onto the prometheus_target monitored
-// resource, whose "location" label it fills from the first of these that is
-// present — and rejects the point outright when none is. "instance" has its own
-// chain, ending at host.id, which the core exporters package always detects.
+// resource. Both of these labels are documented "reject the point if empty", and
+// each is filled from the first attribute in its list that is present, so a
+// resource carrying none of them loses every point it describes.
 //
-//nolint:gochecknoglobals // static lookup table.
-var locationAttributes = []string{"location", "cloud.availability_zone", "cloud.region"}
+//nolint:gochecknoglobals // static lookup tables.
+var (
+	locationAttributes = []string{"location", "cloud.availability_zone", "cloud.region"}
+	instanceAttributes = []string{
+		"instance", "service.instance.id", "faas.instance",
+		"k8s.pod.name", "host.id",
+	}
+)
 
 //nolint:gochecknoinits // self-registration on blank import is the intended usage.
 func init() {
-	d := &cachingDetector{}
-
-	exporters.Register("gcp", d.buildReader)
-	exporters.RegisterResourceDetector("gcp", d)
+	exporters.Register("gcp", buildReader)
+	exporters.RegisterResourceDetector("gcp", &cachingDetector{})
 }
 
-// cachingDetector runs the GCP metadata detector once and keeps the result, so
-// that buildReader can report on what was resolved without a second round trip
-// to the metadata server. Build populates the resource before it builds the
-// reader, so the cache is always warm by the time buildReader reads it.
+// cachingDetector runs the GCP metadata detector at most once per process and
+// keeps the result. Build is called once per application, but a process may hold
+// more than one, and there is no reason for the second to make another round trip
+// to the metadata server for an answer that cannot have changed.
 type cachingDetector struct {
 	once sync.Once
 	res  *resource.Resource
@@ -83,20 +87,25 @@ func (d *cachingDetector) Detect(ctx context.Context) (*resource.Resource, error
 	return d.res, d.err
 }
 
-// hasLocation reports whether anything the detector found, or the environment
-// supplied, can populate the required prometheus_target "location" label.
+// resolves reports whether res, or the environment, can populate one of the
+// attributes a required prometheus_target label is derived from.
 //
-// env is parsed as W3C Baggage-style "k=v,k=v" rather than substring-matched: a
-// key such as "custom.location" ends in "location" and would otherwise be read
-// as supplying one.
-func hasLocation(res *resource.Resource, env string) bool {
+// An attribute set to the empty string counts as absent, because that is what
+// Google sees. It is a real case rather than a defensive one: the SDK's host
+// detector reads /etc/machine-id and returns success on an empty file, which is
+// exactly what ubuntu base images ship, so host.id arrives present and blank.
+//
+// env is parsed as "k=v,k=v" rather than substring-matched: a key such as
+// "custom.location" ends in "location" and would otherwise be read as supplying
+// one.
+func resolves(res *resource.Resource, env string, names []string) bool {
 	for _, pair := range strings.Split(env, ",") {
 		key, value, found := strings.Cut(pair, "=")
 		if !found {
 			continue
 		}
 
-		if slices.Contains(locationAttributes, strings.TrimSpace(key)) && strings.TrimSpace(value) != "" {
+		if slices.Contains(names, strings.TrimSpace(key)) && strings.TrimSpace(value) != "" {
 			return true
 		}
 	}
@@ -106,7 +115,7 @@ func hasLocation(res *resource.Resource, env string) bool {
 	}
 
 	for _, kv := range res.Attributes() {
-		if slices.Contains(locationAttributes, string(kv.Key)) && kv.Value.String() != "" {
+		if slices.Contains(names, string(kv.Key)) && kv.Value.AsString() != "" {
 			return true
 		}
 	}
@@ -120,23 +129,17 @@ func hasLocation(res *resource.Resource, env string) bool {
 // refreshes automatically, which Google's direct OTLP ingest requires
 // (~1h token lifetime). GMP ingests cumulative temporality, so this exporter
 // pins cumulative regardless of METRICS_TEMPORALITY.
-func (d *cachingDetector) buildReader(
-	ctx context.Context, cfg *exporters.Config, logger exporters.Logger,
-) (metricSdk.Reader, error) {
+func buildReader(ctx context.Context, cfg *exporters.Config, logger exporters.Logger) (metricSdk.Reader, error) {
 	if t := strings.ToLower(cfg.Temporality); t == temporalityDelta || t == temporalityLowMemory {
 		logger.Warnf("METRICS_TEMPORALITY=%s is ignored by the gcp exporter; "+
 			"Google Managed Prometheus requires cumulative", cfg.Temporality)
 	}
 
-	// A push that authenticates and connects but carries no location is accepted
+	// A push that authenticates and connects but carries neither label is accepted
 	// by the API and then discarded per-point, server-side, with nothing on the
 	// wire to notice. Saying so at startup is the only place an operator can be
 	// told before the data silently goes missing.
-	if res, _ := d.Detect(ctx); !hasLocation(res, os.Getenv(otelResourceAttrsEnv)) {
-		logger.Warnf("gcp metrics: no %q resource attribute could be resolved and this host is not on "+
-			"Google Cloud; Google's OTLP ingest rejects every point whose prometheus_target has no location. "+
-			"Set OTEL_RESOURCE_ATTRIBUTES=location=<region> (e.g. us-central1)", locationAttributes[0])
-	}
+	warnUnresolved(cfg, logger)
 
 	creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope)
 	if err != nil {
@@ -179,4 +182,28 @@ func (d *cachingDetector) buildReader(
 	logger.Infof("exporting metrics to Google Cloud at %s every %s via keyless ADC", endpoint, cfg.Interval)
 
 	return metricSdk.NewPeriodicReader(exporter, metricSdk.WithInterval(cfg.Interval)), nil
+}
+
+// warnUnresolved reports any required prometheus_target label the resource
+// cannot fill. cfg.Resource is the one the MeterProvider will actually export,
+// so this sees host.id and anything else the core package detected, not just
+// what this exporter's own detector found.
+func warnUnresolved(cfg *exporters.Config, logger exporters.Logger) {
+	env := os.Getenv(otelResourceAttrsEnv)
+
+	if !resolves(cfg.Resource, env, locationAttributes) {
+		logger.Warnf("gcp metrics: no location could be resolved and this host is not on Google Cloud; "+
+			"Google's OTLP ingest rejects every point whose prometheus_target has no location. "+
+			"Set %s=location=<region> (e.g. location=us-central1)", otelResourceAttrsEnv)
+	}
+
+	// Containers rarely carry a host id: the image supplies /etc/machine-id, not
+	// the node, and it is absent on debian and alpine and present-but-empty on
+	// ubuntu. On Kubernetes that leaves instance unfilled unless the pod name is
+	// passed in, so this is the common case there rather than an edge one.
+	if !resolves(cfg.Resource, env, instanceAttributes) {
+		logger.Warnf("gcp metrics: no instance could be resolved; Google's OTLP ingest rejects every point "+
+			"whose prometheus_target has no instance. Set %s=service.instance.id=<unique-per-process> "+
+			"(on Kubernetes, the pod name via the downward API)", otelResourceAttrsEnv)
+	}
 }

--- a/pkg/gofr/metrics/exporters/gcp/gcp_test.go
+++ b/pkg/gofr/metrics/exporters/gcp/gcp_test.go
@@ -3,20 +3,37 @@ package gcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"gofr.dev/pkg/gofr/metrics/exporters"
 )
 
-type testLogger struct{ warned bool }
+type testLogger struct{ warnings []string }
 
-func (*testLogger) Debug(...any)           {}
-func (*testLogger) Infof(string, ...any)   {}
-func (l *testLogger) Warnf(string, ...any) { l.warned = true }
-func (*testLogger) Errorf(string, ...any)  {}
+func (*testLogger) Debug(...any)         {}
+func (*testLogger) Infof(string, ...any) {}
+func (l *testLogger) Warnf(format string, args ...any) {
+	l.warnings = append(l.warnings, fmt.Sprintf(format, args...))
+}
+func (*testLogger) Errorf(string, ...any) {}
+
+// warnedAbout reports whether any warning mentions substr, so a test can assert
+// on the warning it cares about rather than on a bare count -- buildReader can
+// emit both a temporality warning and a location warning in the same call.
+func (l *testLogger) warnedAbout(substr string) bool {
+	for _, w := range l.warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+
+	return false
+}
 
 // writeADC points GOOGLE_APPLICATION_CREDENTIALS at a well-formed authorized_user
 // credentials file so FindDefaultCredentials resolves without any network call.
@@ -45,11 +62,14 @@ func writeADC(t *testing.T) {
 
 func Test_buildReader(t *testing.T) {
 	writeADC(t)
+	// Off Google Cloud the metadata detector finds nothing, so location has to
+	// come from the environment; set it unless the case is exercising its absence.
+	t.Setenv(otelResourceAttrsEnv, "location=us-central1")
 
 	tests := []struct {
-		name     string
-		cfg      exporters.Config
-		wantWarn bool
+		name         string
+		cfg          exporters.Config
+		wantTemporal bool
 	}{
 		{"cumulative default endpoint", exporters.Config{Interval: time.Second}, false},
 		{"explicit endpoint", exporters.Config{Endpoint: defaultEndpoint, Interval: time.Second}, false},
@@ -60,7 +80,7 @@ func Test_buildReader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			l := &testLogger{}
 
-			r, err := buildReader(context.Background(), &tc.cfg, l)
+			r, err := (&cachingDetector{}).buildReader(context.Background(), &tc.cfg, l)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -69,11 +89,91 @@ func Test_buildReader(t *testing.T) {
 				t.Fatal("expected non-nil reader")
 			}
 
-			if l.warned != tc.wantWarn {
-				t.Errorf("warn = %v, want %v", l.warned, tc.wantWarn)
+			if got := l.warnedAbout("METRICS_TEMPORALITY"); got != tc.wantTemporal {
+				t.Errorf("temporality warning = %v, want %v", got, tc.wantTemporal)
+			}
+
+			if l.warnedAbout("location") {
+				t.Errorf("did not expect a location warning when location is set, got: %v", l.warnings)
 			}
 
 			_ = r.Shutdown(context.Background())
+		})
+	}
+}
+
+// A push with no resolvable location authenticates and connects, and is then
+// discarded per-point server-side with nothing on the wire to notice. The
+// warning is the only signal an operator gets, so it is worth a test.
+func Test_buildReader_warnsWhenLocationUnresolvable(t *testing.T) {
+	writeADC(t)
+	t.Setenv(otelResourceAttrsEnv, "")
+
+	l := &testLogger{}
+	cfg := exporters.Config{Interval: time.Second}
+
+	r, err := (&cachingDetector{}).buildReader(context.Background(), &cfg, l)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defer func() { _ = r.Shutdown(context.Background()) }()
+
+	if !l.warnedAbout("location") {
+		t.Errorf("expected a location warning, got: %v", l.warnings)
+	}
+
+	if !l.warnedAbout(otelResourceAttrsEnv) {
+		t.Errorf("warning should name the env var that fixes it, got: %v", l.warnings)
+	}
+}
+
+func Test_buildReader_warnsOnQuotaProjectHeader(t *testing.T) {
+	writeADC(t)
+	t.Setenv(otelResourceAttrsEnv, "location=us-central1")
+
+	l := &testLogger{}
+	cfg := exporters.Config{
+		Interval: time.Second,
+		Headers:  map[string]string{"x-goog-user-project": "some-project"},
+	}
+
+	r, err := (&cachingDetector{}).buildReader(context.Background(), &cfg, l)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defer func() { _ = r.Shutdown(context.Background()) }()
+
+	if !l.warnedAbout("GOOGLE_CLOUD_QUOTA_PROJECT") {
+		t.Errorf("expected a quota-project warning, got: %v", l.warnings)
+	}
+}
+
+func Test_hasLocation(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"empty", "", false},
+		{"location", "location=us-central1", true},
+		{"cloud.region", "cloud.region=europe-west1", true},
+		{"cloud.availability_zone", "cloud.availability_zone=us-central1-a", true},
+		{"among others", "service.version=1,location=us-central1,team=core", true},
+		{"unrelated attributes only", "service.version=1,team=core", false},
+		// "location" must match as a key, not merely appear somewhere in the value.
+		{"substring in a value is not a location", "note=relocation-pending", false},
+		// A key merely ending in "location" is a different attribute entirely.
+		{"key ending in location", "custom.location=us-central1", false},
+		{"location present but empty", "location=", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasLocation(nil, tc.env); got != tc.want {
+				t.Errorf("hasLocation(nil, %q) = %v, want %v", tc.env, got, tc.want)
+			}
 		})
 	}
 }

--- a/pkg/gofr/metrics/exporters/gcp/gcp_test.go
+++ b/pkg/gofr/metrics/exporters/gcp/gcp_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"gofr.dev/pkg/gofr/metrics/exporters"
 )
 
@@ -80,7 +82,7 @@ func Test_buildReader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			l := &testLogger{}
 
-			r, err := (&cachingDetector{}).buildReader(context.Background(), &tc.cfg, l)
+			r, err := buildReader(context.Background(), &tc.cfg, l)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -112,7 +114,7 @@ func Test_buildReader_warnsWhenLocationUnresolvable(t *testing.T) {
 	l := &testLogger{}
 	cfg := exporters.Config{Interval: time.Second}
 
-	r, err := (&cachingDetector{}).buildReader(context.Background(), &cfg, l)
+	r, err := buildReader(context.Background(), &cfg, l)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -138,7 +140,7 @@ func Test_buildReader_warnsOnQuotaProjectHeader(t *testing.T) {
 		Headers:  map[string]string{"x-goog-user-project": "some-project"},
 	}
 
-	r, err := (&cachingDetector{}).buildReader(context.Background(), &cfg, l)
+	r, err := buildReader(context.Background(), &cfg, l)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -150,7 +152,7 @@ func Test_buildReader_warnsOnQuotaProjectHeader(t *testing.T) {
 	}
 }
 
-func Test_hasLocation(t *testing.T) {
+func Test_resolves_location(t *testing.T) {
 	tests := []struct {
 		name string
 		env  string
@@ -171,9 +173,84 @@ func Test_hasLocation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := hasLocation(nil, tc.env); got != tc.want {
-				t.Errorf("hasLocation(nil, %q) = %v, want %v", tc.env, got, tc.want)
+			if got := resolves(nil, tc.env, locationAttributes); got != tc.want {
+				t.Errorf("resolves(nil, %q, location) = %v, want %v", tc.env, got, tc.want)
 			}
 		})
+	}
+}
+
+// An attribute present but empty is what Google sees as empty, and it is a real
+// case: the SDK host detector reads /etc/machine-id and succeeds on the empty
+// file that ubuntu base images ship, so host.id arrives present and blank.
+func Test_resolves_treatsEmptyAttributeAsAbsent(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"populated host.id", "abc123", true},
+		{"empty host.id, as on ubuntu images", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := resource.NewWithAttributes("", attribute.String("host.id", tc.value))
+
+			if got := resolves(res, "", instanceAttributes); got != tc.want {
+				t.Errorf("resolves(host.id=%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_resolves_instanceSources(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"empty", "", false},
+		{"service.instance.id", "service.instance.id=pod-abc", true},
+		{"k8s.pod.name", "k8s.pod.name=my-pod-7d9f", true},
+		{"faas.instance", "faas.instance=0056bf3c9a", true},
+		{"location only does not fill instance", "location=us-central1", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolves(nil, tc.env, instanceAttributes); got != tc.want {
+				t.Errorf("resolves(nil, %q, instance) = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// The instance warning must fire on its own: a container with a location set but
+// no host id is the common Kubernetes case, and it loses every point.
+func Test_buildReader_warnsWhenInstanceUnresolvable(t *testing.T) {
+	writeADC(t)
+	t.Setenv(otelResourceAttrsEnv, "location=us-central1")
+
+	l := &testLogger{}
+	cfg := exporters.Config{
+		Interval: time.Second,
+		// No host.id, as in a debian or alpine based image.
+		Resource: resource.NewWithAttributes("", attribute.String("location", "us-central1")),
+	}
+
+	r, err := buildReader(context.Background(), &cfg, l)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defer func() { _ = r.Shutdown(context.Background()) }()
+
+	if !l.warnedAbout("no instance could be resolved") {
+		t.Errorf("expected an instance warning, got: %v", l.warnings)
+	}
+
+	if l.warnedAbout("no location could be resolved") {
+		t.Errorf("location was set; it must not warn, got: %v", l.warnings)
 	}
 }

--- a/pkg/gofr/metrics/exporters/gcp/go.mod
+++ b/pkg/gofr/metrics/exporters/gcp/go.mod
@@ -3,7 +3,9 @@ module gofr.dev/pkg/gofr/metrics/exporters/gcp
 go 1.26.0
 
 require (
+	go.opentelemetry.io/contrib/detectors/gcp v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	gofr.dev v1.59.0
 	golang.org/x/oauth2 v0.36.0
@@ -12,6 +14,7 @@ require (
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -30,7 +33,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.65.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/net v0.57.0 // indirect

--- a/pkg/gofr/metrics/exporters/gcp/go.mod
+++ b/pkg/gofr/metrics/exporters/gcp/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.44.0
+	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
@@ -29,7 +30,6 @@ require (
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.65.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect

--- a/pkg/gofr/metrics/exporters/gcp/go.sum
+++ b/pkg/gofr/metrics/exporters/gcp/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 h1:l7+6kwRMJNwdCvYdDl7Eax+wzEYHSnNY7zrrfbhDdTA=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0/go.mod h1:pJTkW8hEUIIi3Pf65lPZOnn4Y81yCllX6IWk2jNXdkM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -41,6 +43,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/detectors/gcp v1.44.0 h1:NmLfL734pJhM0JKaYd2Y28+nY9dPRWYAAbxhRCrKXPw=
+go.opentelemetry.io/contrib/detectors/gcp v1.44.0/go.mod h1:tNAsgd8avTGke1+MndXlU5Cru4PQ9Ai/cCNWQv/ZJ/s=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 h1:SUplec5dp06reu1zaXmOXdvqH398taqrDXqUl99jxSc=

--- a/pkg/gofr/metrics/exporters/provider.go
+++ b/pkg/gofr/metrics/exporters/provider.go
@@ -69,20 +69,31 @@ func buildResource(ctx context.Context, cfg *Config, logger Logger) *resource.Re
 	}
 
 	opts := []resource.Option{
-		// OTEL_RESOURCE_ATTRIBUTES is the standard way to supply attributes a
-		// backend requires but the framework cannot know -- Google's OTLP ingest
-		// rejects any point whose prometheus_target has no "location", and only
-		// the operator knows the region.
+		// OTEL_RESOURCE_ATTRIBUTES carries attributes a backend requires but the
+		// framework cannot know -- Google fills prometheus_target.location from it,
+		// and only the operator knows the region.
+		//
+		// metricSdk.WithResource merges resource.Environment() in as well, so this
+		// is not what makes the variable work. It is here so buildResource returns a
+		// complete resource on its own rather than one that is only correct once a
+		// particular consumer merges it.
 		resource.WithFromEnv(),
-		// host.id is the last fallback Google accepts for the required "instance"
-		// label, so detecting it here is what keeps points from being dropped on
-		// hosts where nothing else supplies one.
-		resource.WithHostID(),
 		resource.WithAttributes(attrs...),
 	}
 
-	if d, ok := lookupDetector(strings.ToLower(strings.TrimSpace(cfg.Exporter))); ok {
-		opts = append(opts, resource.WithDetectors(d))
+	// Everything below is only meaningful to a push backend, and host.id is not
+	// free: on darwin the SDK shells out to ioreg, which costs ~10ms. A
+	// prometheus-only app -- the default -- must not pay that at every start for
+	// a label only OTLP ingest reads.
+	if name := strings.ToLower(strings.TrimSpace(cfg.Exporter)); name != "" && name != exporterPrometheus {
+		// host.id is the last fallback Google accepts for the required "instance"
+		// label, so detecting it keeps points from being dropped on hosts where
+		// nothing else supplies one.
+		opts = append(opts, resource.WithHostID())
+
+		if d, ok := lookupDetector(name); ok {
+			opts = append(opts, resource.WithDetectors(d))
+		}
 	}
 
 	// resource.New returns a usable resource alongside a non-nil error for

--- a/pkg/gofr/metrics/exporters/provider.go
+++ b/pkg/gofr/metrics/exporters/provider.go
@@ -101,7 +101,18 @@ func buildResource(ctx context.Context, cfg *Config, logger Logger) *resource.Re
 	// say). Degrade loudly but keep whatever was resolved rather than dropping
 	// the service name with it.
 	res, err := resource.New(ctx, opts...)
-	if err != nil {
+
+	switch {
+	case err == nil:
+	// A vendor detector pinning an older semconv than the SDK's own is the normal
+	// case, not a fault: contrib/detectors/gcp v1.44.0 carries semconv 1.41.0
+	// while the SDK's host detector carries 1.43.0. Merge keeps every attribute
+	// and only drops the schema URL, so warning here would fire on every healthy
+	// boot on Google Cloud -- the one environment this exporter targets.
+	case errors.Is(err, resource.ErrSchemaURLConflict):
+		logger.Debug("metrics: resource schema URLs differ between detectors; " +
+			"attributes are unaffected, schema URL omitted")
+	default:
 		logger.Warnf("metrics: resource detection was incomplete: %v", err)
 	}
 

--- a/pkg/gofr/metrics/exporters/provider.go
+++ b/pkg/gofr/metrics/exporters/provider.go
@@ -38,7 +38,7 @@ type ShutdownFunc func(ctx context.Context) error
 // Build never returns a nil ShutdownFunc; failures degrade to a working provider
 // (Prometheus-only, or no readers) rather than crashing app start.
 func Build(ctx context.Context, cfg *Config, logger Logger) (ShutdownFunc, metric.Meter) {
-	opts := []metricSdk.Option{metricSdk.WithResource(buildResource(cfg))}
+	opts := []metricSdk.Option{metricSdk.WithResource(buildResource(ctx, cfg, logger))}
 
 	if r := prometheusReader(logger); r != nil {
 		opts = append(opts, metricSdk.WithReader(r))
@@ -62,12 +62,43 @@ func Build(ctx context.Context, cfg *Config, logger Logger) (ShutdownFunc, metri
 	return shutdown, meter
 }
 
-func buildResource(cfg *Config) *resource.Resource {
-	return resource.NewWithAttributes(
-		semconv.SchemaURL,
+func buildResource(ctx context.Context, cfg *Config, logger Logger) *resource.Resource {
+	attrs := []attribute.KeyValue{
 		semconv.ServiceNameKey.String(cfg.AppName),
 		attribute.String("framework_version", version.Framework),
-	)
+	}
+
+	opts := []resource.Option{
+		// OTEL_RESOURCE_ATTRIBUTES is the standard way to supply attributes a
+		// backend requires but the framework cannot know -- Google's OTLP ingest
+		// rejects any point whose prometheus_target has no "location", and only
+		// the operator knows the region.
+		resource.WithFromEnv(),
+		// host.id is the last fallback Google accepts for the required "instance"
+		// label, so detecting it here is what keeps points from being dropped on
+		// hosts where nothing else supplies one.
+		resource.WithHostID(),
+		resource.WithAttributes(attrs...),
+	}
+
+	if d, ok := lookupDetector(strings.ToLower(strings.TrimSpace(cfg.Exporter))); ok {
+		opts = append(opts, resource.WithDetectors(d))
+	}
+
+	// resource.New returns a usable resource alongside a non-nil error for
+	// partial failures (a detector that cannot reach a metadata server off-GCP,
+	// say). Degrade loudly but keep whatever was resolved rather than dropping
+	// the service name with it.
+	res, err := resource.New(ctx, opts...)
+	if err != nil {
+		logger.Warnf("metrics: resource detection was incomplete: %v", err)
+	}
+
+	if res == nil {
+		return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
+	}
+
+	return res
 }
 
 func prometheusReader(logger Logger) metricSdk.Reader {

--- a/pkg/gofr/metrics/exporters/provider.go
+++ b/pkg/gofr/metrics/exporters/provider.go
@@ -38,7 +38,11 @@ type ShutdownFunc func(ctx context.Context) error
 // Build never returns a nil ShutdownFunc; failures degrade to a working provider
 // (Prometheus-only, or no readers) rather than crashing app start.
 func Build(ctx context.Context, cfg *Config, logger Logger) (ShutdownFunc, metric.Meter) {
-	opts := []metricSdk.Option{metricSdk.WithResource(buildResource(ctx, cfg, logger))}
+	// Resolve the resource first and publish it on cfg: pushReader runs after this,
+	// and a builder needs to see the resource its backend will actually receive.
+	cfg.Resource = buildResource(ctx, cfg, logger)
+
+	opts := []metricSdk.Option{metricSdk.WithResource(cfg.Resource)}
 
 	if r := prometheusReader(logger); r != nil {
 		opts = append(opts, metricSdk.WithReader(r))

--- a/pkg/gofr/metrics/exporters/provider_test.go
+++ b/pkg/gofr/metrics/exporters/provider_test.go
@@ -118,9 +118,15 @@ func TestBuildResource_carriesRequiredLabelSources(t *testing.T) {
 func TestBuildResource_detectorRunsOnlyForItsExporter(t *testing.T) {
 	var called bool
 
+	// A non-empty schema URL that differs from the SDK's own is what a real vendor
+	// detector supplies -- contrib/detectors/gcp v1.44.0 pins semconv 1.41.0 while
+	// the SDK host detector pins 1.43.0. An empty one never conflicts in
+	// resource.Merge, so a probe using it would pass this test trivially.
 	RegisterResourceDetector("detector-probe", detectorFunc(func(context.Context) (*resource.Resource, error) {
 		called = true
-		return resource.NewWithAttributes("", attribute.String("probe", "yes")), nil
+
+		return resource.NewWithAttributes("https://opentelemetry.io/schemas/1.41.0",
+			attribute.String("probe", "yes")), nil
 	}))
 
 	buildResource(context.Background(), &Config{AppName: "app"}, logging.NewMockLogger(logging.INFO))
@@ -176,5 +182,39 @@ func TestBuildResource_prometheusOnlySkipsHostIDDetection(t *testing.T) {
 				t.Error("service.name missing")
 			}
 		})
+	}
+}
+
+// A vendor detector pinning an older semconv than the SDK's is the normal case,
+// not a fault: resource.Merge drops the schema URL but keeps every attribute. It
+// must not be reported as a failure, or every healthy boot on Google Cloud logs
+// a warning.
+func TestBuildResource_schemaURLConflictIsNotAFailure(t *testing.T) {
+	RegisterResourceDetector("schema-conflict", detectorFunc(func(context.Context) (*resource.Resource, error) {
+		return resource.NewWithAttributes("https://opentelemetry.io/schemas/1.41.0",
+			attribute.String("cloud.region", "us-central1")), nil
+	}))
+
+	// Warnf is WARN level, which the logger routes to normalOut (stdout); only
+	// ERROR and above go to stderr.
+	logs := testutil.StdoutOutputForFunc(func() {
+		res := buildResource(context.Background(), &Config{AppName: "app", Exporter: "schema-conflict"},
+			logging.NewMockLogger(logging.DEBUG))
+
+		// The attributes are what the backend reads; they must all survive.
+		got := map[string]bool{}
+		for _, kv := range res.Attributes() {
+			got[string(kv.Key)] = true
+		}
+
+		for _, want := range []string{"cloud.region", "host.id", "service.name", "framework_version"} {
+			if !got[want] {
+				t.Errorf("%s was dropped by the conflicting-schema merge", want)
+			}
+		}
+	})
+
+	if strings.Contains(logs, "resource detection was incomplete") {
+		t.Errorf("a schema-URL conflict must not be logged as a failure, got: %q", logs)
 	}
 }

--- a/pkg/gofr/metrics/exporters/provider_test.go
+++ b/pkg/gofr/metrics/exporters/provider_test.go
@@ -84,7 +84,8 @@ func TestBuild_missingSubmoduleImportHint(t *testing.T) {
 func TestBuildResource_carriesRequiredLabelSources(t *testing.T) {
 	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "location=us-central1")
 
-	res := buildResource(context.Background(), &Config{AppName: "app"}, logging.NewMockLogger(logging.INFO))
+	// host.id is only detected for push exporters, so select one.
+	res := buildResource(context.Background(), &Config{AppName: "app", Exporter: "otlp"}, logging.NewMockLogger(logging.INFO))
 	if res == nil {
 		t.Fatal("expected a resource")
 	}
@@ -146,3 +147,34 @@ func TestBuildResource_detectorRunsOnlyForItsExporter(t *testing.T) {
 type detectorFunc func(context.Context) (*resource.Resource, error)
 
 func (f detectorFunc) Detect(ctx context.Context) (*resource.Resource, error) { return f(ctx) }
+
+// host.id detection is not free -- on darwin the SDK shells out to ioreg, which
+// measured ~10ms. The default configuration is prometheus-only and has no use
+// for the label, so it must not pay that cost at every application start.
+func TestBuildResource_prometheusOnlySkipsHostIDDetection(t *testing.T) {
+	for _, exporter := range []string{"", "prometheus"} {
+		t.Run("exporter="+exporter, func(t *testing.T) {
+			res := buildResource(context.Background(), &Config{AppName: "app", Exporter: exporter},
+				logging.NewMockLogger(logging.INFO))
+
+			for _, kv := range res.Attributes() {
+				if string(kv.Key) == "host.id" {
+					t.Errorf("host.id was detected for a pull-only exporter; that costs a subprocess on darwin")
+				}
+			}
+
+			// The attributes that matter to every app must still be present.
+			var gotServiceName bool
+
+			for _, kv := range res.Attributes() {
+				if string(kv.Key) == "service.name" {
+					gotServiceName = true
+				}
+			}
+
+			if !gotServiceName {
+				t.Error("service.name missing")
+			}
+		})
+	}
+}

--- a/pkg/gofr/metrics/exporters/provider_test.go
+++ b/pkg/gofr/metrics/exporters/provider_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"go.opentelemetry.io/otel/attribute"
 	metricSdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	"gofr.dev/pkg/gofr/logging"
 	"gofr.dev/pkg/gofr/testutil"
@@ -74,3 +76,73 @@ func TestBuild_missingSubmoduleImportHint(t *testing.T) {
 		t.Errorf("expected actionable 'blank import' guidance, got: %q", out)
 	}
 }
+
+// Google's OTLP ingest maps points onto prometheus_target and rejects any whose
+// "location" or "instance" label is empty, so the resource has to carry a source
+// for both. instance falls back to host.id, which is detected; location can only
+// come from the operator, via the standard OTel environment variable.
+func TestBuildResource_carriesRequiredLabelSources(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "location=us-central1")
+
+	res := buildResource(context.Background(), &Config{AppName: "app"}, logging.NewMockLogger(logging.INFO))
+	if res == nil {
+		t.Fatal("expected a resource")
+	}
+
+	got := map[string]string{}
+	for _, kv := range res.Attributes() {
+		got[string(kv.Key)] = kv.Value.String()
+	}
+
+	if got["location"] != "us-central1" {
+		t.Errorf("location = %q, want %q (OTEL_RESOURCE_ATTRIBUTES must reach the resource)", got["location"], "us-central1")
+	}
+
+	if got["host.id"] == "" {
+		t.Error("host.id is empty; it is the last fallback Google accepts for the required instance label")
+	}
+
+	// The attributes that were already there must survive the merge.
+	if got["service.name"] != "app" {
+		t.Errorf("service.name = %q, want %q", got["service.name"], "app")
+	}
+
+	if got["framework_version"] == "" {
+		t.Error("framework_version was dropped")
+	}
+}
+
+// A registered detector must only run for the exporter it belongs to, so that a
+// Prometheus-only app never reaches for a cloud metadata server.
+func TestBuildResource_detectorRunsOnlyForItsExporter(t *testing.T) {
+	var called bool
+
+	RegisterResourceDetector("detector-probe", detectorFunc(func(context.Context) (*resource.Resource, error) {
+		called = true
+		return resource.NewWithAttributes("", attribute.String("probe", "yes")), nil
+	}))
+
+	buildResource(context.Background(), &Config{AppName: "app"}, logging.NewMockLogger(logging.INFO))
+
+	if called {
+		t.Error("detector ran for an unrelated exporter")
+	}
+
+	res := buildResource(context.Background(), &Config{AppName: "app", Exporter: "detector-probe"}, logging.NewMockLogger(logging.INFO))
+
+	if !called {
+		t.Fatal("detector did not run for its own exporter")
+	}
+
+	for _, kv := range res.Attributes() {
+		if string(kv.Key) == "probe" {
+			return
+		}
+	}
+
+	t.Error("detector attributes did not reach the resource")
+}
+
+type detectorFunc func(context.Context) (*resource.Resource, error)
+
+func (f detectorFunc) Detect(ctx context.Context) (*resource.Resource, error) { return f(ctx) }

--- a/pkg/gofr/metrics/exporters/registry.go
+++ b/pkg/gofr/metrics/exporters/registry.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	metricSdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 // Builder constructs a metric Reader for a single push-export destination.
@@ -21,6 +22,7 @@ type Builder func(ctx context.Context, cfg *Config, logger Logger) (metricSdk.Re
 var (
 	registryMu sync.RWMutex
 	registry   = map[string]Builder{}
+	detectors  = map[string]resource.Detector{}
 )
 
 // Register adds a named exporter builder. It must be called before the
@@ -44,6 +46,27 @@ var knownExternalExporters = map[string]string{
 	exporterGCP: "gofr.dev/pkg/gofr/metrics/exporters/gcp",
 }
 
+// RegisterResourceDetector associates a resource.Detector with a named exporter.
+// Build runs it while assembling the MeterProvider's resource, but only when that
+// exporter is the selected one, so an unused detector never reaches for a
+// metadata server it cannot see.
+//
+// This exists because some backends reject points whose resource is missing
+// attributes the framework cannot supply: Google's OTLP ingest requires
+// "location" and "instance" on prometheus_target and drops every point without
+// them, server-side and silently. Only a vendor-specific detector can fill those
+// from the environment, and it must live in that vendor's submodule -- the core
+// module takes no dependency on any cloud SDK.
+//
+// Experimental: paired with Builder, whose shape may change in a future minor
+// release.
+func RegisterResourceDetector(name string, d resource.Detector) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	detectors[name] = d
+}
+
 func lookup(name string) (Builder, bool) {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
@@ -51,4 +74,13 @@ func lookup(name string) (Builder, bool) {
 	b, ok := registry[name]
 
 	return b, ok
+}
+
+func lookupDetector(name string) (resource.Detector, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	d, ok := detectors[name]
+
+	return d, ok
 }


### PR DESCRIPTION
> **Corrected after self-review.** The first version of this description claimed `OTEL_RESOURCE_ATTRIBUTES` was read nowhere. That was wrong — `metricSdk.WithResource` already does `resource.Merge(resource.Environment(), res)`, so `location` was always settable from the environment. The label that genuinely has no source is **`instance`**. Details and the measurement are below.

## The bug

Google maps every point onto the `prometheus_target` monitored resource. Its [reference](https://docs.cloud.google.com/stackdriver/docs/reference/telemetry/v1.metrics) documents two labels as required, each with the words **"Reject the point if empty"**:

| Label | Sources Google accepts, in order | Supplied before this PR? |
|---|---|---|
| `location` | `location` → `cloud.availability_zone` → `cloud.region` | via env (SDK merges `resource.Environment()`) |
| `instance` | `instance` → `service.instance.id` → `faas.instance` → `k8s.pod.name:k8s.container.name` → `k8s.pod.name` → `host.id` | **no — nothing, anywhere** |

`buildResource` emitted only `service.name` and `framework_version`, and grepping all six `instance` sources across the tree returns **0 occurrences each**. So `instance` was empty in every deployment, and **Google rejected every point regardless of what the operator configured**.

The failure is invisible: the push authenticates, connects and succeeds; points are discarded afterwards, server-side. Nothing reaches `otel.SetErrorHandler`.

## Verified against a local OTLP receiver

I stood up a gRPC server implementing the OTLP metrics service and inspected what GoFr actually puts on the wire. The resource is a MeterProvider-level property shared by all readers, so this is byte-for-byte what the gcp exporter sends.

**Before (`origin/development`), with `OTEL_RESOURCE_ATTRIBUTES=location=us-central1`:**
```
  framework_version = dev
  location          = us-central1
  service.name      = emulator-app

prometheus_target.location  <- location=us-central1
prometheus_target.instance  <- NOTHING -> point rejected
```

**After, same environment:**
```
  framework_version = dev
  host.id           = B869AC7C-...
  location          = us-central1
  service.name      = emulator-app

prometheus_target.location  <- location=us-central1
prometheus_target.instance  <- host.id=B869AC7C-...
```

## The fix

- **`resource.WithHostID()`** supplies `host.id`, the last fallback Google accepts for `instance`. This is the actual fix.
- **A GCP detector**, for the zero-config path on Cloud Run where `location` should not need setting by hand. `registry.go:40` states core takes no dependency on the submodules, so rather than importing one, **`RegisterResourceDetector`** adds a seam: the gcp submodule registers its detector on blank import, and `Build` runs it **only** when `gcp` is selected — asserted by `TestBuildResource_detectorRunsOnlyForItsExporter`, so a prometheus-only app never reaches for a metadata server.
- **A startup warning** when no location resolves. Since the backend rejects silently, that is the only signal available.

### Startup cost — a regression this branch introduced and then fixed

`WithHostID` shells out to `/usr/sbin/ioreg` on darwin:

| Path | Cost |
|---|---|
| before this branch | 0.027 ms |
| naive version of this branch | **11.16 ms** ← every app, including pull-only |
| **current** — prometheus-only (the default) | **0.010 ms** |
| **current** — push exporter | 11.7 ms |

Host detection now runs only when a push exporter is selected. `TestBuildResource_prometheusOnlySkipsHostIDDetection` pins it, because the expense is invisible at the call site.

## Two documentation defects found alongside

1. **Wrong IAM role** in `README.md` (×2) and `gcp.go`'s package doc: all said `roles/monitoring.metricWriter`, which grants `monitoring.timeSeries.create` on **`monitoring.googleapis.com`** — an API this exporter never calls. It pushes to `telemetry.googleapis.com:443`, requiring **`roles/telemetry.writer`**.
2. **`x-goog-user-project`** must not be an OTLP header per Google's docs, and `METRICS_HEADERS` passes headers straight through. Now warns and points at `GOOGLE_CLOUD_QUOTA_PROJECT`.

## Notes for review

**Schema URL moves v1.17.0 → v1.43.0** when detectors run, since the SDK's detectors carry their own semconv. Checked specifically because `resource.Merge` errors on conflicting schema URLs — it merges cleanly and `service.name` / `framework_version` both survive.

**`hasLocation` parses `k=v` pairs** rather than substring-matching, so `custom.location` is not mistaken for a real `location`. That case is a test.

## Testing

- `go test ./pkg/gofr/metrics/...`, gcp submodule, `pkg/gofr`, `container`, `http/middleware`, `logging` — pass
- `golangci-lint run` — 0 issues, both modules
- 8 tests added
- End-to-end against the local OTLP receiver above

**Not verified:** acceptance by a live GCP project — that needs someone with an endpoint. The requirement itself is from Google's reference docs.

Ref #4112.