### PR TITLE
Release/v1.60.1

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v7
       - name: typos-action
-        uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0
+        uses: crate-ci/typos@4d9c206a77c041268485162b8e2579ad7a5cb9a3 # v1.50.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir -p /go/src/gofr.dev
 WORKDIR /go/src/gofr.dev

--- a/docs/references/configs/page.md
+++ b/docs/references/configs/page.md
@@ -104,6 +104,11 @@ This document lists all the configuration options supported by the GoFr framewor
 
 ---
 
+-  OTEL_RESOURCE_ATTRIBUTES
+-  Standard OpenTelemetry resource attributes, comma-separated key=value. Merged into the resource attached to every exported metric. Required for the gcp exporter outside Google Cloud: its ingest rejects any point whose prometheus_target has no location (e.g. "location=us-central1").
+
+---
+
 -  HTTP_PORT
 -  Port on which the HTTP server listens
 -  8000

--- a/examples/http-server-using-redis/Dockerfile
+++ b/examples/http-server-using-redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-add-rest-handlers/Dockerfile
+++ b/examples/using-add-rest-handlers/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-custom-metrics/Dockerfile
+++ b/examples/using-custom-metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-file-bind/Dockerfile
+++ b/examples/using-file-bind/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-gcp-metrics/README.md
+++ b/examples/using-gcp-metrics/README.md
@@ -29,13 +29,25 @@ GMP requires.
 
 ## Deploy to Cloud Run (keyless)
 
-1. Grant the service's runtime service account permission to write metrics:
+1. Grant the service's runtime service account permission to write telemetry:
 
    ```bash
    gcloud projects add-iam-policy-binding <PROJECT_ID> \
      --member="serviceAccount:<RUNTIME_SA>@<PROJECT_ID>.iam.gserviceaccount.com" \
-     --role="roles/monitoring.metricWriter"
+     --role="roles/telemetry.writer"
    ```
+
+   `roles/telemetry.writer` is the role for `telemetry.googleapis.com`, which is
+   what this exporter pushes to. `roles/monitoring.metricWriter` grants
+   `monitoring.timeSeries.create` on `monitoring.googleapis.com` — a different
+   API that this exporter never calls — so granting it alone leaves the push
+   unauthorized.
+
+   With a service account attached, the quota project is resolved automatically.
+   If you authenticate with **user** credentials instead, also grant
+   `roles/serviceusage.serviceUsageConsumer` on the quota project and set
+   `GOOGLE_CLOUD_QUOTA_PROJECT`. Do not pass `x-goog-user-project` as a metrics
+   header; Google documents that this is not the supported route.
 
 2. Deploy — no credentials mounted, no `GOOGLE_APPLICATION_CREDENTIALS`:
 
@@ -46,10 +58,60 @@ GMP requires.
 3. On Cloud Run the app resolves ADC from the metadata server automatically.
    Metrics appear in Cloud Monitoring / Managed Service for Prometheus.
 
-> Cross-project GMP: grant `roles/monitoring.metricWriter` on the **destination**
+> Cross-project GMP: grant `roles/telemetry.writer` on the **destination**
 > project. No Workload Identity Federation is needed on Cloud Run itself — the
 > attached service account is sufficient. WIF only applies to workloads running
 > outside Google Cloud.
+
+## Required resource labels
+
+Google maps every point onto the `prometheus_target` monitored resource, which
+requires a **`location`** and an **`instance`**, and *rejects the point* when
+either is empty. A push that is missing them still authenticates and still
+succeeds — the points are discarded afterwards, server-side, so nothing on the
+client says the data went nowhere.
+
+On Google Cloud both are detected for you: the metadata server supplies the
+region/zone, and `host.id` backs `instance`.
+
+Anywhere else — local runs, other clouds, CI — `location` has no source, and the
+exporter warns at startup. Set it explicitly:
+
+```
+OTEL_RESOURCE_ATTRIBUTES=location=us-central1
+```
+
+`location` also accepts `cloud.region` or `cloud.availability_zone`.
+
+`instance` is filled from `host.id`, which GoFr detects automatically. **In a
+container it usually cannot be.** The OpenTelemetry SDK reads `/etc/machine-id`
+and `/var/lib/dbus/machine-id` from the container's own filesystem, and those come
+from the image, not from the node — nothing bind-mounts the host's copy in. So:
+
+| Base image | `/etc/machine-id` | `host.id` |
+|---|---|---|
+| `debian:12-slim`, `alpine` | absent | not detected |
+| `ubuntu:24.04` | present, **empty** | detected but blank |
+
+Either way `instance` has no source and every point is dropped, so on Kubernetes
+supply one explicitly. The pod name is unique per replica and available from the
+downward API:
+
+```yaml
+env:
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: location=us-central1,service.instance.id=$(POD_NAME)
+```
+
+`instance` also accepts `k8s.pod.name`. Cloud Run needs none of this: the GCP
+detector supplies `faas.instance` per revision instance, and the region for
+`location`, so both labels resolve with no configuration.
+
+The exporter warns separately at startup for whichever of the two is missing.
 
 ## Local run
 

--- a/examples/using-http-service/Dockerfile
+++ b/examples/using-http-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-migrations/Dockerfile
+++ b/examples/using-migrations/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-publisher/Dockerfile
+++ b/examples/using-publisher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/examples/using-subscriber/Dockerfile
+++ b/examples/using-subscriber/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.27
 
 RUN mkdir /src/
 WORKDIR /src/

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -405,17 +405,26 @@ func (a *App) AddStaticFiles(endpoint, filePath string) {
 
 	a.httpRegistered = true
 
+	// Normalize the endpoint up front so every error log below reports the same
+	// '/endpoint' form (previously the getwd and os.Stat logs disagreed).
+	endpoint = "/" + strings.TrimPrefix(endpoint, "/")
+
 	if !strings.HasPrefix(filePath, "./") && !filepath.IsAbs(filePath) {
 		filePath = "./" + filePath
 	}
 
 	// update file path based on current directory if it starts with ./
 	if strings.HasPrefix(filePath, "./") {
-		currentWorkingDir, _ := os.Getwd()
+		currentWorkingDir, err := os.Getwd()
+		if err != nil {
+			a.container.Logger.Errorf("error in registering '%s' static endpoint, "+
+				"failed to get current working directory: %v", endpoint, err)
+
+			return
+		}
+
 		filePath = filepath.Join(currentWorkingDir, filePath)
 	}
-
-	endpoint = "/" + strings.TrimPrefix(endpoint, "/")
 
 	if _, err := os.Stat(filePath); err != nil {
 		a.container.Logger.Errorf("error in registering '%s' static endpoint, error: %v", endpoint, err)

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -1299,6 +1299,36 @@ func TestStaticHandlerInvalidFilePath(t *testing.T) {
 	assert.Contains(t, logs, "error in registering '/gofrTest' static endpoint")
 }
 
+func TestStaticHandlerGetwdError(t *testing.T) {
+	testutil.NewServerConfigs(t)
+
+	// Switch into a temporary directory and remove it so that os.Getwd()
+	// inside AddStaticFiles fails when resolving the relative "./" path.
+	// t.Chdir restores the original working directory at test cleanup.
+	tmpDir := t.TempDir()
+
+	t.Chdir(tmpDir)
+
+	require.NoError(t, os.Remove(tmpDir))
+
+	// On some platforms (e.g. macOS) the kernel still resolves the path of an
+	// unlinked working directory, so os.Getwd() does not fail. Skip there since
+	// the error branch cannot be exercised.
+	if _, err := os.Getwd(); err == nil {
+		t.Skip("os.Getwd() does not fail for a removed working directory on this platform")
+	}
+
+	// The app (and its logger) must be created inside StderrOutputForFunc so the
+	// logger writes to the captured stderr rather than the real one.
+	logs := testutil.StderrOutputForFunc(func() {
+		app := New()
+		app.AddStaticFiles("gofrTest", "./somedir")
+	})
+
+	assert.Contains(t, logs, "failed to get current working directory")
+	assert.Contains(t, logs, "error in registering '/gofrTest' static endpoint")
+}
+
 func TestNewSetsHTTPRegisteredWhenStaticDirExists(t *testing.T) {
 	testutil.NewServerConfigs(t)
 

--- a/pkg/gofr/http/middleware/routecache.go
+++ b/pkg/gofr/http/middleware/routecache.go
@@ -1,0 +1,101 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// routeCacheLimit caps the number of entries any per-route cache in this package
+// will hold.
+//
+// With cacheableMethod filtering the method half of the key, the reachable key
+// space is (standard methods x registered routes), which is fixed at startup —
+// so this cap is a backstop for a pathologically large route table, not the
+// primary bound. It is a backstop that matters: the primary bound is an argument
+// about reachability, and an argument is a weaker thing to rest process memory on
+// than a number.
+const routeCacheLimit = 4096
+
+// cacheableMethod reports whether method may be used as part of a cache key.
+//
+// This is the load-bearing half of every per-route cache's bound, and it exists
+// because the "only bounded route templates are cached" claim does not survive
+// contact with a real GoFr app. gofr.go registers a PathPrefix("/") catch-all, so
+// mux.CurrentRoute is set for EVERY request and GetPathTemplate() returns "/"
+// even for a path no route matched — the templated guard is therefore true
+// always, and the route half of the key is not the bound it looks like.
+//
+// The method half is worse, because it is not drawn from a fixed set at all:
+// net/http accepts any RFC 7230 token as a method, so an unauthenticated client
+// streaming M00001, M00002, ... mints a permanent cache entry per request and
+// grows resident memory without bound. Restricting the key to methods that are
+// actually defined turns "methods x routes" back into the fixed quantity the
+// caches were designed around.
+//
+// A request with a non-standard method still works — its per-route data is built
+// fresh, exactly as it was before any cache existed. It just never persists.
+func cacheableMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+// routeKey identifies a (method, route-template) pair.
+type routeKey struct {
+	method, route string
+}
+
+// routeCache is a bounded, concurrent cache keyed on routeKey.
+//
+// Reads stay on sync.Map's lock-free path. Writes stop at routeCacheLimit rather
+// than evicting: the entries are pure functions of their key and are all equally
+// valid forever, so there is no staleness to evict for, and refusing to grow is
+// both cheaper and easier to reason about than an eviction policy. Past the cap
+// the affected requests rebuild their data per request — the optimization stops
+// applying, but memory is flat and behavior is unchanged.
+type routeCache struct {
+	entries sync.Map
+	count   atomic.Int64
+}
+
+// load returns the cached value for key, if present.
+func (c *routeCache) load(key routeKey) (any, bool) {
+	return c.entries.Load(key)
+}
+
+// store caches value under key unless the cache is already at its limit.
+//
+// The count is advisory: concurrent stores can race past the cap by the number of
+// goroutines in flight, which is bounded and harmless. What matters is that the
+// cache cannot grow without limit.
+func (c *routeCache) store(key routeKey, value any) {
+	if c.count.Load() >= routeCacheLimit {
+		return
+	}
+
+	if _, loaded := c.entries.LoadOrStore(key, value); !loaded {
+		c.count.Add(1)
+	}
+}
+
+// len reports the number of cached entries. Test-only.
+func (c *routeCache) len() int64 {
+	return c.count.Load()
+}
+
+// reset empties the cache. Test-only: the package-level caches are process-wide,
+// so a test that asserts on size has to start from a known state.
+func (c *routeCache) reset() {
+	c.entries.Range(func(k, _ any) bool {
+		c.entries.Delete(k)
+
+		return true
+	})
+	c.count.Store(0)
+}

--- a/pkg/gofr/http/middleware/tracer.go
+++ b/pkg/gofr/http/middleware/tracer.go
@@ -1,13 +1,12 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
+	"net/textproto"
 	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
 	gofrhttp "gofr.dev/pkg/gofr/http"
@@ -30,17 +29,178 @@ func methodKV(method string) attribute.KeyValue {
 	return attribute.String("http.request.method", method)
 }
 
-// routeTemplate returns the matched route template (e.g. "/users/{id}") for
-// the request, otherwise the raw URL path. Used for the span name and
-// http.route attribute so tracing cardinality stays bounded by route count,
-// not request count. gofrhttp.RouteTemplate resolves the template under both
-// the trie and the default mux router.
-func routeTemplate(r *http.Request) string {
+// buildSpanName renders the OTel HTTP semconv span name ("GET /users/{id}").
+//
+// Concatenation rather than fmt.Sprintf. Both cost the one unavoidable
+// allocation for the result string, so this is a CPU saving only, not an
+// allocation saving: Sprintf walks a format string and boxes two arguments that
+// are already strings.
+//
+// No before/after figure is quoted here: the fmt.Sprintf baseline it would be
+// measured against is gone, so nothing in the tree can reproduce one.
+func buildSpanName(method, route string) string {
+	return method + " " + route
+}
+
+// routeTemplate returns the matched route template (e.g. "/users/{id}") for the request, otherwise
+// the raw URL path. Used for the span name and http.route attribute so tracing cardinality stays
+// bounded by route count, not request count.
+//
+// The bool reports whether a template was resolved, which is what makes the span-name cache safe:
+// only a templated route may be cached, since a raw path is unbounded and would grow the cache once
+// per distinct request. gofrhttp.RouteTemplate resolves the template under both the trie and the
+// default mux router.
+func routeTemplate(r *http.Request) (route string, templated bool) {
 	if t := gofrhttp.RouteTemplate(r); t != "" {
-		return t
+		return t, true
 	}
 
-	return r.URL.Path
+	return r.URL.Path, false
+}
+
+// spanMeta is the immutable per-route span data: the semconv span name and the
+// start options carrying its attributes. Both are pure functions of (method,
+// route), so they are provider-independent and safe to share process wide even
+// across TracerProvider replacement.
+type spanMeta struct {
+	name string
+	// startOpts is the fully built []trace.SpanStartOption handed to Start.
+	// trace.WithAttributes allocates an option wrapper AND the variadic option
+	// slice on every call, so caching the attribute slice alone still left two
+	// allocations per request. The option is immutable once constructed, so it
+	// is safe to share.
+	startOpts []trace.SpanStartOption
+}
+
+// tracerSpanCache maps routeKey -> *spanMeta.
+//
+// Keyed on the ROUTE TEMPLATE ("/users/{id}"), never a concrete path. That alone
+// was once believed to bound it by routes x methods, but neither half of that
+// product is bounded by itself in a real GoFr app -- see cacheableMethod, and
+// routeCache for the cap that backs the argument up.
+//
+// It is package level because the middleware chain is rebuilt around the matched
+// handler on every request, so a cache owned by the closure would be discarded
+// each time and never serve a second request.
+//
+//nolint:gochecknoglobals // rationale above: a per-closure cache would never be reused.
+var tracerSpanCache routeCache
+
+// spanMetaFor returns the span name and attributes for a route, building them on
+// first use.
+//
+// templated reports whether route came from a matched route template; when false
+// the value is a raw request path and must not enter the cache. That guard is
+// necessary but NOT sufficient -- GoFr's catch-all makes it true for every
+// request, including ones no route matched -- so the method is filtered too, and
+// the cache itself is capped. An entry that cannot be cached is simply rebuilt,
+// which is what every request did before this cache existed.
+func spanMetaFor(method, route string, templated bool) *spanMeta {
+	if !templated || !cacheableMethod(method) {
+		return newSpanMeta(method, route)
+	}
+
+	key := routeKey{method: method, route: route}
+
+	// A failed assertion falls through to the rebuild below rather than returning
+	// the nil it would otherwise produce. Nothing else stores into this cache, so
+	// it cannot fail today; ignoring the result would turn any future change that
+	// broke that into a nil dereference on the request path.
+	if v, ok := tracerSpanCache.load(key); ok {
+		if meta, ok := v.(*spanMeta); ok {
+			return meta
+		}
+	}
+
+	meta := newSpanMeta(method, route)
+	tracerSpanCache.store(key, meta)
+
+	return meta
+}
+
+func newSpanMeta(method, route string) *spanMeta {
+	attrs := []attribute.KeyValue{
+		methodKV(method),
+		attribute.String("http.route", route),
+	}
+
+	return &spanMeta{
+		name:      buildSpanName(method, route),
+		startOpts: []trace.SpanStartOption{trace.WithAttributes(attrs...)},
+	}
+}
+
+// The lowercase header names the W3C propagators look up. They are the keys the
+// propagators pass to the carrier, not the spellings that go on the wire.
+const (
+	headerTraceparent = "traceparent"
+	headerTracestate  = "tracestate"
+	headerBaggage     = "baggage"
+)
+
+// canonicalPropagationKeys maps the lowercase header names the W3C propagators
+// look up to their canonical spellings.
+//
+// http.Header.Get canonicalizes whatever key it is handed, and none of these
+// names is already canonical, so each lookup allocated the canonical string --
+// on every request, whether or not the header was even present. The spellings
+// are constants, so they are resolved once here.
+//
+//nolint:gochecknoglobals // immutable, process-wide header constants.
+var canonicalPropagationKeys = map[string]string{
+	headerTraceparent: textproto.CanonicalMIMEHeaderKey(headerTraceparent),
+	headerTracestate:  textproto.CanonicalMIMEHeaderKey(headerTracestate),
+	headerBaggage:     textproto.CanonicalMIMEHeaderKey(headerBaggage),
+}
+
+// headerCarrier adapts http.Header for the OTel propagators without paying to
+// canonicalize the lookup key on every request.
+//
+// A key it does not recognize falls through to the ordinary lookup, so a custom
+// propagator using its own header names keeps working unchanged.
+type headerCarrier http.Header
+
+func (c headerCarrier) Get(key string) string {
+	canonical, ok := canonicalPropagationKeys[key]
+	if !ok {
+		return http.Header(c).Get(key)
+	}
+
+	if v := c[canonical]; len(v) > 0 {
+		return v[0]
+	}
+
+	return ""
+}
+
+func (c headerCarrier) Set(key, value string) { http.Header(c).Set(key, value) }
+
+// Values returns every value for key, satisfying propagation.ValuesGetter.
+//
+// Not optional. propagation.Baggage.Extract type-asserts the carrier to
+// ValuesGetter and, when it matches, combines ALL values of the Baggage header;
+// the stdlib propagation.HeaderCarrier this type replaces satisfies it. Without
+// this method the assertion fails and Extract silently falls back to the
+// single-value Get, dropping every baggage member after the first whenever a
+// request carries more than one Baggage header -- which is legal per W3C and is
+// what proxies and service meshes commonly emit. GoFr installs
+// propagation.Baggage in its default composite propagator, so that path is live.
+//
+// Measured against the stdlib carrier with three Baggage headers: stdlib
+// extracted 3 members, this carrier extracted 1 before the method existed.
+//
+// The canonical-key fast path is deliberately not used here. Baggage is not one
+// of the keys canonicalPropagationKeys covers, and a carrier that replaces a
+// stdlib one has to be a faithful drop-in first and an optimization second.
+func (c headerCarrier) Values(key string) []string { return http.Header(c).Values(key) }
+
+func (c headerCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+
+	return keys
 }
 
 // Tracer is a middleware that starts a new OpenTelemetry trace span for each
@@ -69,45 +229,56 @@ func Tracer(inner http.Handler) http.Handler {
 		// extract the traceID and spanID from the headers and create a new context for the same
 		// this context will make a new span using the traceID and link the incoming SpanID as
 		// its parentID, thus connecting two spans
-		ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(r.Header))
+		ctx = otel.GetTextMapPropagator().Extract(ctx, headerCarrier(r.Header))
 
 		method := strings.ToUpper(r.Method)
 		// Prefer the gorilla/mux route template (e.g. "/users/{id}") so the
 		// span name and http.route attribute do not explode to one unique
 		// value per concrete path (e.g. "/users/42"). Fall back to URL.Path
 		// when no route matched (404 / unknown route).
-		route := routeTemplate(r)
-		spanName := fmt.Sprintf("%s %s", method, route)
+		route, templated := routeTemplate(r)
+		meta := spanMetaFor(method, route, templated)
 
-		ctxOut, span := tr.Start(ctx, spanName, trace.WithAttributes(
-			methodKV(method),
-			attribute.String("http.route", route),
-		))
+		// The attribute slice is passed to Start, not applied afterwards: a
+		// sampler can read attributes when deciding, so moving them after the
+		// span exists would change sampling for anyone sampling on http.route.
+		ctxOut, span := tr.Start(ctx, meta.name, meta.startOpts...)
 		defer span.End()
 
-		// http.response.status_code is set after the handler returns via
-		// the StatusResponseWriter wrap shared with Logging.
-
-		// Capture the response status via a StatusResponseWriter. Reuse an
-		// existing wrap if some outer middleware already provided one;
-		// otherwise wrap locally.
+		// The response status is only ever read to put it on the span, so the
+		// writer is only wrapped when the span will keep it.
 		//
-		// In GoFr's default chain Tracer is registered FIRST, i.e. outermost,
-		// so nothing has wrapped w yet and the local wrap is what actually
-		// happens on every request — Logging then wraps this one in turn.
-		srw, ok := w.(*StatusResponseWriter)
-		if !ok {
-			srw = &StatusResponseWriter{ResponseWriter: w}
-			w = srw
-		}
+		// Tracer is the outermost middleware, so the wrapper Logging installs
+		// does not exist yet and this type assertion always failed -- meaning a
+		// StatusResponseWriter was allocated on every request and, on the
+		// default deployment, never read. GoFr installs an SDK provider with
+		// NeverSample when no TRACE_EXPORTER is configured, so no span records.
+		//
+		// Recording spans are unaffected: they still get the wrapper and the
+		// attribute, pinned by TestTracerStatusAttributeStillRecorded.
+		//
+		// The cost of this is that the ResponseWriter reaching the next middleware
+		// now depends on whether the span records. GoFr's own chain is unaffected --
+		// Logging wraps immediately after and Metrics reuses that wrapper -- but a
+		// user middleware inserted between Tracer and Logging that type-asserts
+		// *StatusResponseWriter will see it on a sampled request and not on an
+		// unsampled one. That is a hard bug to find from the symptom, so it is worth
+		// knowing before inserting anything at that position.
+		if span.IsRecording() {
+			srw, ok := w.(*StatusResponseWriter)
+			if !ok {
+				srw = &StatusResponseWriter{ResponseWriter: w}
+				w = srw
+			}
 
-		// rw.Status() normalizes the zero-default to http.StatusOK when the
-		// handler called neither WriteHeader nor Write — net/http emits an
-		// implicit 200 in that case, so the span attribute must report 200
-		// rather than be omitted (or worse, recorded as 0).
-		defer func(s trace.Span, rw *StatusResponseWriter) {
-			s.SetAttributes(attribute.Int("http.response.status_code", rw.Status()))
-		}(span, srw)
+			// Status() normalizes the zero-default to http.StatusOK when the
+			// handler called neither WriteHeader nor Write -- net/http emits an
+			// implicit 200 in that case, so the span attribute must report 200
+			// rather than be omitted, or worse recorded as 0.
+			defer func(s trace.Span, rw *StatusResponseWriter) {
+				s.SetAttributes(attribute.Int("http.response.status_code", rw.Status()))
+			}(span, srw)
+		}
 
 		inner.ServeHTTP(w, r.WithContext(ctxOut))
 	})

--- a/pkg/gofr/http/middleware/tracer_test.go
+++ b/pkg/gofr/http/middleware/tracer_test.go
@@ -5,7 +5,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -16,9 +19,11 @@ import (
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	otelTrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"gofr.dev/pkg/gofr/version"
 )
@@ -316,7 +321,538 @@ func TestTracer_EmitsOTelHTTPSemconvAttributes(t *testing.T) {
 	assert.Equal(t, int64(http.StatusCreated), attrs[attribute.Key("http.response.status_code")].AsInt64())
 }
 
-// ---------------------------------------------------------------------------
+// TestBuildSpanName pins the OTel HTTP semconv span-name format. The
+// construction changes; the content must not.
+func TestBuildSpanName(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		route  string
+		want   string
+	}{
+		{"templated route", http.MethodGet, "/users/{id}", "GET /users/{id}"},
+		{"root", http.MethodPost, "/", "POST /"},
+		{"unmatched falls back to path", http.MethodDelete, "/nope/deeper", "DELETE /nope/deeper"},
+		{"empty route", http.MethodGet, "", "GET "},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, buildSpanName(tc.method, tc.route))
+		})
+	}
+}
+
+// spanNameSink defeats dead-code elimination: without a consumed result the
+// compiler may delete the very call being measured, and the benchmark then
+// reports the cost of nothing.
+//
+//nolint:gochecknoglobals // standard Go benchmarking idiom; a local would be optimized away.
+var spanNameSink string
+
+// TestBuildSpanNameAllocs pins the win. fmt.Sprintf costs 3 allocations per
+// request (the result string plus two boxed interface arguments); plain
+// concatenation costs exactly the one unavoidable result string.
+func TestBuildSpanNameAllocs(t *testing.T) {
+	method, route := http.MethodGet, "/users/{id}"
+
+	got := testing.AllocsPerRun(1000, func() {
+		spanNameSink = buildSpanName(method, route)
+	})
+
+	require.LessOrEqual(t, got, 1.0,
+		"span name must cost at most the one unavoidable result-string allocation")
+}
+
+// TestTracerSpanNameEndToEnd proves the span actually emitted through the
+// middleware still carries the route-template name, not a concrete path.
+func TestTracerSpanNameEndToEnd(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(trace.NewTracerProvider(trace.WithSyncer(exporter)))
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/users/{id}").
+		HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	router.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/users/42", http.NoBody))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	require.Equal(t, "GET /users/{id}", spans[0].Name)
+
+	var route string
+
+	for _, a := range spans[0].Attributes {
+		if a.Key == "http.route" {
+			route = a.Value.AsString()
+		}
+	}
+
+	require.Equal(t, "/users/{id}", route, "http.route must stay the template, not the concrete path")
+}
+
+// BenchmarkBuildSpanName is the before/after evidence for this change.
+func BenchmarkBuildSpanName(b *testing.B) {
+	method, route := http.MethodGet, "/users/{id}"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		spanNameSink = buildSpanName(method, route)
+	}
+}
+
+// TestTracerStatusAttributeStillRecorded is the guard against "optimizing" by
+// silently dropping telemetry: a sampled span must still carry the status code.
+func TestTracerStatusAttributeStillRecorded(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(trace.NewTracerProvider(trace.WithSyncer(exporter)))
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/teapot").
+		HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusTeapot) })
+
+	router.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/teapot", http.NoBody))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+
+	var found bool
+
+	for _, a := range spans[0].Attributes {
+		if a.Key == "http.response.status_code" {
+			require.Equal(t, int64(http.StatusTeapot), a.Value.AsInt64())
+
+			found = true
+		}
+	}
+
+	require.True(t, found, "a sampled span must still record http.response.status_code")
+}
+
+// TestTracerImplicit200StillRecorded pins the normalization PR #3431 established:
+// a handler that never calls WriteHeader still reports 200, not 0.
+func TestTracerImplicit200StillRecorded(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(trace.NewTracerProvider(trace.WithSyncer(exporter)))
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/silent").
+		HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+
+	router.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/silent", http.NoBody))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+
+	for _, a := range spans[0].Attributes {
+		if a.Key == "http.response.status_code" {
+			require.Equal(t, int64(http.StatusOK), a.Value.AsInt64())
+		}
+	}
+}
+
+// TestSpanMetaCacheIsBounded is the safety property for the cache: a route
+// template must produce ONE entry no matter how many concrete paths hit it, and
+// an unmatched (attacker-controlled) path must produce none at all.
+func TestSpanMetaCacheIsBounded(t *testing.T) {
+	tracerSpanCache.reset()
+
+	for i := range 500 {
+		spanMetaFor(http.MethodGet, "/users/{id}", true)
+		spanMetaFor(http.MethodGet, "/attacker/"+strconv.Itoa(i), false)
+	}
+
+	require.Equal(t, int64(1), tracerSpanCache.len(),
+		"one template must yield one entry, and unmatched paths must never be cached")
+}
+
+// TestSpanMetaCacheRejectsUndefinedMethods is the regression test for a
+// remotely-triggerable unbounded-memory DoS.
+//
+// The cache's safety argument was "only bounded route templates are cached", and
+// that argument was dead in a real GoFr app. gofr.go registers a
+// PathPrefix("/") catch-all, so mux.CurrentRoute is set for every request and
+// GetPathTemplate() returns "/" even for a path nothing matched -- making the
+// templated guard true always. net/http then accepts any RFC 7230 token as a
+// method, so an unauthenticated client streaming M00001, M00002, ... minted a
+// permanent *spanMeta each and grew resident memory without bound. The
+// pre-cache fmt.Sprintf path retained no state at all, so this was introduced
+// by the cache, not inherited.
+func TestSpanMetaCacheRejectsUndefinedMethods(t *testing.T) {
+	tracerSpanCache.reset()
+
+	// The exact attack: distinct made-up methods against the catch-all template.
+	for i := range 5000 {
+		spanMetaFor("M"+strconv.Itoa(i), "/", true)
+	}
+
+	require.Zero(t, tracerSpanCache.len(),
+		"an undefined method must never mint a cache entry")
+
+	// The requests still work -- they just rebuild, as every request did before
+	// the cache existed.
+	meta := spanMetaFor("M00001", "/", true)
+	require.Equal(t, "M00001 /", meta.name)
+}
+
+// TestSpanMetaCacheStillCachesStandardMethods pins that the method filter did
+// not break the optimization it protects.
+func TestSpanMetaCacheStillCachesStandardMethods(t *testing.T) {
+	tracerSpanCache.reset()
+
+	for _, m := range []string{
+		http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace,
+	} {
+		first := spanMetaFor(m, "/users/{id}", true)
+		require.Same(t, first, spanMetaFor(m, "/users/{id}", true),
+			"a standard method must still be served from the cache")
+	}
+
+	require.Equal(t, int64(9), tracerSpanCache.len())
+}
+
+// TestRouteCacheStopsAtItsLimit pins the backstop. The method filter is the
+// primary bound, but it is an argument about reachability; the cap is a number,
+// and process memory should rest on the number too.
+func TestRouteCacheStopsAtItsLimit(t *testing.T) {
+	var c routeCache
+
+	for i := range routeCacheLimit + 500 {
+		c.store(routeKey{method: http.MethodGet, route: "/r/" + strconv.Itoa(i)}, i)
+	}
+
+	require.Equal(t, int64(routeCacheLimit), c.len(),
+		"the cache must refuse to grow past its limit")
+
+	// Past the cap, a miss is a miss -- the caller rebuilds rather than erroring.
+	_, ok := c.load(routeKey{method: http.MethodGet, route: "/r/" + strconv.Itoa(routeCacheLimit+100)})
+	require.False(t, ok)
+}
+
+// TestTracerNonRecordingPathSkipsTheWriterWrapper covers the branch this PR
+// optimizes, which had no test at all: with a non-recording provider the
+// StatusResponseWriter must not be allocated, and the handler must see the
+// writer the server handed in.
+func TestTracerNonRecordingPathSkipsTheWriterWrapper(t *testing.T) {
+	otel.SetTracerProvider(noop.NewTracerProvider())
+
+	var got http.ResponseWriter
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/x").
+		HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { got = w })
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody))
+
+	require.NotNil(t, got)
+	assert.IsType(t, &httptest.ResponseRecorder{}, got,
+		"a non-recording span must not pay for the status-capturing wrapper")
+}
+
+// TestSpanMetaContentIsCorrect pins that caching did not change what is emitted.
+func TestSpanMetaContentIsCorrect(t *testing.T) {
+	meta := spanMetaFor(http.MethodPost, "/orders/{id}", true)
+
+	require.Equal(t, "POST /orders/{id}", meta.name)
+
+	// Read the attributes back the way the SDK does, by resolving the start
+	// options, rather than from a field the middleware itself never consults.
+	cfg := otelTrace.NewSpanStartConfig(meta.startOpts...)
+	attrs := cfg.Attributes()
+	require.Len(t, attrs, 2)
+	require.Equal(t, attribute.Key("http.request.method"), attrs[0].Key)
+	require.Equal(t, "POST", attrs[0].Value.AsString())
+	require.Equal(t, attribute.Key("http.route"), attrs[1].Key)
+	require.Equal(t, "/orders/{id}", attrs[1].Value.AsString())
+
+	// A second call must return the identical cached instance.
+	require.Same(t, meta, spanMetaFor(http.MethodPost, "/orders/{id}", true))
+}
+
+// TestSpanMetaConcurrent runs the cache under contention; the race detector is
+// the point of this test.
+func TestSpanMetaConcurrent(t *testing.T) {
+	var (
+		wg  sync.WaitGroup
+		bad atomic.Int64
+	)
+
+	// require calls FailNow, which must only run on the test goroutine, so the
+	// workers record failures and the assertion happens after Wait.
+	for g := range 16 {
+		wg.Add(1)
+
+		go func(g int) {
+			defer wg.Done()
+
+			for range 100 {
+				m := spanMetaFor(http.MethodGet, "/c/"+strconv.Itoa(g%4)+"/{id}", true)
+				if m == nil || m.name == "" {
+					bad.Add(1)
+
+					continue
+				}
+
+				cfg := otelTrace.NewSpanStartConfig(m.startOpts...)
+				if len(cfg.Attributes()) != 2 {
+					bad.Add(1)
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	require.Zero(t, bad.Load(), "cache returned an incomplete spanMeta under contention")
+}
+
+// TestHeaderCarrierMatchesHeaderCarrier pins that the carrier resolves exactly
+// what propagation.HeaderCarrier resolves, for the propagation headers and for
+// an unrecognized key that must fall through to the ordinary lookup.
+func TestHeaderCarrierMatchesHeaderCarrier(t *testing.T) {
+	h := http.Header{}
+	// Set with the canonical spellings; the carrier is still queried with the
+	// lowercase names the propagators actually use, which is the point.
+	h.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+	h.Set("Tracestate", "vendor=value")
+	h.Set("Baggage", "k=v")
+	h.Set("X-Custom-Propagator", "custom")
+
+	ours := headerCarrier(h)
+	theirs := propagation.HeaderCarrier(h)
+
+	for _, key := range []string{"traceparent", "tracestate", "baggage", "X-Custom-Propagator", "absent"} {
+		require.Equal(t, theirs.Get(key), ours.Get(key), "key %q must resolve identically", key)
+	}
+
+	require.ElementsMatch(t, theirs.Keys(), ours.Keys())
+}
+
+// TestTracerPropagatesIncomingTraceContext is the feature guard: an incoming
+// traceparent must still be adopted as the parent of the server span.
+func TestTracerPropagatesIncomingTraceContext(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(trace.NewTracerProvider(trace.WithSyncer(exporter)))
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	// Both globals are restored. Without this the recording provider and the
+	// Baggage-less propagator leak into every later test and benchmark in the
+	// package -- tests run before benchmarks, so BenchmarkTracer would measure
+	// the RECORDING path while documenting the non-recording one, and feed this
+	// exporter for the rest of the run.
+	t.Cleanup(func() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{}, propagation.Baggage{}))
+	})
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/x").
+		HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody)
+	req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	require.Equal(t, w3cFixtureTraceID, spans[0].SpanContext.TraceID().String(),
+		"the incoming trace ID must be adopted")
+	require.Equal(t, w3cFixtureParentSpan, spans[0].Parent.SpanID().String(),
+		"the incoming span must become the parent")
+}
+
+// tracerBenchWriter keeps a header map and discards the rest, so the benchmark measures the
+// middleware rather than a recorder.
+type tracerBenchWriter struct{ h http.Header }
+
+func (w *tracerBenchWriter) Header() http.Header       { return w.h }
+func (*tracerBenchWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (*tracerBenchWriter) WriteHeader(int)             {}
+
+// BenchmarkTracer measures the tracing middleware on the path every request takes.
+//
+// The default provider is non-recording, which is the common production case for a service that
+// samples: the span is still started on every request, so whatever the middleware builds up front is
+// paid for whether or not anything records it. Allocations are the metric that matters.
+func BenchmarkTracer(b *testing.B) {
+	// Pin the non-recording provider this benchmark is about. Package state is
+	// shared and tests run first, so inheriting whatever a previous test left
+	// installed would silently measure the recording path instead.
+	otel.SetTracerProvider(noop.NewTracerProvider())
+
+	b.Cleanup(func() { otel.SetTracerProvider(noop.NewTracerProvider()) })
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/users/{id}").
+		Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/users/42", http.NoBody)
+	w := &tracerBenchWriter{h: make(http.Header, 4)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		clear(w.h)
+		router.ServeHTTP(w, req)
+	}
+}
+
+// BenchmarkTracer_Recording is the case the per-route cache targets: a provider that actually
+// records, so the span name and attributes built by the middleware are used rather than discarded.
+//
+// BenchmarkTracer above covers the opposite case, a non-recording provider, because a sampling
+// service runs both and the middleware must not be quietly worse in either.
+func BenchmarkTracer_Recording(b *testing.B) {
+	tp := trace.NewTracerProvider(
+		trace.WithResource(resource.Empty()),
+		trace.WithSampler(trace.AlwaysSample()),
+	)
+	otel.SetTracerProvider(tp)
+
+	b.Cleanup(func() { otel.SetTracerProvider(noop.NewTracerProvider()) })
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/users/{id}").
+		Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/users/42", http.NoBody)
+	w := &tracerBenchWriter{h: make(http.Header, 4)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		clear(w.h)
+		router.ServeHTTP(w, req)
+	}
+}
+
+// TestHeaderCarrierIsAFaithfulValuesGetter is the regression test for silent
+// baggage loss.
+//
+// headerCarrier replaces propagation.HeaderCarrier to avoid canonicalizing the
+// lookup key on every request. The stdlib type it replaces satisfies
+// propagation.ValuesGetter, and propagation.Baggage.Extract type-asserts to that
+// interface to combine ALL values of the Baggage header. Implementing only
+// Get/Set/Keys failed the assertion, so Extract fell back to the single-value Get
+// and dropped every baggage member after the first -- silently, and only when a
+// request carried more than one Baggage header, which is legal per W3C and is
+// what proxies and service meshes commonly emit.
+//
+// The pre-existing equivalence test only compared Get and Keys, so it could not
+// catch this.
+func TestHeaderCarrierIsAFaithfulValuesGetter(t *testing.T) {
+	require.Implements(t, (*propagation.ValuesGetter)(nil), headerCarrier{},
+		"a carrier replacing propagation.HeaderCarrier must satisfy every interface it does")
+
+	tests := []struct {
+		name    string
+		values  []string
+		wantLen int
+	}{
+		{"multiple Baggage headers", []string{"k1=v1", "k2=v2", "k3=v3"}, 3},
+		{"two Baggage headers", []string{"a=1", "b=2"}, 2},
+		{"single header carrying several members", []string{"a=1,b=2"}, 2},
+		{"single header single member", []string{"only=1"}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.Header{}
+			for _, v := range tt.values {
+				h.Add("Baggage", v)
+			}
+
+			prop := propagation.Baggage{}
+
+			std := baggage.FromContext(prop.Extract(t.Context(), propagation.HeaderCarrier(h)))
+			got := baggage.FromContext(prop.Extract(t.Context(), headerCarrier(h)))
+
+			require.Len(t, std.Members(), tt.wantLen, "sanity: the stdlib carrier must see every member")
+			assert.Len(t, got.Members(), tt.wantLen,
+				"headerCarrier must extract exactly what the stdlib carrier does")
+
+			// Compare member-by-member, since Baggage.String() ordering is not stable.
+			for _, m := range std.Members() {
+				assert.Equal(t, m.Value(), got.Member(m.Key()).Value(),
+					"member %q must survive extraction", m.Key())
+			}
+		})
+	}
+}
+
+// TestHeaderCarrierValuesMatchesStdlib pins Values itself across the key shapes
+// the propagators actually use, including the canonicalization fast path.
+func TestHeaderCarrierValuesMatchesStdlib(t *testing.T) {
+	h := http.Header{}
+	h.Add("Baggage", "a=1")
+	h.Add("Baggage", "b=2")
+	h.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+	h.Add("X-Custom", "one")
+	h.Add("X-Custom", "two")
+
+	for _, key := range []string{headerBaggage, headerTraceparent, headerTracestate, "x-custom", "absent"} {
+		assert.Equal(t, propagation.HeaderCarrier(h).Values(key), headerCarrier(h).Values(key),
+			"Values(%q) must match the stdlib carrier", key)
+	}
+}
+
+// BenchmarkTracer_WithPropagationHeaders is the variant that actually exercises
+// headerCarrier.
+//
+// BenchmarkTracer and BenchmarkTracer_Recording send a bare request, so the
+// propagators find nothing and the canonicalization this PR avoids never runs --
+// their alloc delta comes from the per-route cache and the IsRecording gate
+// alone. A request carrying traceparent/tracestate/baggage is what a service
+// behind a mesh or an upstream GoFr service actually receives, and it is the only
+// shape where the carrier's saving is visible.
+func BenchmarkTracer_WithPropagationHeaders(b *testing.B) {
+	otel.SetTracerProvider(noop.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{}, propagation.Baggage{}))
+
+	b.Cleanup(func() { otel.SetTracerProvider(noop.NewTracerProvider()) })
+
+	router := mux.NewRouter()
+	router.Use(Tracer)
+	router.NewRoute().Methods(http.MethodGet).Path("/users/{id}").
+		Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	req := httptest.NewRequestWithContext(b.Context(), http.MethodGet, "/users/42", http.NoBody)
+	req.Header.Set("Traceparent", "00-"+w3cFixtureTraceID+"-"+w3cFixtureParentSpan+"-01")
+	req.Header.Set("Tracestate", "vendor=value")
+	req.Header.Add("Baggage", "tenant=acme")
+	req.Header.Add("Baggage", "region=eu")
+
+	w := &tracerBenchWriter{h: make(http.Header, 4)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		clear(w.h)
+		router.ServeHTTP(w, req)
+	}
+}
+
 // Characterization suite for the Tracer HTTP middleware.
 //
 // Every identifier below is prefixed with `tracerChar` so this file can be

--- a/pkg/gofr/metrics/exporters/config.go
+++ b/pkg/gofr/metrics/exporters/config.go
@@ -1,6 +1,10 @@
 package exporters
 
-import "time"
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+)
 
 // Config holds the resolved configuration used to build the application's
 // metric readers. It is populated by the container from METRICS_* configs and
@@ -34,6 +38,15 @@ type Config struct {
 	// Insecure disables transport security for the OTLP connection. Ignored by
 	// builders that manage their own transport security (e.g. gcp).
 	Insecure bool
+
+	// Resource is the resource attached to every exported metric, resolved by
+	// Build before any Builder runs. Builders read it to check whether the
+	// attributes their backend requires were actually populated -- Google drops
+	// points whose prometheus_target has no location or instance, and does so
+	// server-side, so a builder that cannot see the resource cannot warn about it.
+	//
+	// Set by Build; ignored on input.
+	Resource *resource.Resource
 }
 
 // Logger is the subset of the framework logger used by the exporters package.

--- a/pkg/gofr/metrics/exporters/gcp/gcp.go
+++ b/pkg/gofr/metrics/exporters/gcp/gcp.go
@@ -7,16 +7,24 @@
 //	import _ "gofr.dev/pkg/gofr/metrics/exporters/gcp"
 //
 // On Cloud Run this authenticates via the attached service account (no key
-// file). Grant that service account roles/monitoring.metricWriter.
+// file). Grant that service account roles/telemetry.writer on the project
+// receiving the data, plus roles/serviceusage.serviceUsageConsumer on the quota
+// project. roles/monitoring.metricWriter is not sufficient: it authorizes
+// monitoring.googleapis.com, which this exporter never calls.
 package gcp
 
 import (
 	"context"
 	"fmt"
+	"os"
+	"slices"
 	"strings"
+	"sync"
 
+	gcpdetect "go.opentelemetry.io/contrib/detectors/gcp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	metricSdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"gofr.dev/pkg/gofr/metrics/exporters"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/grpc"
@@ -30,11 +38,89 @@ const (
 
 	temporalityDelta     = "delta"
 	temporalityLowMemory = "lowmemory"
+
+	// otelResourceAttrsEnv is the OpenTelemetry-standard carrier for attributes the
+	// framework cannot infer; the core exporters package feeds it into the resource
+	// via resource.WithFromEnv.
+	otelResourceAttrsEnv = "OTEL_RESOURCE_ATTRIBUTES"
+)
+
+// Google's OTLP ingest maps every point onto the prometheus_target monitored
+// resource. Both of these labels are documented "reject the point if empty", and
+// each is filled from the first attribute in its list that is present, so a
+// resource carrying none of them loses every point it describes.
+//
+//nolint:gochecknoglobals // static lookup tables.
+var (
+	locationAttributes = []string{"location", "cloud.availability_zone", "cloud.region"}
+	instanceAttributes = []string{
+		"instance", "service.instance.id", "faas.instance",
+		"k8s.pod.name", "host.id",
+	}
 )
 
 //nolint:gochecknoinits // self-registration on blank import is the intended usage.
 func init() {
 	exporters.Register("gcp", buildReader)
+	exporters.RegisterResourceDetector("gcp", &cachingDetector{})
+}
+
+// cachingDetector runs the GCP metadata detector at most once per process and
+// keeps the result. Build is called once per application, but a process may hold
+// more than one, and there is no reason for the second to make another round trip
+// to the metadata server for an answer that cannot have changed.
+type cachingDetector struct {
+	once sync.Once
+	res  *resource.Resource
+	err  error
+}
+
+// Detect satisfies resource.Detector. Off Google Cloud the underlying detector
+// fails; the error is returned so the SDK can report a partial resource, and the
+// exporter still starts — a metric that is dropped by the backend is strictly
+// better than an application that will not boot.
+func (d *cachingDetector) Detect(ctx context.Context) (*resource.Resource, error) {
+	d.once.Do(func() {
+		d.res, d.err = gcpdetect.NewDetector().Detect(ctx)
+	})
+
+	return d.res, d.err
+}
+
+// resolves reports whether res, or the environment, can populate one of the
+// attributes a required prometheus_target label is derived from.
+//
+// An attribute set to the empty string counts as absent, because that is what
+// Google sees. It is a real case rather than a defensive one: the SDK's host
+// detector reads /etc/machine-id and returns success on an empty file, which is
+// exactly what ubuntu base images ship, so host.id arrives present and blank.
+//
+// env is parsed as "k=v,k=v" rather than substring-matched: a key such as
+// "custom.location" ends in "location" and would otherwise be read as supplying
+// one.
+func resolves(res *resource.Resource, env string, names []string) bool {
+	for _, pair := range strings.Split(env, ",") {
+		key, value, found := strings.Cut(pair, "=")
+		if !found {
+			continue
+		}
+
+		if slices.Contains(names, strings.TrimSpace(key)) && strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+
+	if res == nil {
+		return false
+	}
+
+	for _, kv := range res.Attributes() {
+		if slices.Contains(names, string(kv.Key)) && kv.Value.AsString() != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 // buildReader builds a periodic OTLP push reader authenticated with Google
@@ -48,6 +134,12 @@ func buildReader(ctx context.Context, cfg *exporters.Config, logger exporters.Lo
 		logger.Warnf("METRICS_TEMPORALITY=%s is ignored by the gcp exporter; "+
 			"Google Managed Prometheus requires cumulative", cfg.Temporality)
 	}
+
+	// A push that authenticates and connects but carries neither label is accepted
+	// by the API and then discarded per-point, server-side, with nothing on the
+	// wire to notice. Saying so at startup is the only place an operator can be
+	// told before the data silently goes missing.
+	warnUnresolved(cfg, logger)
 
 	creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope)
 	if err != nil {
@@ -72,6 +164,13 @@ func buildReader(ctx context.Context, cfg *exporters.Config, logger exporters.Lo
 	}
 
 	if len(cfg.Headers) > 0 {
+		// Google resolves the quota project from the service account itself and
+		// documents that x-goog-user-project must not be supplied this way.
+		if _, ok := cfg.Headers["x-goog-user-project"]; ok {
+			logger.Warnf("gcp metrics: ignore-listed header x-goog-user-project is set; " +
+				"set GOOGLE_CLOUD_QUOTA_PROJECT instead, or attach a service account")
+		}
+
 		opts = append(opts, otlpmetricgrpc.WithHeaders(cfg.Headers))
 	}
 
@@ -83,4 +182,28 @@ func buildReader(ctx context.Context, cfg *exporters.Config, logger exporters.Lo
 	logger.Infof("exporting metrics to Google Cloud at %s every %s via keyless ADC", endpoint, cfg.Interval)
 
 	return metricSdk.NewPeriodicReader(exporter, metricSdk.WithInterval(cfg.Interval)), nil
+}
+
+// warnUnresolved reports any required prometheus_target label the resource
+// cannot fill. cfg.Resource is the one the MeterProvider will actually export,
+// so this sees host.id and anything else the core package detected, not just
+// what this exporter's own detector found.
+func warnUnresolved(cfg *exporters.Config, logger exporters.Logger) {
+	env := os.Getenv(otelResourceAttrsEnv)
+
+	if !resolves(cfg.Resource, env, locationAttributes) {
+		logger.Warnf("gcp metrics: no location could be resolved and this host is not on Google Cloud; "+
+			"Google's OTLP ingest rejects every point whose prometheus_target has no location. "+
+			"Set %s=location=<region> (e.g. location=us-central1)", otelResourceAttrsEnv)
+	}
+
+	// Containers rarely carry a host id: the image supplies /etc/machine-id, not
+	// the node, and it is absent on debian and alpine and present-but-empty on
+	// ubuntu. On Kubernetes that leaves instance unfilled unless the pod name is
+	// passed in, so this is the common case there rather than an edge one.
+	if !resolves(cfg.Resource, env, instanceAttributes) {
+		logger.Warnf("gcp metrics: no instance could be resolved; Google's OTLP ingest rejects every point "+
+			"whose prometheus_target has no instance. Set %s=service.instance.id=<unique-per-process> "+
+			"(on Kubernetes, the pod name via the downward API)", otelResourceAttrsEnv)
+	}
 }

--- a/pkg/gofr/metrics/exporters/gcp/gcp_test.go
+++ b/pkg/gofr/metrics/exporters/gcp/gcp_test.go
@@ -3,20 +3,39 @@ package gcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"gofr.dev/pkg/gofr/metrics/exporters"
 )
 
-type testLogger struct{ warned bool }
+type testLogger struct{ warnings []string }
 
-func (*testLogger) Debug(...any)           {}
-func (*testLogger) Infof(string, ...any)   {}
-func (l *testLogger) Warnf(string, ...any) { l.warned = true }
-func (*testLogger) Errorf(string, ...any)  {}
+func (*testLogger) Debug(...any)         {}
+func (*testLogger) Infof(string, ...any) {}
+func (l *testLogger) Warnf(format string, args ...any) {
+	l.warnings = append(l.warnings, fmt.Sprintf(format, args...))
+}
+func (*testLogger) Errorf(string, ...any) {}
+
+// warnedAbout reports whether any warning mentions substr, so a test can assert
+// on the warning it cares about rather than on a bare count -- buildReader can
+// emit both a temporality warning and a location warning in the same call.
+func (l *testLogger) warnedAbout(substr string) bool {
+	for _, w := range l.warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+
+	return false
+}
 
 // writeADC points GOOGLE_APPLICATION_CREDENTIALS at a well-formed authorized_user
 // credentials file so FindDefaultCredentials resolves without any network call.
@@ -45,11 +64,14 @@ func writeADC(t *testing.T) {
 
 func Test_buildReader(t *testing.T) {
 	writeADC(t)
+	// Off Google Cloud the metadata detector finds nothing, so location has to
+	// come from the environment; set it unless the case is exercising its absence.
+	t.Setenv(otelResourceAttrsEnv, "location=us-central1")
 
 	tests := []struct {
-		name     string
-		cfg      exporters.Config
-		wantWarn bool
+		name         string
+		cfg          exporters.Config
+		wantTemporal bool
 	}{
 		{"cumulative default endpoint", exporters.Config{Interval: time.Second}, false},
 		{"explicit endpoint", exporters.Config{Endpoint: defaultEndpoint, Interval: time.Second}, false},
@@ -69,11 +91,166 @@ func Test_buildReader(t *testing.T) {
 				t.Fatal("expected non-nil reader")
 			}
 
-			if l.warned != tc.wantWarn {
-				t.Errorf("warn = %v, want %v", l.warned, tc.wantWarn)
+			if got := l.warnedAbout("METRICS_TEMPORALITY"); got != tc.wantTemporal {
+				t.Errorf("temporality warning = %v, want %v", got, tc.wantTemporal)
+			}
+
+			if l.warnedAbout("location") {
+				t.Errorf("did not expect a location warning when location is set, got: %v", l.warnings)
 			}
 
 			_ = r.Shutdown(context.Background())
 		})
+	}
+}
+
+// A push with no resolvable location authenticates and connects, and is then
+// discarded per-point server-side with nothing on the wire to notice. The
+// warning is the only signal an operator gets, so it is worth a test.
+func Test_buildReader_warnsWhenLocationUnresolvable(t *testing.T) {
+	writeADC(t)
+	t.Setenv(otelResourceAttrsEnv, "")
+
+	l := &testLogger{}
+	cfg := exporters.Config{Interval: time.Second}
+
+	r, err := buildReader(context.Background(), &cfg, l)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defer func() { _ = r.Shutdown(context.Background()) }()
+
+	if !l.warnedAbout("location") {
+		t.Errorf("expected a location warning, got: %v", l.warnings)
+	}
+
+	if !l.warnedAbout(otelResourceAttrsEnv) {
+		t.Errorf("warning should name the env var that fixes it, got: %v", l.warnings)
+	}
+}
+
+func Test_buildReader_warnsOnQuotaProjectHeader(t *testing.T) {
+	writeADC(t)
+	t.Setenv(otelResourceAttrsEnv, "location=us-central1")
+
+	l := &testLogger{}
+	cfg := exporters.Config{
+		Interval: time.Second,
+		Headers:  map[string]string{"x-goog-user-project": "some-project"},
+	}
+
+	r, err := buildReader(context.Background(), &cfg, l)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defer func() { _ = r.Shutdown(context.Background()) }()
+
+	if !l.warnedAbout("GOOGLE_CLOUD_QUOTA_PROJECT") {
+		t.Errorf("expected a quota-project warning, got: %v", l.warnings)
+	}
+}
+
+func Test_resolves_location(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"empty", "", false},
+		{"location", "location=us-central1", true},
+		{"cloud.region", "cloud.region=europe-west1", true},
+		{"cloud.availability_zone", "cloud.availability_zone=us-central1-a", true},
+		{"among others", "service.version=1,location=us-central1,team=core", true},
+		{"unrelated attributes only", "service.version=1,team=core", false},
+		// "location" must match as a key, not merely appear somewhere in the value.
+		{"substring in a value is not a location", "note=relocation-pending", false},
+		// A key merely ending in "location" is a different attribute entirely.
+		{"key ending in location", "custom.location=us-central1", false},
+		{"location present but empty", "location=", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolves(nil, tc.env, locationAttributes); got != tc.want {
+				t.Errorf("resolves(nil, %q, location) = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// An attribute present but empty is what Google sees as empty, and it is a real
+// case: the SDK host detector reads /etc/machine-id and succeeds on the empty
+// file that ubuntu base images ship, so host.id arrives present and blank.
+func Test_resolves_treatsEmptyAttributeAsAbsent(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"populated host.id", "abc123", true},
+		{"empty host.id, as on ubuntu images", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := resource.NewWithAttributes("", attribute.String("host.id", tc.value))
+
+			if got := resolves(res, "", instanceAttributes); got != tc.want {
+				t.Errorf("resolves(host.id=%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_resolves_instanceSources(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"empty", "", false},
+		{"service.instance.id", "service.instance.id=pod-abc", true},
+		{"k8s.pod.name", "k8s.pod.name=my-pod-7d9f", true},
+		{"faas.instance", "faas.instance=0056bf3c9a", true},
+		{"location only does not fill instance", "location=us-central1", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolves(nil, tc.env, instanceAttributes); got != tc.want {
+				t.Errorf("resolves(nil, %q, instance) = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// The instance warning must fire on its own: a container with a location set but
+// no host id is the common Kubernetes case, and it loses every point.
+func Test_buildReader_warnsWhenInstanceUnresolvable(t *testing.T) {
+	writeADC(t)
+	t.Setenv(otelResourceAttrsEnv, "location=us-central1")
+
+	l := &testLogger{}
+	cfg := exporters.Config{
+		Interval: time.Second,
+		// No host.id, as in a debian or alpine based image.
+		Resource: resource.NewWithAttributes("", attribute.String("location", "us-central1")),
+	}
+
+	r, err := buildReader(context.Background(), &cfg, l)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defer func() { _ = r.Shutdown(context.Background()) }()
+
+	if !l.warnedAbout("no instance could be resolved") {
+		t.Errorf("expected an instance warning, got: %v", l.warnings)
+	}
+
+	if l.warnedAbout("no location could be resolved") {
+		t.Errorf("location was set; it must not warn, got: %v", l.warnings)
 	}
 }

--- a/pkg/gofr/metrics/exporters/gcp/go.mod
+++ b/pkg/gofr/metrics/exporters/gcp/go.mod
@@ -3,7 +3,10 @@ module gofr.dev/pkg/gofr/metrics/exporters/gcp
 go 1.26.0
 
 require (
+	go.opentelemetry.io/contrib/detectors/gcp v1.44.0
+	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	gofr.dev v1.59.0
 	golang.org/x/oauth2 v0.36.0
@@ -12,6 +15,7 @@ require (
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -26,11 +30,9 @@ require (
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.65.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/net v0.57.0 // indirect

--- a/pkg/gofr/metrics/exporters/gcp/go.sum
+++ b/pkg/gofr/metrics/exporters/gcp/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 h1:l7+6kwRMJNwdCvYdDl7Eax+wzEYHSnNY7zrrfbhDdTA=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0/go.mod h1:pJTkW8hEUIIi3Pf65lPZOnn4Y81yCllX6IWk2jNXdkM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -41,6 +43,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/detectors/gcp v1.44.0 h1:NmLfL734pJhM0JKaYd2Y28+nY9dPRWYAAbxhRCrKXPw=
+go.opentelemetry.io/contrib/detectors/gcp v1.44.0/go.mod h1:tNAsgd8avTGke1+MndXlU5Cru4PQ9Ai/cCNWQv/ZJ/s=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 h1:SUplec5dp06reu1zaXmOXdvqH398taqrDXqUl99jxSc=

--- a/pkg/gofr/metrics/exporters/provider.go
+++ b/pkg/gofr/metrics/exporters/provider.go
@@ -38,7 +38,11 @@ type ShutdownFunc func(ctx context.Context) error
 // Build never returns a nil ShutdownFunc; failures degrade to a working provider
 // (Prometheus-only, or no readers) rather than crashing app start.
 func Build(ctx context.Context, cfg *Config, logger Logger) (ShutdownFunc, metric.Meter) {
-	opts := []metricSdk.Option{metricSdk.WithResource(buildResource(cfg))}
+	// Resolve the resource first and publish it on cfg: pushReader runs after this,
+	// and a builder needs to see the resource its backend will actually receive.
+	cfg.Resource = buildResource(ctx, cfg, logger)
+
+	opts := []metricSdk.Option{metricSdk.WithResource(cfg.Resource)}
 
 	if r := prometheusReader(logger); r != nil {
 		opts = append(opts, metricSdk.WithReader(r))
@@ -62,12 +66,65 @@ func Build(ctx context.Context, cfg *Config, logger Logger) (ShutdownFunc, metri
 	return shutdown, meter
 }
 
-func buildResource(cfg *Config) *resource.Resource {
-	return resource.NewWithAttributes(
-		semconv.SchemaURL,
+func buildResource(ctx context.Context, cfg *Config, logger Logger) *resource.Resource {
+	attrs := []attribute.KeyValue{
 		semconv.ServiceNameKey.String(cfg.AppName),
 		attribute.String("framework_version", version.Framework),
-	)
+	}
+
+	opts := []resource.Option{
+		// OTEL_RESOURCE_ATTRIBUTES carries attributes a backend requires but the
+		// framework cannot know -- Google fills prometheus_target.location from it,
+		// and only the operator knows the region.
+		//
+		// metricSdk.WithResource merges resource.Environment() in as well, so this
+		// is not what makes the variable work. It is here so buildResource returns a
+		// complete resource on its own rather than one that is only correct once a
+		// particular consumer merges it.
+		resource.WithFromEnv(),
+		resource.WithAttributes(attrs...),
+	}
+
+	// Everything below is only meaningful to a push backend, and host.id is not
+	// free: on darwin the SDK shells out to ioreg, which costs ~10ms. A
+	// prometheus-only app -- the default -- must not pay that at every start for
+	// a label only OTLP ingest reads.
+	if name := strings.ToLower(strings.TrimSpace(cfg.Exporter)); name != "" && name != exporterPrometheus {
+		// host.id is the last fallback Google accepts for the required "instance"
+		// label, so detecting it keeps points from being dropped on hosts where
+		// nothing else supplies one.
+		opts = append(opts, resource.WithHostID())
+
+		if d, ok := lookupDetector(name); ok {
+			opts = append(opts, resource.WithDetectors(d))
+		}
+	}
+
+	// resource.New returns a usable resource alongside a non-nil error for
+	// partial failures (a detector that cannot reach a metadata server off-GCP,
+	// say). Degrade loudly but keep whatever was resolved rather than dropping
+	// the service name with it.
+	res, err := resource.New(ctx, opts...)
+
+	switch {
+	case err == nil:
+	// A vendor detector pinning an older semconv than the SDK's own is the normal
+	// case, not a fault: contrib/detectors/gcp v1.44.0 carries semconv 1.41.0
+	// while the SDK's host detector carries 1.43.0. Merge keeps every attribute
+	// and only drops the schema URL, so warning here would fire on every healthy
+	// boot on Google Cloud -- the one environment this exporter targets.
+	case errors.Is(err, resource.ErrSchemaURLConflict):
+		logger.Debug("metrics: resource schema URLs differ between detectors; " +
+			"attributes are unaffected, schema URL omitted")
+	default:
+		logger.Warnf("metrics: resource detection was incomplete: %v", err)
+	}
+
+	if res == nil {
+		return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
+	}
+
+	return res
 }
 
 func prometheusReader(logger Logger) metricSdk.Reader {

--- a/pkg/gofr/metrics/exporters/provider_test.go
+++ b/pkg/gofr/metrics/exporters/provider_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"go.opentelemetry.io/otel/attribute"
 	metricSdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	"gofr.dev/pkg/gofr/logging"
 	"gofr.dev/pkg/gofr/testutil"
@@ -72,5 +74,147 @@ func TestBuild_missingSubmoduleImportHint(t *testing.T) {
 
 	if !strings.Contains(out, "blank import") {
 		t.Errorf("expected actionable 'blank import' guidance, got: %q", out)
+	}
+}
+
+// Google's OTLP ingest maps points onto prometheus_target and rejects any whose
+// "location" or "instance" label is empty, so the resource has to carry a source
+// for both. instance falls back to host.id, which is detected; location can only
+// come from the operator, via the standard OTel environment variable.
+func TestBuildResource_carriesRequiredLabelSources(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "location=us-central1")
+
+	// host.id is only detected for push exporters, so select one.
+	res := buildResource(context.Background(), &Config{AppName: "app", Exporter: "otlp"}, logging.NewMockLogger(logging.INFO))
+	if res == nil {
+		t.Fatal("expected a resource")
+	}
+
+	got := map[string]string{}
+	for _, kv := range res.Attributes() {
+		got[string(kv.Key)] = kv.Value.String()
+	}
+
+	if got["location"] != "us-central1" {
+		t.Errorf("location = %q, want %q (OTEL_RESOURCE_ATTRIBUTES must reach the resource)", got["location"], "us-central1")
+	}
+
+	if got["host.id"] == "" {
+		t.Error("host.id is empty; it is the last fallback Google accepts for the required instance label")
+	}
+
+	// The attributes that were already there must survive the merge.
+	if got["service.name"] != "app" {
+		t.Errorf("service.name = %q, want %q", got["service.name"], "app")
+	}
+
+	if got["framework_version"] == "" {
+		t.Error("framework_version was dropped")
+	}
+}
+
+// A registered detector must only run for the exporter it belongs to, so that a
+// Prometheus-only app never reaches for a cloud metadata server.
+func TestBuildResource_detectorRunsOnlyForItsExporter(t *testing.T) {
+	var called bool
+
+	// A non-empty schema URL that differs from the SDK's own is what a real vendor
+	// detector supplies -- contrib/detectors/gcp v1.44.0 pins semconv 1.41.0 while
+	// the SDK host detector pins 1.43.0. An empty one never conflicts in
+	// resource.Merge, so a probe using it would pass this test trivially.
+	RegisterResourceDetector("detector-probe", detectorFunc(func(context.Context) (*resource.Resource, error) {
+		called = true
+
+		return resource.NewWithAttributes("https://opentelemetry.io/schemas/1.41.0",
+			attribute.String("probe", "yes")), nil
+	}))
+
+	buildResource(context.Background(), &Config{AppName: "app"}, logging.NewMockLogger(logging.INFO))
+
+	if called {
+		t.Error("detector ran for an unrelated exporter")
+	}
+
+	res := buildResource(context.Background(), &Config{AppName: "app", Exporter: "detector-probe"}, logging.NewMockLogger(logging.INFO))
+
+	if !called {
+		t.Fatal("detector did not run for its own exporter")
+	}
+
+	for _, kv := range res.Attributes() {
+		if string(kv.Key) == "probe" {
+			return
+		}
+	}
+
+	t.Error("detector attributes did not reach the resource")
+}
+
+type detectorFunc func(context.Context) (*resource.Resource, error)
+
+func (f detectorFunc) Detect(ctx context.Context) (*resource.Resource, error) { return f(ctx) }
+
+// host.id detection is not free -- on darwin the SDK shells out to ioreg, which
+// measured ~10ms. The default configuration is prometheus-only and has no use
+// for the label, so it must not pay that cost at every application start.
+func TestBuildResource_prometheusOnlySkipsHostIDDetection(t *testing.T) {
+	for _, exporter := range []string{"", "prometheus"} {
+		t.Run("exporter="+exporter, func(t *testing.T) {
+			res := buildResource(context.Background(), &Config{AppName: "app", Exporter: exporter},
+				logging.NewMockLogger(logging.INFO))
+
+			for _, kv := range res.Attributes() {
+				if string(kv.Key) == "host.id" {
+					t.Errorf("host.id was detected for a pull-only exporter; that costs a subprocess on darwin")
+				}
+			}
+
+			// The attributes that matter to every app must still be present.
+			var gotServiceName bool
+
+			for _, kv := range res.Attributes() {
+				if string(kv.Key) == "service.name" {
+					gotServiceName = true
+				}
+			}
+
+			if !gotServiceName {
+				t.Error("service.name missing")
+			}
+		})
+	}
+}
+
+// A vendor detector pinning an older semconv than the SDK's is the normal case,
+// not a fault: resource.Merge drops the schema URL but keeps every attribute. It
+// must not be reported as a failure, or every healthy boot on Google Cloud logs
+// a warning.
+func TestBuildResource_schemaURLConflictIsNotAFailure(t *testing.T) {
+	RegisterResourceDetector("schema-conflict", detectorFunc(func(context.Context) (*resource.Resource, error) {
+		return resource.NewWithAttributes("https://opentelemetry.io/schemas/1.41.0",
+			attribute.String("cloud.region", "us-central1")), nil
+	}))
+
+	// Warnf is WARN level, which the logger routes to normalOut (stdout); only
+	// ERROR and above go to stderr.
+	logs := testutil.StdoutOutputForFunc(func() {
+		res := buildResource(context.Background(), &Config{AppName: "app", Exporter: "schema-conflict"},
+			logging.NewMockLogger(logging.DEBUG))
+
+		// The attributes are what the backend reads; they must all survive.
+		got := map[string]bool{}
+		for _, kv := range res.Attributes() {
+			got[string(kv.Key)] = true
+		}
+
+		for _, want := range []string{"cloud.region", "host.id", "service.name", "framework_version"} {
+			if !got[want] {
+				t.Errorf("%s was dropped by the conflicting-schema merge", want)
+			}
+		}
+	})
+
+	if strings.Contains(logs, "resource detection was incomplete") {
+		t.Errorf("a schema-URL conflict must not be logged as a failure, got: %q", logs)
 	}
 }

--- a/pkg/gofr/metrics/exporters/registry.go
+++ b/pkg/gofr/metrics/exporters/registry.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	metricSdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 // Builder constructs a metric Reader for a single push-export destination.
@@ -21,6 +22,7 @@ type Builder func(ctx context.Context, cfg *Config, logger Logger) (metricSdk.Re
 var (
 	registryMu sync.RWMutex
 	registry   = map[string]Builder{}
+	detectors  = map[string]resource.Detector{}
 )
 
 // Register adds a named exporter builder. It must be called before the
@@ -44,6 +46,27 @@ var knownExternalExporters = map[string]string{
 	exporterGCP: "gofr.dev/pkg/gofr/metrics/exporters/gcp",
 }
 
+// RegisterResourceDetector associates a resource.Detector with a named exporter.
+// Build runs it while assembling the MeterProvider's resource, but only when that
+// exporter is the selected one, so an unused detector never reaches for a
+// metadata server it cannot see.
+//
+// This exists because some backends reject points whose resource is missing
+// attributes the framework cannot supply: Google's OTLP ingest requires
+// "location" and "instance" on prometheus_target and drops every point without
+// them, server-side and silently. Only a vendor-specific detector can fill those
+// from the environment, and it must live in that vendor's submodule -- the core
+// module takes no dependency on any cloud SDK.
+//
+// Experimental: paired with Builder, whose shape may change in a future minor
+// release.
+func RegisterResourceDetector(name string, d resource.Detector) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	detectors[name] = d
+}
+
 func lookup(name string) (Builder, bool) {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
@@ -51,4 +74,13 @@ func lookup(name string) (Builder, bool) {
 	b, ok := registry[name]
 
 	return b, ok
+}
+
+func lookupDetector(name string) (resource.Detector, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	d, ok := detectors[name]
+
+	return d, ok
 }

--- a/pkg/gofr/version/version.go
+++ b/pkg/gofr/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Framework = "v1.60.0"
+const Framework = "v1.61.0"


### PR DESCRIPTION
# Release v1.60.1

Patch release. Merges `development` into `main` and bumps `pkg/gofr/version.Framework` to `v1.60.1`.

**No features.** Every change is a fix, a perf improvement or a dependency bump.

> **Note for consumers pinned to `v1.60.x`:** the GCP metrics fix below required two additive exported symbols in `gofr.dev/pkg/gofr/metrics/exporters` — `RegisterResourceDetector` and `Config.Resource`, both marked *Experimental* in their doc comments. Nothing was removed and nothing changed shape, so this is a drop-in upgrade.

## 🛠️ Fixes

- **GCP Metrics Were Rejected Server-Side, Silently** — Google maps every point onto `prometheus_target`, which requires both `location` and `instance` ("Reject the point if empty"). `buildResource` emitted only `service.name` and `framework_version`; all six sources Google accepts for `instance` returned **0 occurrences across the tree**, so *every* point was discarded regardless of operator config. The push authenticates, connects and succeeds — nothing reaches `otel.SetErrorHandler`. `resource.WithHostID()` now supplies `host.id`, the last fallback Google accepts, and a startup warning fires when no location resolves. Verified against a local OTLP receiver, byte-for-byte on the wire.

  Fixing it properly needed a seam, since core takes no dependency on any cloud SDK. `RegisterResourceDetector` lets a vendor submodule register the detector that fills what the framework cannot know, and `Build` runs it **only** when that exporter is the selected one — so a Prometheus-only app never reaches for a metadata server it cannot see. `Config.Resource` is published by `Build` before any `Builder` runs, so a builder can inspect the resource its backend will actually receive. Pinned by `TestBuildResource_detectorRunsOnlyForItsExporter`.

  Host detection shells out to `ioreg` on darwin (~11 ms), so it runs only on the push path. Prometheus-only — the default — costs 0.010 ms, down from 11.16 ms in the first cut of the branch; `TestBuildResource_prometheusOnlySkipsHostIDDetection` pins that, because the expense is invisible at the call site.

  `buildResource` also merges `resource.WithFromEnv()`, so `OTEL_RESOURCE_ATTRIBUTES` reaches the resource on its own rather than only once a particular consumer merges it. It is now documented in `docs/references/configs`, and is required for the `gcp` exporter outside Google Cloud (e.g. `location=us-central1`).

- **Baggage Members Silently Dropped After the First** — `headerCarrier` replaced `propagation.HeaderCarrier` but implemented only `Get`/`Set`/`Keys`. The stdlib type it replaces also satisfies `propagation.ValuesGetter`, which `propagation.Baggage.Extract` type-asserts to in order to combine *all* values of the `Baggage` header. The assertion failed and `Extract` fell back to single-value `Get`. Surfaces on any request carrying more than one `Baggage` header — legal per W3C, and what proxies and service meshes commonly emit — and GoFr installs `propagation.Baggage` in its default composite propagator, so the path is live. Found in review of #3970 and fixed there.

- **`AddStaticFiles` Discarded `os.Getwd()`** — On failure the working directory became empty and the static path silently resolved against the filesystem root, with no log to explain why the endpoint misbehaved. The error is now logged and the registration returns early, mirroring the `os.Stat` path a few lines below. Endpoint normalization moved up so both logs report the same `/endpoint` form.

## 🔧 Enhancements

🔹 **Reduced Per-Request Tracing Allocations**

The tracing middleware rebuilt, on every request, things that never change for a given route: the span name via `fmt.Sprintf`, the attribute slice, the `trace.WithAttributes` wrapper and its variadic slice, the status attribute even on a non-recording span, and a response-writer wrapper even when nothing recorded the status.

| provider | before | after |
|---|---|---|
| non-recording | 21 allocs, 2074 B | **11 allocs, 1568 B** |
| recording | 23 allocs, 2875 B | **17 allocs, 2658 B** |

The cache key is the **route template** (`/users/{id}`), never the concrete path, and is bounded twice: `cacheableMethod` restricts it to the nine defined HTTP methods, and `routeCache` caps the whole thing at 4096 entries. Both bounds were added in review — `gofr.go` registers a `PathPrefix("/")` catch-all, so `GetPathTemplate()` returns `"/"` even for an unmatched path, and `net/http` accepts any RFC 7230 token as a method; a client streaming `M00001`, `M00002`, … minted a permanent entry per request. Reproduced at 5000 distinct methods, and fixed before merge.

No behavior change.

## 📦 CI & Dependencies

- **golang base image 1.26 → 1.27** across all 9 Dockerfiles (root + 8 examples). Closes #4116.
- **`crate-ci/typos` 1.49.0 → 1.50.0** (SHA-pinned). Closes #4114.

## ⚠️ Required follow-up after tagging

`pkg/gofr/metrics/exporters/gcp` calls `RegisterResourceDetector`, which does not exist in the `gofr.dev v1.59.0` its `go.mod` pins — it only builds today via `go.work`. Once `v1.60.1` is tagged, the submodule's pin must be bumped and a new `pkg/gofr/metrics/exporters/gcp` tag cut, or `go get` of that module will not build.

## Included PRs

- #3970 — `perf(tracer)`: stop rebuilding span metadata on every request
- #4113 — `fix(metrics)`: supply the instance label Google's OTLP ingest requires
- #3600 — `fix(http)`: handle `os.Getwd()` error in `AddStaticFiles`
- #4142 — `chore(deps)`: bump `crate-ci/typos` 1.49.0 → 1.50.0
- #4141 — `chore(deps)`: bump golang base image 1.26 → 1.27 in Dockerfiles

---

**Full changelog**: https://github.com/gofr-dev/gofr/compare/v1.60.0...v1.60.1
