### PR TITLE
fix(dgraph): commit the transaction Mutate opens

### DIFF
--- a/docs/datasources/dgraph/page.md
+++ b/docs/datasources/dgraph/page.md
@@ -114,7 +114,7 @@ func DGraphInsertHandler(c *gofr.Context) (any, error) {
 	// Create an api.Mutation object
 	mutation := &api.Mutation{
 		SetJson:   []byte(mutationData), // Set the JSON payload
-		CommitNow: true,                 // Auto-commit the transaction
+		CommitNow: true,                 // Optional: Mutate commits the write either way
 	}
 
 	// Run the mutation in Dgraph

--- a/pkg/gofr/datasource/dgraph/dgraph.go
+++ b/pkg/gofr/datasource/dgraph/dgraph.go
@@ -205,6 +205,8 @@ func (d *Client) QueryWithVars(ctx context.Context, query string, vars map[strin
 }
 
 // Mutate executes a write operation (mutation) in the Dgraph database and returns the result.
+//
+// The write is committed before this returns, whether or not CommitNow is set on the mutation.
 func (d *Client) Mutate(ctx context.Context, mu any) (any, error) {
 	start := time.Now()
 
@@ -217,7 +219,7 @@ func (d *Client) Mutate(ctx context.Context, mu any) (any, error) {
 	}
 
 	// Execute mutation
-	resp, err := d.client.NewTxn().Mutate(tracedCtx, mutation)
+	resp, err := d.mutateInTxn(tracedCtx, mutation)
 	duration := time.Since(start).Microseconds()
 
 	// Create and log the mutation details
@@ -235,6 +237,43 @@ func (d *Client) Mutate(ctx context.Context, mu any) (any, error) {
 	}
 
 	d.sendOperationStats(tracedCtx, start, mutationToString(mutation), "mutate", span, ql, "dgraph_mutate_duration")
+
+	return resp, nil
+}
+
+// mutateInTxn runs the mutation and resolves the transaction it opens.
+//
+// dgo only finishes the transaction when the caller set CommitNow on the mutation — it copies
+// the field into the request (dgo v210 txn.go:157) and marks the transaction finished only when
+// it is set (txn.go:206). Mutating without it therefore staged the write into a transaction that
+// was then abandoned to the garbage collector: nothing was persisted, no error was returned, and
+// the transaction stayed open on the server until Dgraph timed it out. Committing here makes a
+// single Mutate call atomic whichever way the caller wrote it.
+func (d *Client) mutateInTxn(ctx context.Context, mutation *api.Mutation) (*api.Response, error) {
+	txn := d.client.NewTxn()
+
+	// Discard is a no-op once the transaction is finished (dgo v210 txn.go:289), so this only
+	// does anything on the paths that did not reach a commit.
+	defer func() {
+		if err := txn.Discard(ctx); err != nil {
+			d.logger.Error("dgraph mutation transaction discard failed: ", err)
+		}
+	}()
+
+	resp, err := txn.Mutate(ctx, mutation)
+	if err != nil {
+		return nil, err
+	}
+
+	// dgo already committed and marked the transaction finished; calling Commit again returns
+	// ErrFinished (txn.go:239).
+	if mutation.CommitNow {
+		return resp, nil
+	}
+
+	if err := txn.Commit(ctx); err != nil {
+		return nil, err
+	}
 
 	return resp, nil
 }

--- a/pkg/gofr/datasource/dgraph/dgraph_test.go
+++ b/pkg/gofr/datasource/dgraph/dgraph_test.go
@@ -153,6 +153,7 @@ func Test_Mutate_Success(t *testing.T) {
 	mutation := &api.Mutation{CommitNow: true}
 
 	mockTxn.EXPECT().Mutate(gomock.Any(), mutation).Return(&api.Response{Json: []byte(`{"result": "mutation success"}`)}, nil)
+	mockTxn.EXPECT().Discard(gomock.Any()).Return(nil)
 
 	mockLogger.EXPECT().Debug(gomock.Any())
 	mockLogger.EXPECT().Debugf("dgraph mutation succeeded in %dµs", gomock.Any())
@@ -199,6 +200,7 @@ func Test_Mutate_Error(t *testing.T) {
 	mutation := &api.Mutation{CommitNow: true}
 
 	mockTxn.EXPECT().Mutate(gomock.Any(), mutation).Return(nil, errMutationFailed)
+	mockTxn.EXPECT().Discard(gomock.Any()).Return(nil)
 
 	mockLogger.EXPECT().Debug(gomock.Any())
 	mockLogger.EXPECT().Error("dgraph mutation failed: ", errMutationFailed)

--- a/pkg/gofr/datasource/dgraph/mutate_txn_test.go
+++ b/pkg/gofr/datasource/dgraph/mutate_txn_test.go
@@ -1,0 +1,175 @@
+package dgraph
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.uber.org/mock/gomock"
+)
+
+var (
+	errCommitFailed  = errors.New("commit failed")
+	errDiscardFailed = errors.New("discard failed")
+)
+
+// recordingTxn counts what Mutate does to the transaction it opens.
+//
+// A gomock Txn cannot answer "was Commit called?" in this package: setupDB runs ctrl.Finish()
+// when it returns, which marks the controller finished before the test body starts, so the
+// t.Cleanup verification gomock.NewController installs short-circuits (mock v0.6.0
+// controller.go:268) and an unmet expectation is never reported. Counting here asserts on what
+// happened rather than on the mock library's bookkeeping.
+type recordingTxn struct {
+	mutateErr  error
+	commitErr  error
+	discardErr error
+
+	mutations int
+	commits   int
+	discards  int
+}
+
+func (r *recordingTxn) Mutate(_ context.Context, _ *api.Mutation) (*api.Response, error) {
+	r.mutations++
+
+	if r.mutateErr != nil {
+		return nil, r.mutateErr
+	}
+
+	return &api.Response{Json: []byte(`{}`)}, nil
+}
+
+func (r *recordingTxn) Commit(context.Context) error {
+	r.commits++
+
+	return r.commitErr
+}
+
+func (r *recordingTxn) Discard(context.Context) error {
+	r.discards++
+
+	return r.discardErr
+}
+
+func (r *recordingTxn) BestEffort() Txn { return r }
+
+func (*recordingTxn) Query(context.Context, string) (*api.Response, error) { return nil, nil }
+
+func (*recordingTxn) QueryRDF(context.Context, string) (*api.Response, error) { return nil, nil }
+
+func (*recordingTxn) QueryWithVars(context.Context, string, map[string]string) (*api.Response, error) {
+	return nil, nil
+}
+
+func (*recordingTxn) QueryRDFWithVars(context.Context, string,
+	map[string]string) (*api.Response, error) {
+	return nil, nil
+}
+
+func (*recordingTxn) Do(context.Context, *api.Request) (*api.Response, error) { return nil, nil }
+
+func setupWithTxn(t *testing.T, txn Txn) (*Client, *MockLogger) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+
+	logger := NewMockLogger(ctrl)
+	logger.EXPECT().Debug(gomock.Any()).AnyTimes()
+	logger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	logger.EXPECT().Log(gomock.Any()).AnyTimes()
+	logger.EXPECT().Logf(gomock.Any(), gomock.Any()).AnyTimes()
+	logger.EXPECT().Error(gomock.Any(), gomock.Any()).AnyTimes()
+
+	metrics := NewMockMetrics(ctrl)
+	metrics.EXPECT().RecordHistogram(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	client := New(Config{Host: "localhost", Port: "9080"})
+	client.UseLogger(logger)
+	client.UseMetrics(metrics)
+	client.UseTracer(otel.GetTracerProvider().Tracer("gofr-dgraph"))
+
+	dgraphClient := NewMockDgraphClient(ctrl)
+	dgraphClient.EXPECT().NewTxn().Return(txn).AnyTimes()
+	client.client = dgraphClient
+
+	return client, logger
+}
+
+func Test_Mutate_TransactionHandling(t *testing.T) {
+	tests := []struct {
+		name         string
+		commitNow    bool
+		txn          recordingTxn
+		wantErr      error
+		wantResp     bool
+		wantCommits  int
+		wantDiscards int
+	}{
+		{
+			// The defect: dgo only finishes the transaction when CommitNow is set, so without
+			// an explicit Commit the write was staged and abandoned, silently.
+			name:         "commits when CommitNow is not set",
+			wantResp:     true,
+			wantCommits:  1,
+			wantDiscards: 1,
+		},
+		{
+			// dgo has already finished the transaction; Commit again returns ErrFinished.
+			name:         "does not commit again when CommitNow is set",
+			commitNow:    true,
+			wantResp:     true,
+			wantCommits:  0,
+			wantDiscards: 1,
+		},
+		{
+			name:         "commit failure is returned",
+			txn:          recordingTxn{commitErr: errCommitFailed},
+			wantErr:      errCommitFailed,
+			wantCommits:  1,
+			wantDiscards: 1,
+		},
+		{
+			name:         "mutate failure is returned without committing",
+			txn:          recordingTxn{mutateErr: errMutationFailed},
+			wantErr:      errMutationFailed,
+			wantCommits:  0,
+			wantDiscards: 1,
+		},
+		{
+			// A failing Discard must not turn a committed write into an error.
+			name:         "discard failure does not fail a committed write",
+			txn:          recordingTxn{discardErr: errDiscardFailed},
+			wantResp:     true,
+			wantCommits:  1,
+			wantDiscards: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			txn := tc.txn
+			client, _ := setupWithTxn(t, &txn)
+
+			resp, err := client.Mutate(t.Context(), &api.Mutation{
+				SetJson:   []byte(`{"name":"GoFr"}`),
+				CommitNow: tc.commitNow,
+			})
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Nil(t, resp)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.wantResp, resp != nil, "response")
+			require.Equal(t, 1, txn.mutations, "Mutate calls")
+			require.Equal(t, tc.wantCommits, txn.commits, "Commit calls")
+			require.Equal(t, tc.wantDiscards, txn.discards, "Discard calls")
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4157

## Description

`Client.Mutate` opened a transaction, mutated, and returned — it never called `Commit` or `Discard`. Whether the write landed was decided by a field the **caller** set on the `*api.Mutation`.

dgo copies `CommitNow` from the caller's mutation into the request (`dgo v210 txn.go:157`) and marks the transaction finished only when it is set (`txn.go:206`). A caller who left it unset had the write staged into a transaction that was then abandoned to the garbage collector: **nothing persisted, `err == nil`, and a non-nil response**. The transaction also stayed open on the server until Dgraph timed it out.

GoFr's own migration code was exactly such a caller (`pkg/gofr/migration/dgraph.go` on `development`, no `CommitNow`), which is one of the three reasons Dgraph migrations never recorded anything — see #3186.

## Changes

`Mutate` now resolves the transaction it opens, in a small `mutateInTxn` helper so the logging/metrics wrapper is untouched:

- commits before returning when the caller did not set `CommitNow`;
- leaves a `CommitNow` mutation alone — dgo has already finished that transaction, and `Commit` on a finished one returns `ErrFinished` (`txn.go:239`);
- defers `Discard`, which is a no-op once the transaction is finished (`txn.go:289`), so it only releases the paths that did not reach a commit;
- logs a failing `Discard` rather than turning a committed write into an error.

Behaviour for callers who already set `CommitNow` — including the documented example — is unchanged.

## Testing

**Unit.** New table test `Test_Mutate_TransactionHandling`, five cases: commits without `CommitNow`, does not commit again with it, commit failure returned, mutate failure returned without committing, discard failure does not fail a committed write.

`Test_Mutate_DiscardSurvivesCallerCancellation` covers the deferred discard separately: it calls `Mutate` with an already-canceled context and asserts the context the discard receives is not done. It fails with `context canceled` if the discard takes the caller's context, which is what it did before review.

It asserts on a recording fake rather than gomock expectations, on purpose. `setupDB` calls `ctrl.Finish()` when it returns, which marks the controller finished before the test body starts, so the `t.Cleanup` verification `gomock.NewController` installs short-circuits (`mock v0.6.0 controller.go:268`) and an unmet expectation is never reported. Counting calls asserts on what happened instead. Flagged as a follow-up below rather than fixed here — turning that verification back on surfaces over-specified expectations across most of the package's existing tests, which is a much larger diff than this fix.

**The tests fail without the fix.** Reverting `mutateInTxn` to `development`'s body fails all five subtests:

```
--- FAIL: Test_Mutate_TransactionHandling/commits_when_CommitNow_is_not_set          Commit calls
--- FAIL: Test_Mutate_TransactionHandling/does_not_commit_again_when_CommitNow_is_set Discard calls
--- FAIL: Test_Mutate_TransactionHandling/commit_failure_is_returned
--- FAIL: Test_Mutate_TransactionHandling/mutate_failure_is_returned_without_committing Discard calls
--- FAIL: Test_Mutate_TransactionHandling/discard_failure_does_not_fail_a_committed_write Commit calls
```

**End to end, against a real Dgraph v21.03.0.** Two mutations through `Client`, one without `CommitNow` and one with, then counted back with a query. `drop_all` between runs, 3 runs:

| | `development` | this PR |
|---|---|---|
| persisted without `CommitNow` | **0** | **1** |
| persisted with `CommitNow` | 1 | 1 |

Both calls returned `err=<nil>` and a non-nil response on `development` — the write simply was not there.

The e2e check needed a live Dgraph, so it is not committed; the two existing `Test_Mutate_*` tests gained the `Discard` expectation the new code path requires.

| gate | result |
|---|---|
| `gofmt -l` | clean |
| `go vet ./...` | clean |
| `go test ./... -count=1` | pass |
| `go test ./... -race` | pass |
| coverage | **67.4% → 71.7%** |
| `golangci-lint run ./...` | **0 issues** (absolute, not just `--new-from-rev`) |

## Why this is a fix and not a behaviour change

The transaction `Mutate` opens is never handed to the caller. `Mutate` returns `(any, error)` carrying the `*api.Response` — there is no path by which a caller who omitted `CommitNow` could reach that transaction and commit it afterwards. Abandoning the write was the only reachable outcome, not one of two defensible ones, which is what makes committing the only sensible semantics rather than a judgement call between two.

Manual transaction control is a separate, untouched path: `Client.NewTxn()` and `Client.NewReadOnlyTxn()` hand back a transaction the caller drives themselves. Nothing here changes it — `mutateInTxn` opens and resolves its own.

## Release note

> [!IMPORTANT]
> **`dgraph.Client.Mutate` now persists writes that omit `CommitNow`.** The signature is unchanged. A mutation sent without `CommitNow` previously returned `err == nil` and a non-nil response while persisting nothing and leaving the transaction open on the server until Dgraph timed it out; it is now committed before `Mutate` returns. Callers who already set `CommitNow` are unaffected. No action is required, but a caller who was relying on the silent drop as a dry run will now see the write land.

Same-signature semantic changes do not show up in a diff review of the call sites, so this is stated here for the notes rather than only in the godoc on `Mutate` and in `docs/datasources/dgraph/page.md`. There is no `CHANGELOG` in the repo — release notes are compiled from merged PRs — so the PR body is the only place this can be picked up from.

## Breaking Changes

None. No exported signature changes. A caller who omitted `CommitNow` was losing the write silently; now it is written. A caller who set it sees no change.

## Follow-up, not in this PR

`setupDB` in `pkg/gofr/datasource/dgraph/dgraph_test.go` runs `ctrl.Finish()` before the test body, so gomock never reports a missing call for any test in the package. Removing it makes verification live and immediately fails several existing tests that declare `Log`/`Debugf` expectations which never fire. Worth its own change.

## Checklist

- [x] I have formatted my code using `gofmt`.
- [x] All new code is covered by unit tests.
- [x] This PR does not decrease the overall code coverage.
- [x] I have reviewed the code comments and documentation for clarity.




