### PR TITLE
fix(logging): ensure remote log-level transitions are announced without discard

### DIFF
--- a/pkg/gofr/logging/remotelogger/dynamic_level_logger.go
+++ b/pkg/gofr/logging/remotelogger/dynamic_level_logger.go
@@ -236,8 +236,13 @@ func (r *remoteLogger) UpdateLogLevel() {
 			r.currentLevel = newLevel
 			r.mu.Unlock()
 
-			logLevelChange(r, oldLevel, newLevel)
-			r.ChangeLevel(newLevel)
+			if newLevel > oldLevel {
+				logLevelChange(r, oldLevel, newLevel)
+				r.ChangeLevel(newLevel)
+			} else {
+				r.ChangeLevel(newLevel)
+				logLevelChange(r, oldLevel, newLevel)
+			}
 		} else {
 			r.mu.Unlock()
 		}
@@ -257,27 +262,31 @@ func (r *remoteLogger) UpdateLogLevel() {
 
 // Helper function to log level changes at appropriate level.
 func logLevelChange(r *remoteLogger, oldLevel, newLevel logging.Level) {
-	// Use the higher level to ensure visibility
-	logLevel := oldLevel
-	if newLevel > oldLevel {
-		logLevel = newLevel
-	}
-
 	message := fmt.Sprintf("LOG_LEVEL updated from %v to %v", oldLevel, newLevel)
 
+	logLevel := newLevel
+	if newLevel > oldLevel {
+		logLevel = newLevel
+		if newLevel == logging.FATAL {
+			if oldLevel == logging.ERROR {
+				logLevel = logging.ERROR
+			} else {
+				logLevel = logging.WARN
+			}
+		}
+	}
+
 	switch logLevel {
-	case logging.FATAL:
-		r.Warnf("%s", message)
 	case logging.ERROR:
 		r.Errorf("%s", message)
 	case logging.WARN:
 		r.Warnf("%s", message)
 	case logging.NOTICE:
 		r.Noticef("%s", message)
-	case logging.INFO:
+	case logging.INFO, logging.DEBUG:
 		r.Infof("%s", message)
-	case logging.DEBUG:
-		r.Infof("%s", message) // Using Info for DEBUG to ensure visibility
+	default:
+		r.Infof("%s", message)
 	}
 }
 

--- a/pkg/gofr/logging/remotelogger/dynamic_level_logger_test.go
+++ b/pkg/gofr/logging/remotelogger/dynamic_level_logger_test.go
@@ -501,3 +501,51 @@ func TestRemoteLoggerLogEnabledAgreesWithLog(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoteLogger_AllLevelTransitionsAnnounced(t *testing.T) {
+	levels := []logging.Level{
+		logging.DEBUG,
+		logging.INFO,
+		logging.NOTICE,
+		logging.WARN,
+		logging.ERROR,
+		logging.FATAL,
+	}
+
+	for _, oldLevel := range levels {
+		for _, newLevel := range levels {
+			if oldLevel == newLevel {
+				continue
+			}
+
+			t.Run(fmt.Sprintf("%s_to_%s", oldLevel, newLevel), func(t *testing.T) {
+				mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprintf(w, `{"data":{"serviceName":"test-service","logLevel":"%s"}}`, newLevel)
+				}))
+				defer mockServer.Close()
+
+				expectedMsg := fmt.Sprintf("LOG_LEVEL updated from %v to %v", oldLevel, newLevel)
+
+				var out string
+				stdout := testutil.StdoutOutputForFunc(func() {
+					stderr := testutil.StderrOutputForFunc(func() {
+						rl := New(oldLevel, mockServer.URL, 10*time.Millisecond)
+						time.Sleep(30 * time.Millisecond)
+
+						if r, ok := rl.(*remoteLogger); ok {
+							r.mu.RLock()
+							assert.Equal(t, newLevel, r.currentLevel)
+							r.mu.RUnlock()
+						}
+					})
+					out += stderr
+				})
+				out += stdout
+
+				assert.Contains(t, out, expectedMsg, "transition announcement must not be discarded")
+			})
+		}
+	}
+}
+


### PR DESCRIPTION
Fixes #4101

### Description
In remote logger, log-level transitions where the previous level was `FATAL` or when transitioning from `ERROR` to `FATAL` resulted in the transition announcement being discarded (6 of 30 combinations), because `r.Warnf` was called while the logger was still filtered at `FATAL` or `ERROR`.

This PR fixes this by:
1. Calling `r.ChangeLevel(newLevel)` prior to announcing when lowering the level (`oldLevel > newLevel`), ensuring the new level's logger can emit the announcement.
2. For level increases (`newLevel > oldLevel`), announcing before `ChangeLevel`, and using `ERROR` level if `newLevel == FATAL` and `oldLevel == ERROR`.
3. Adding a test table in `dynamic_level_logger_test.go` verifying all 30 transitions are visible and not discarded.