### PR TITLE
chore(deps): bump golang base image 1.26 -> 1.27 in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir -p /go/src/gofr.dev
 WORKDIR /go/src/gofr.dev

--- a/examples/http-server-using-redis/Dockerfile
+++ b/examples/http-server-using-redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-add-rest-handlers/Dockerfile
+++ b/examples/using-add-rest-handlers/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-custom-metrics/Dockerfile
+++ b/examples/using-custom-metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-file-bind/Dockerfile
+++ b/examples/using-file-bind/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-http-service/Dockerfile
+++ b/examples/using-http-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-migrations/Dockerfile
+++ b/examples/using-migrations/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-publisher/Dockerfile
+++ b/examples/using-publisher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-subscriber/Dockerfile
+++ b/examples/using-subscriber/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/


### PR DESCRIPTION
## Consolidated Dependabot Update (Docker)

Bumps the `golang` base image from `1.26` to `1.27` across all 9 Dockerfiles (root + 8 examples). Mechanical `FROM` bump only — can't go through `go get`, so it's split from the go-module consolidation.

Closes #4116.