### PR TITLE
fix(pubsub/eventhub): cap in-flight health probes at one to prevent goroutine leak

### DIFF
--- a/pkg/gofr/datasource/pubsub/eventhub/eventhub.go
+++ b/pkg/gofr/datasource/pubsub/eventhub/eventhub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -24,6 +25,7 @@ var (
 	ErrTopicMismatch      = errors.New("topic should be same as Event Hub name")
 	errClientNotConnected = errors.New("eventhub client not connected")
 	errEmptyTopic         = errors.New("topic name cannot be empty")
+	errProbeInFlight      = errors.New("eventhub health probe already in progress")
 )
 
 const (
@@ -78,6 +80,11 @@ type Client struct {
 	logger       Logger
 	metrics      Metrics
 	tracer       trace.Tracer
+	// probeMu caps in-flight health probes at one. A probe can outlive its deadline parked in the
+	// SDK (see probeWithin), so without this a broker that accepts a connection but never answers
+	// would strand a goroutine on every health poll -- an unbounded leak. Held for the lifetime of
+	// the parked probe and released by the goroutine that ran it.
+	probeMu sync.Mutex
 }
 
 // New Creates the client for Event Hub.
@@ -528,10 +535,22 @@ func (c *Client) Health() datasource.Health {
 // Running the call on its own goroutine and selecting here makes the deadline ours. The cost is
 // that an abandoned probe stays parked until the SDK returns; the channel is buffered so it can
 // always finish and exit rather than blocking forever on the send.
+//
+// probeMu caps that cost at a single parked goroutine. Without it, every poll against a broker
+// stuck in exactly this state would strand another goroutine -- an unbounded leak on the hot
+// health path. If a probe is already parked the broker is already unresponsive, so a poll that
+// finds the lock held reports that rather than piling on another abandoned goroutine. The lock is
+// released by the goroutine that ran the probe, once the SDK call finally returns.
 func (c *Client) probeWithin(ctx context.Context) (azeventhubs.EventHubProperties, error) {
+	if !c.probeMu.TryLock() {
+		return azeventhubs.EventHubProperties{}, errProbeInFlight
+	}
+
 	done := make(chan eventHubProps, 1)
 
 	go func() {
+		defer c.probeMu.Unlock()
+
 		props, err := c.consumer.GetEventHubProperties(ctx, nil)
 		done <- eventHubProps{props: props, err: err}
 	}()

--- a/pkg/gofr/datasource/pubsub/eventhub/eventhub.go
+++ b/pkg/gofr/datasource/pubsub/eventhub/eventhub.go
@@ -540,7 +540,9 @@ func (c *Client) Health() datasource.Health {
 // stuck in exactly this state would strand another goroutine -- an unbounded leak on the hot
 // health path. If a probe is already parked the broker is already unresponsive, so a poll that
 // finds the lock held reports that rather than piling on another abandoned goroutine. The lock is
-// released by the goroutine that ran the probe, once the SDK call finally returns.
+// released by the goroutine that ran the probe, once the SDK call returns -- on the timeout path
+// that is whenever the abandoned call finally unblocks, which is exactly when the next probe may
+// safely start.
 func (c *Client) probeWithin(ctx context.Context) (azeventhubs.EventHubProperties, error) {
 	if !c.probeMu.TryLock() {
 		return azeventhubs.EventHubProperties{}, errProbeInFlight
@@ -549,9 +551,11 @@ func (c *Client) probeWithin(ctx context.Context) (azeventhubs.EventHubPropertie
 	done := make(chan eventHubProps, 1)
 
 	go func() {
-		defer c.probeMu.Unlock()
-
 		props, err := c.consumer.GetEventHubProperties(ctx, nil)
+
+		// Release before publishing the result, so a caller that reads it and immediately
+		// re-probes never finds the lock still held by an already-finished probe.
+		c.probeMu.Unlock()
 		done <- eventHubProps{props: props, err: err}
 	}()
 

--- a/pkg/gofr/datasource/pubsub/eventhub/eventhub_test.go
+++ b/pkg/gofr/datasource/pubsub/eventhub/eventhub_test.go
@@ -716,3 +716,38 @@ func Test_Health_ParkedProbeIsCappedAtOne(t *testing.T) {
 	require.Equal(t, int32(1), atomic.LoadInt32(&callCount),
 		"the SDK probe must run at most once while one is still parked; more means a goroutine leaks per poll")
 }
+
+// Test_Health_ProbeRecoversAfterParkedCallReturns pins the release half of the cap: once a parked
+// probe's SDK call finally returns, the lock must free so the next poll runs a fresh probe rather
+// than stay wedged on errProbeInFlight forever. Drop the Unlock in probeWithin and a client that
+// probed once can never report up again -- a permanent false DOWN that the cap test alone does not
+// catch, because it never lets its parked probe return.
+func Test_Health_ProbeRecoversAfterParkedCallReturns(t *testing.T) {
+	release := make(chan struct{})
+
+	var calls int32
+
+	client := newHealthTestClient(t, &mockConsumerClient{
+		getPropsFunc: func(context.Context,
+			*azeventhubs.GetEventHubPropertiesOptions) (azeventhubs.EventHubProperties, error) {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				<-release // the first probe parks until released; later probes answer immediately
+			}
+
+			return azeventhubs.EventHubProperties{PartitionIDs: []string{"0"}}, nil
+		},
+	})
+
+	// First poll parks the probe and returns down on the deadline.
+	require.Equal(t, datasource.StatusDown, client.Health().Status)
+
+	// Let the parked probe finish. Its goroutine must release the lock as it returns.
+	close(release)
+
+	// A subsequent poll must therefore be able to run a fresh probe and report up. Eventually,
+	// because the release races the parked goroutine's return by a hair.
+	require.Eventually(t, func() bool {
+		return client.Health().Status == datasource.StatusUp
+	}, 5*time.Second, 20*time.Millisecond,
+		"probe must recover once the parked call returns and releases the lock")
+}

--- a/pkg/gofr/datasource/pubsub/eventhub/eventhub_test.go
+++ b/pkg/gofr/datasource/pubsub/eventhub/eventhub_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -675,4 +676,43 @@ func Test_Health_ProbeDeadlineIsTwoSeconds(t *testing.T) {
 	require.True(t, gotDeadline, "the probe must be given a deadline")
 	require.Greater(t, remaining, 1500*time.Millisecond, "deadline is shorter than expected, got %v", remaining)
 	require.LessOrEqual(t, remaining, 2*time.Second, "deadline is longer than expected, got %v", remaining)
+}
+
+// Test_Health_ParkedProbeIsCappedAtOne proves a broker that accepts the probe but never answers
+// cannot leak a goroutine per health poll. probeWithin returns on its own deadline while the SDK
+// call stays parked (see Test_Health_BoundsAProbeThatIgnoresContext); without a cap, every poll
+// would strand another goroutine on the hot health path. The fake blocks in GetEventHubProperties
+// without reading ctx -- what the SDK does once a management link exists -- so the first Health
+// parks a goroutine, and every poll while it is parked must report the in-flight probe rather than
+// spawn another. Revert the TryLock cap and callCount climbs with each poll: this goes red.
+func Test_Health_ParkedProbeIsCappedAtOne(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	var callCount int32
+
+	client := newHealthTestClient(t, &mockConsumerClient{
+		getPropsFunc: func(context.Context,
+			*azeventhubs.GetEventHubPropertiesOptions) (azeventhubs.EventHubProperties, error) {
+			atomic.AddInt32(&callCount, 1)
+			<-release
+
+			return azeventhubs.EventHubProperties{}, nil
+		},
+	})
+
+	// The first poll parks a goroutine in the fake and returns down on the deadline.
+	first := client.Health()
+	require.Equal(t, datasource.StatusDown, first.Status)
+
+	// Every poll while that goroutine is still parked must short-circuit without entering the fake.
+	for range 5 {
+		h := client.Health()
+		require.Equal(t, datasource.StatusDown, h.Status)
+		require.Equal(t, errProbeInFlight.Error(), h.Details["error"],
+			"a poll while a probe is parked must report the in-flight probe, not spawn another")
+	}
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&callCount),
+		"the SDK probe must run at most once while one is still parked; more means a goroutine leaks per poll")
 }


### PR DESCRIPTION
### Problem

`Health()` runs the Event Hub connectivity probe on a goroutine so `probeWithin` can return on its own deadline. That design is correct — the Azure SDK's `GetEventHubProperties` passes `context.Background()` to the AMQP RPC (`mgmt.go`) and the reply-wait selects on *that* context (`internal/rpc.go`), so the caller's deadline can't bound it; only selecting on our own deadline does.

The cost, as the existing comment notes, is that an abandoned probe stays parked in the SDK call until it returns. Against a broker that **accepts a connection but never answers**, that call doesn't return promptly — so every health poll stranded *another* parked goroutine. Health checks are polled continuously (liveness, `/.well-known/health`), so this is an unbounded goroutine leak on the hot path, and it compounds exactly when the broker is already degraded.

### Fix

Cap concurrent probes at one via `TryLock`. A poll that finds a probe already parked reports `errProbeInFlight` (the broker is already unresponsive, so reporting down is correct) instead of piling on another abandoned goroutine. The lock is released by the goroutine that ran the probe, once the SDK call finally returns — so at most **one** goroutine is ever parked, regardless of poll rate.

Behaviour is unchanged in every healthy/normal-failure case: the probe still returns on its 2s deadline; only the pathological "accepts-but-hangs" broker is now bounded.

### Test

`Test_Health_ParkedProbeIsCappedAtOne` parks a probe against a fake that blocks without reading `ctx` (what the SDK does once a management link exists), then polls `Health()` repeatedly and asserts the SDK probe runs **at most once** while one is still parked. Reverting the cap makes the count climb — verified red.

`go test ./... -race` passes; `golangci-lint --new-from-rev` reports 0 new issues.

Follow-up to #3649.
