### PR TITLE
feat(health): serve detailed health map on metrics server (#3806)

### DIFF
--- a/docs/advanced-guide/monitoring-service-health/page.md
+++ b/docs/advanced-guide/monitoring-service-health/page.md
@@ -49,8 +49,8 @@ A caller that wants to act on degradation must read the `status` field itself.
 
 To avoid leaking infrastructure details on an unauthenticated port, this endpoint intentionally does
 **not** expose per-dependency information (hosts, ports, database/keyspace/bucket names, connection
-pool stats, usernames, or raw error strings). No HTTP route serves the detailed map after this
-change — `Container.Health` still computes it for in-process ops tooling.
+pool stats, usernames, or raw error strings). The detailed map is served instead at `GET /health`
+on the metrics server — see below.
 
 > **Changed response shape:** this endpoint previously returned the full per-dependency map. It now
 > returns `{name, status}` only. The HTTP status code is unchanged (`200`), so existing readiness
@@ -69,9 +69,27 @@ Sample response when the service is ready (HTTP 200):
 }
 ```
 
-> **Note:** The detailed per-dependency health map is being moved to the metrics server
-> (`METRICS_PORT`), behind the same network boundary as `/metrics` and `/debug/pprof`. Track that
-> work in #3806.
+### 3. Detailed health map - /health on the metrics server
+
+Ops tooling that needs the full per-dependency map can scrape `GET /health` on `METRICS_PORT`
+(default `2121`), next to `/metrics` and `/debug/pprof`:
+
+```json
+{
+  "name": "sample-service",
+  "version": "v1.0.0",
+  "status": "UP",
+  "sql": { "...": "..." }
+}
+```
+
+Like the public endpoint, it answers `200` regardless of the aggregate `status` — read the
+`status` field itself to act on degradation. Setting `METRICS_PORT=0` disables the metrics
+server entirely, this endpoint with it.
+
+> **Note:** "private" here means *not exposed through ingress*, identical to `/debug/pprof`'s
+> current guarantee — the metrics server binds all interfaces, so the boundary is network
+> policy, not loopback. Keep this port out of public ingress exactly as you would `/metrics`.
 
 ## Related production guides
 

--- a/pkg/gofr/health.go
+++ b/pkg/gofr/health.go
@@ -9,9 +9,8 @@ type healthResponse struct {
 
 // healthHandler serves the public, unauthenticated /.well-known/health endpoint. It reports only
 // the application name and aggregate status — no hosts, ports, credentials, or connection stats.
-// No HTTP route serves the full detailed map after this change; Container.Health still computes it
-// for in-process ops tooling, and #3806 tracks exposing it on the metrics server (METRICS_PORT),
-// behind the same network boundary as /metrics and /debug/pprof.
+// The full detailed map is served instead at GET /health on the metrics server (METRICS_PORT),
+// behind the same network boundary as /metrics and /debug/pprof; see newMetricsMux.
 func healthHandler(c *Context) (any, error) {
 	return healthResponse{Name: c.GetAppName(), Status: aggregateStatus(c)}, nil
 }

--- a/pkg/gofr/metrics_server.go
+++ b/pkg/gofr/metrics_server.go
@@ -2,6 +2,7 @@ package gofr
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -30,7 +31,7 @@ func (m *metricServer) Run(c *container.Container) {
 		// ListenAndServe call never holds it while Shutdown reads srv.
 		srv := &http.Server{
 			Addr:              fmt.Sprintf(":%d", m.port),
-			Handler:           metrics.GetHandler(c.Metrics()),
+			Handler:           newMetricsMux(c),
 			ReadHeaderTimeout: 5 * time.Second,
 		}
 
@@ -58,4 +59,49 @@ func (m *metricServer) Shutdown(ctx context.Context) error {
 	return ShutdownWithContext(ctx, func(ctx context.Context) error {
 		return srv.Shutdown(ctx)
 	}, nil)
+}
+
+// newMetricsMux builds the metrics server's router: /metrics and /debug/pprof come from
+// metrics.GetHandler, and the detailed health map is served at /health for ops tooling —
+// the counterpart to the redacted public /.well-known/health endpoint. The /health route
+// is registered here rather than inside metrics.GetHandler so that function's exported
+// signature, and the metrics package's independence from container, stay untouched.
+func newMetricsMux(c *container.Container) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", detailedHealthHandler(c))
+	mux.Handle("/", metrics.GetHandler(c.Metrics()))
+
+	return mux
+}
+
+// detailedHealthHandler serves the full map computed by Container.Health — per-dependency
+// details included. It lives on the metrics port behind the same network boundary as
+// /metrics and /debug/pprof, never on the public HTTP port, which is what makes serving
+// the unredacted map acceptable. METRICS_PORT=0 disables the whole metrics server, this
+// endpoint with it.
+func detailedHealthHandler(c *container.Container) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// The route carries no method matcher — deliberately, so a non-GET does not
+		// fall through to the "/" catch-all and answer 404 for a path that exists.
+		// GET-only matches /metrics next to it, which registers Methods(GET).
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed on health endpoint", http.StatusMethodNotAllowed)
+
+			return
+		}
+
+		body, err := json.Marshal(c.Health(r.Context()))
+		if err != nil {
+			c.Errorf("failed to encode detailed health response: %v", err)
+			http.Error(w, "failed to encode health response", http.StatusInternalServerError)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, _ = w.Write(body)
+	}
 }

--- a/pkg/gofr/metrics_server_test.go
+++ b/pkg/gofr/metrics_server_test.go
@@ -1,0 +1,69 @@
+package gofr
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gofr.dev/pkg/gofr/testutil"
+)
+
+// TestMetricsMux_DetailedHealth covers GET /health on the metrics server: the detailed
+// map counterpart to the redacted public /.well-known/health endpoint (see #3806).
+func TestMetricsMux_DetailedHealth(t *testing.T) {
+	testutil.NewServerConfigs(t)
+
+	app := New()
+
+	srv := httptest.NewServer(newMetricsMux(app.container))
+	defer srv.Close()
+
+	const healthPath = "/health"
+
+	t.Run("GET serves the full detail map", func(t *testing.T) {
+		resp, err := srv.Client().Get(srv.URL + healthPath)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(body, &got))
+
+		// Pin the aggregate keys every consumer relies on; per-backend keys join them
+		// whenever datasources are configured. No datasources are configured here, so
+		// the aggregate is UP.
+		assert.Equal(t, "UP", got["status"])
+		assert.Contains(t, got, "name")
+		assert.Contains(t, got, "version")
+	})
+
+	t.Run("non-GET is refused", func(t *testing.T) {
+		resp, err := srv.Client().Post(srv.URL+healthPath, "application/json", http.NoBody)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("unknown paths still reach the underlying metrics router", func(t *testing.T) {
+		// The "/" catch-all mounts metrics.GetHandler. An unknown path must answer
+		// with that router's 404 rather than anything from the /health route — without
+		// scraping /metrics itself, whose status depends on process-global Prometheus
+		// registry state shared with every other test in this package.
+		resp, err := srv.Client().Get(srv.URL + "/no-such-route")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}


### PR DESCRIPTION
**Description:**

Fixes #3806.

The #3802 redaction left the detailed per-dependency health map served *nowhere*: the public `/.well-known/health` endpoint correctly reports only `{name, status}`, but ops tooling lost all per-dependency visibility. This PR serves the full map from `Container.Health()` at `GET /health` on the metrics server (`METRICS_PORT`, default `2121`), next to `/metrics` and `/debug/pprof`.

Implementation notes:

- The route is registered in `newMetricsMux` (package `gofr`), which mounts the existing `metrics.GetHandler` under `/`. Registering it there — rather than passing the container into `GetHandler` — avoids an import cycle (`container` already imports `metrics`) and leaves that exported signature untouched.
- The handler answers `200` with the raw JSON map regardless of aggregate status (same contract as the public endpoint — callers read the `status` field); non-GET gets `405` with an `Allow` header instead of falling through to the catch-all's `404`.
- `METRICS_PORT=0` disables the whole metrics server, this endpoint with it.
- Docs updated in `monitoring-service-health`, including the network-boundary caveat (the metrics port binds all interfaces — privacy means keeping it out of public ingress, same as `/debug/pprof`).

Verified with new `TestMetricsMux_DetailedHealth` (200 + body keys, POST → 405, unknown path → underlying router's 404). Full `pkg/gofr`, `pkg/gofr/http` and `pkg/gofr/metrics` suites pass; `go vet` clean.

**Breaking Changes (if applicable):**

None. Additive-only: one new route on the metrics port, no existing route or response shape touched.

**Additional Information:**

No new dependencies.

**Checklist:**

* [x] All new code is covered by unit tests.
* [x] I have reviewed the code comments and documentation for clarity.
* [x] This PR does not decrease the overall code coverage.
* [x] No new dependencies were added.
