### PR TITLE
chore(deps): bump crate-ci/typos 1.49.0 -> 1.50.0

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v7
       - name: typos-action
-        uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0
+        uses: crate-ci/typos@4d9c206a77c041268485162b8e2579ad7a5cb9a3 # v1.50.0


### PR DESCRIPTION
## Consolidated Dependabot Update (GitHub Action)

Bumps `crate-ci/typos` from `1.49.0` to `1.50.0` (SHA-pinned) in `.github/workflows/typos.yml`.

Closes #4114.