### PR TITLE
perf(logging): cut two allocations from the request-log path

### DIFF
--- a/pkg/gofr/http/middleware/entry_logger_dispatch_test.go
+++ b/pkg/gofr/http/middleware/entry_logger_dispatch_test.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// countingEntryLogger implements both the plain logger contract and the
+// entryLogger fast path, and records which one the middleware actually used.
+type countingEntryLogger struct {
+	logCalls, errorCalls           int
+	logEntryCalls, errorEntryCalls int
+}
+
+func (c *countingEntryLogger) Log(...any)     { c.logCalls++ }
+func (c *countingEntryLogger) Error(...any)   { c.errorCalls++ }
+func (c *countingEntryLogger) LogEntry(any)   { c.logEntryCalls++ }
+func (c *countingEntryLogger) ErrorEntry(any) { c.errorEntryCalls++ }
+
+// TestEntryLoggerFastPathIsTaken pins that the middleware really uses the
+// optional interface when the logger offers it.
+//
+// This is the one thing the rest of the suite cannot catch. LogEntry and Log
+// produce byte-identical output by design, so a type assertion that silently
+// stopped matching -- a renamed method, a pointer/value receiver mismatch, an
+// interface that drifted -- would keep every output test passing while quietly
+// giving back the allocation the fast path exists to save. Only counting which
+// method was called can tell the difference.
+func TestEntryLoggerFastPathIsTaken(t *testing.T) {
+	logger := &countingEntryLogger{}
+
+	handler := Logging(LogProbes{}, logger)(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody))
+
+	assert.Equal(t, 1, logger.logEntryCalls, "the middleware must use the LogEntry fast path")
+	assert.Zero(t, logger.logCalls, "the variadic Log path allocates the slice this avoids")
+}
+
+// TestErrorEntryFastPathIsTaken is the same guarantee for the 5xx path, which
+// takes a different branch and could regress independently.
+func TestErrorEntryFastPathIsTaken(t *testing.T) {
+	logger := &countingEntryLogger{}
+
+	handler := Logging(LogProbes{}, logger)(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusInternalServerError) }))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody))
+
+	assert.Equal(t, 1, logger.errorEntryCalls, "a 5xx must use the ErrorEntry fast path")
+	assert.Zero(t, logger.errorCalls)
+}
+
+// plainOnlyLogger offers only the base contract, so the middleware must fall
+// back -- the compatibility half of the same guarantee.
+type plainOnlyLogger struct{ logCalls, errorCalls int }
+
+func (p *plainOnlyLogger) Log(...any)   { p.logCalls++ }
+func (p *plainOnlyLogger) Error(...any) { p.errorCalls++ }
+
+// TestFallbackForLoggerWithoutFastPath pins that an external logger that never
+// heard of LogEntry keeps working unchanged.
+func TestFallbackForLoggerWithoutFastPath(t *testing.T) {
+	logger := &plainOnlyLogger{}
+
+	handler := Logging(LogProbes{}, logger)(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody))
+
+	assert.Equal(t, 1, logger.logCalls, "a logger without the fast path must still be logged through")
+}

--- a/pkg/gofr/http/middleware/logger.go
+++ b/pkg/gofr/http/middleware/logger.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bufio"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -158,6 +159,19 @@ type logEnabler interface {
 	LogEnabled() bool
 }
 
+// entryLogger is the optional fast-path interface for logging one already-built
+// entry.
+//
+// The plain logger contract is Log(...any), so Log(l) allocates a one-element
+// []any on every request purely to be unwrapped again inside the logger. A
+// logger that can take the entry directly avoids it. An implementation without
+// these methods falls back to Log/Error and behaves exactly as before, so no
+// external logger is affected.
+type entryLogger interface {
+	LogEntry(any)
+	ErrorEntry(any)
+}
+
 // Logging is a middleware which logs response status and time in milliseconds along with other data.
 //
 // The StatusResponseWriter wrapper allocated per request is pooled in a
@@ -188,24 +202,19 @@ func Logging(probes LogProbes, logger logger) func(inner http.Handler) http.Hand
 				pool.Put(srw)
 			}()
 
-			// Fetch SpanContext once and resolve trace/span IDs to strings only
-			// when they are valid. Under a noop tracer (the default after PR-1
-			// when no exporter is configured) the SpanContext is invalid and
-			// the IDs are all-zeros — calling .String() on those is wasted
-			// allocation. Substitute the precomputed zero-string constants so
-			// the log line and the X-Correlation-ID response header carry
-			// byte-identical values to the pre-PR-7 wire shape.
+			// Fetch the SpanContext once. GoFr installs an SDK provider with NeverSample
+			// when no exporter is configured, so the default deployment has a VALID span
+			// context and both IDs are real -- the zero-string constants below are for
+			// the genuinely absent case, not the common one.
 			sc := trace.SpanFromContext(r.Context()).SpanContext()
 
-			// Only the trace ID is needed before the handler runs, for the
-			// X-Correlation-ID response header. The span ID is used solely
-			// inside the log entry, so it is resolved in handleRequestLog --
-			// after the level gate -- and costs nothing on a request whose
-			// entry is discarded.
-			traceID := zeroTraceID
-			if sc.IsValid() {
-				traceID = sc.TraceID().String()
-			}
+			// Both IDs are resolved here, in one allocation. The trace ID is
+			// needed before the handler runs, for the X-Correlation-ID response
+			// header; the span ID is only used inside the log entry, so a request
+			// whose entry the level gate discards pays for 16 bytes it does not
+			// use. That costs no extra allocation -- one buffer covers both -- and
+			// saves one on every request that IS logged, which is the default.
+			traceID, spanID := traceSpanIDs(sc)
 
 			// Assigned rather than Set: Header.Set canonicalizes its key on
 			// every call, and "X-Correlation-ID" is not already in canonical
@@ -225,15 +234,15 @@ func Logging(probes LogProbes, logger logger) func(inner http.Handler) http.Hand
 			}
 
 			start := time.Now()
-			defer handleRequestLog(srw, r, start, traceID, sc, logger)
+			defer handleRequestLog(srw, r, start, traceID, spanID, logger)
 
 			inner.ServeHTTP(srw, r)
 		})
 	}
 }
 
-func handleRequestLog(srw *StatusResponseWriter, r *http.Request, start time.Time, traceID string,
-	sc trace.SpanContext, logger logger) {
+func handleRequestLog(srw *StatusResponseWriter, r *http.Request, start time.Time,
+	traceID, spanID string, logger logger) {
 	status := srw.Status()
 
 	// A server error is reported through Error, which survives every level below
@@ -243,11 +252,6 @@ func handleRequestLog(srw *StatusResponseWriter, r *http.Request, start time.Tim
 		if e, ok := logger.(logEnabler); ok && !e.LogEnabled() {
 			return
 		}
-	}
-
-	spanID := zeroSpanID
-	if sc.IsValid() {
-		spanID = sc.SpanID().String()
 	}
 
 	l := &RequestLog{
@@ -262,12 +266,24 @@ func handleRequestLog(srw *StatusResponseWriter, r *http.Request, start time.Tim
 		Response:     status,
 	}
 
-	if logger != nil {
+	if logger == nil {
+		return
+	}
+
+	if e, ok := logger.(entryLogger); ok {
 		if status >= http.StatusInternalServerError {
-			logger.Error(l)
+			e.ErrorEntry(l)
 		} else {
-			logger.Log(l)
+			e.LogEntry(l)
 		}
+
+		return
+	}
+
+	if status >= http.StatusInternalServerError {
+		logger.Error(l)
+	} else {
+		logger.Log(l)
 	}
 }
 
@@ -343,4 +359,33 @@ func panicRecovery(re any, w http.ResponseWriter, logger logger) {
 		envelopeMessageKey: "Some unexpected error has occurred",
 	}
 	_ = json.NewEncoder(w).Encode(res)
+}
+
+// traceSpanIDs renders both IDs into ONE allocation.
+//
+// otel's TraceID.String() and SpanID.String() are each a hex.EncodeToString, so
+// each costs its own string allocation, and a logged request always needs both --
+// the trace ID for the correlation header, both for the log entry. Encoding them
+// into a single buffer and slicing the result gives byte-identical strings for
+// one allocation instead of two.
+//
+// The span ID is now formatted before the level gate rather than after it, so a
+// request whose entry is discarded pays for 16 bytes it does not use. That costs
+// no extra allocation -- the one buffer covers both -- and it buys an allocation
+// on every request that IS logged, which is the default configuration.
+func traceSpanIDs(sc trace.SpanContext) (traceID, spanID string) {
+	if !sc.IsValid() {
+		return zeroTraceID, zeroSpanID
+	}
+
+	tid, sid := sc.TraceID(), sc.SpanID()
+
+	var b [len(zeroTraceID) + len(zeroSpanID)]byte
+
+	hex.Encode(b[:len(zeroTraceID)], tid[:])
+	hex.Encode(b[len(zeroTraceID):], sid[:])
+
+	s := string(b[:])
+
+	return s[:len(zeroTraceID)], s[len(zeroTraceID):]
 }

--- a/pkg/gofr/http/middleware/logger_test.go
+++ b/pkg/gofr/http/middleware/logger_test.go
@@ -520,7 +520,7 @@ func TestRequestLogEmittedWhenLevelAllows(t *testing.T) {
 	srw := &StatusResponseWriter{ResponseWriter: httptest.NewRecorder(), status: http.StatusOK}
 
 	handleRequestLog(srw, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody),
-		time.Now(), "tid", trace.SpanContext{}, lg)
+		time.Now(), "tid", zeroSpanID, lg)
 
 	require.Equal(t, 1, lg.logCalls, "an allowed level must still emit the request log")
 }
@@ -531,7 +531,7 @@ func TestRequestLogSkippedWhenLevelDiscards(t *testing.T) {
 	srw := &StatusResponseWriter{ResponseWriter: httptest.NewRecorder(), status: http.StatusOK}
 
 	handleRequestLog(srw, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody),
-		time.Now(), "tid", trace.SpanContext{}, lg)
+		time.Now(), "tid", zeroSpanID, lg)
 
 	require.Zero(t, lg.logCalls, "a discarded level must not be handed an entry")
 }
@@ -543,7 +543,7 @@ func TestRequestLogAlwaysEmittedForServerErrors(t *testing.T) {
 	srw := &StatusResponseWriter{ResponseWriter: httptest.NewRecorder(), status: http.StatusInternalServerError}
 
 	handleRequestLog(srw, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody),
-		time.Now(), "tid", trace.SpanContext{}, lg)
+		time.Now(), "tid", zeroSpanID, lg)
 
 	require.Equal(t, 1, lg.errCalls, "a server error must be logged regardless of the informational level")
 }
@@ -555,7 +555,7 @@ func TestRequestLogUngatedLoggerUnaffected(t *testing.T) {
 	srw := &StatusResponseWriter{ResponseWriter: httptest.NewRecorder(), status: http.StatusOK}
 
 	handleRequestLog(srw, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody),
-		time.Now(), "tid", trace.SpanContext{}, lg)
+		time.Now(), "tid", zeroSpanID, lg)
 
 	require.Equal(t, 1, lg.logCalls, "a logger without the gate must still receive the entry")
 }
@@ -652,7 +652,7 @@ func TestRequestLogGateWithRealLoggers(t *testing.T) {
 					srw := &StatusResponseWriter{ResponseWriter: httptest.NewRecorder(), status: http.StatusOK}
 					req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", http.NoBody)
 
-					handleRequestLog(srw, req, time.Now(), "tid", trace.SpanContext{}, build.make(tt.level))
+					handleRequestLog(srw, req, time.Now(), "tid", zeroSpanID, build.make(tt.level))
 				})
 
 				assert.Equal(t, tt.emitted, strings.Contains(out, "/x"),
@@ -673,7 +673,7 @@ func TestRequestLogGateNeverSuppresses5xx(t *testing.T) {
 		}
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/boom", http.NoBody)
 
-		handleRequestLog(srw, req, time.Now(), "tid", trace.SpanContext{},
+		handleRequestLog(srw, req, time.Now(), "tid", zeroSpanID,
 			remotelogger.New(logging.ERROR, "", time.Second))
 	})
 
@@ -1903,7 +1903,7 @@ func Test_LoggingContract_HandleRequestLogNilLogger(t *testing.T) {
 	req := logCharNewRequest(t, http.MethodGet, "http://dummy/nil-logger")
 
 	assert.NotPanics(t, func() {
-		handleRequestLog(srw, req, time.Now(), zeroTraceID, trace.SpanContext{}, nil)
+		handleRequestLog(srw, req, time.Now(), zeroTraceID, zeroSpanID, nil)
 	})
 }
 

--- a/pkg/gofr/http/middleware/logging_alloc_guard_test.go
+++ b/pkg/gofr/http/middleware/logging_alloc_guard_test.go
@@ -1,0 +1,96 @@
+//go:build !race
+
+// Allocation counts are only meaningful without the race detector, which adds
+// bookkeeping allocations of its own -- this same measurement reads 8 normally
+// and 11 under -race. The guard is therefore excluded from race builds rather
+// than loosened to a tolerance that would no longer catch anything.
+
+package middleware
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"gofr.dev/pkg/gofr/logging"
+)
+
+// discardWriter is a ResponseWriter that allocates nothing, so the count below
+// is the middleware's and not httptest's.
+type discardWriter struct{ h http.Header }
+
+func (d *discardWriter) Header() http.Header       { return d.h }
+func (*discardWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (*discardWriter) WriteHeader(int)             {}
+
+// TestLoggingChainAllocationsDoNotRegress guards the allocations removed from
+// the request-log path.
+//
+// Both savings here -- taking the log entry through LogEntry instead of a
+// variadic Log, and rendering the trace and span IDs into one buffer instead of
+// two -- are invisible from the outside: the bytes logged are identical either
+// way, so every other test in this file passes with them reverted. This counts
+// instead.
+//
+// It pins the count exactly, because each saving is worth one allocation and a
+// tolerance wide enough to absorb drift is also wide enough to hide a
+// regression. Reverting either optimization takes this from 8 to 9.
+//
+// The span context is valid on purpose. GoFr installs an SDK provider with
+// NeverSample when no exporter is configured, so a default deployment really
+// does format both IDs on every request; measuring with an invalid one would
+// skip the very work being guarded.
+func TestLoggingChainAllocationsDoNotRegress(t *testing.T) {
+	// Exact, not a ceiling with headroom. Each saving here is worth exactly one
+	// allocation, so any slack at all makes the guard blind to losing one -- an
+	// earlier version allowed 21 against a measured 18 and passed with BOTH
+	// optimizations reverted. AllocsPerRun is deterministic for fixed code, so the
+	// only thing that moves this number is a Go or dependency upgrade, and that is
+	// worth a human looking at rather than absorbing silently. If this fails after
+	// such an upgrade, re-measure and update the constant in the same commit.
+	const wantAllocs = 8
+
+	tid, err := trace.TraceIDFromHex("0af7651916cd43dd8448eb211c80319c")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sid, err := trace.SpanIDFromHex("b7ad6b7169203331")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: tid, SpanID: sid})
+
+	// A real logger, not the mock. MockLogger does not implement LogEntry, so the
+	// middleware would take the variadic fallback and the guard would be blind to
+	// the very saving it exists to protect -- and it would measure the mock's own
+	// fmt.Fprintf to stdout rather than the framework's work. NewFileLogger with an
+	// empty path writes to io.Discard.
+	handler := Logging(LogProbes{}, logging.NewFileLogger(""))(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, "ok")
+		}))
+
+	req := httptest.NewRequestWithContext(
+		trace.ContextWithSpanContext(t.Context(), sc), http.MethodGet, "/x", http.NoBody)
+	w := &discardWriter{h: make(http.Header, 4)}
+
+	// Warm the pooled status writer so the measured runs see the steady state.
+	for range 5 {
+		handler.ServeHTTP(w, req)
+	}
+
+	got := testing.AllocsPerRun(300, func() { handler.ServeHTTP(w, req) })
+
+	if got != wantAllocs {
+		t.Errorf("request-log path allocates %.0f objects, expected exactly %d -- an "+
+			"optimization in this package has regressed, or a toolchain change moved the "+
+			"baseline", got, wantAllocs)
+	}
+
+	t.Logf("request-log path: %.0f allocations", got)
+}

--- a/pkg/gofr/logging/logger.go
+++ b/pkg/gofr/logging/logger.go
@@ -103,9 +103,22 @@ func (l *logger) logf(level Level, format string, args ...any) {
 
 	if l.isTerminal {
 		l.prettyPrint(&entry, out)
-	} else {
-		_ = json.NewEncoder(out).Encode(entry)
+
+		return
 	}
+
+	l.encodeJSON(&entry, out)
+}
+
+// encodeJSON writes one entry as JSON.
+//
+// The entry is taken by pointer so that logf and logEntry can share this without
+// copying the struct at the call. That is a readability choice, not a saving:
+// &entry escapes into Encode's any exactly as a boxed copy would, and the
+// allocation count is identical either way -- measured at 4 for Log and 6 for
+// Infof, before and after. encoding/json produces the same bytes for both.
+func (*logger) encodeJSON(entry *logEntry, out io.Writer) {
+	_ = json.NewEncoder(out).Encode(entry)
 }
 
 func (l *logger) Debug(args ...any) {
@@ -157,6 +170,55 @@ func (l *logger) Log(args ...any) {
 // raised LOG_LEVEL. It returns false only from NOTICE upward.
 func (l *logger) LogEnabled() bool {
 	return l.enabled(INFO)
+}
+
+// LogEntry logs a single pre-built value at INFO without the slice a variadic
+// call allocates.
+//
+// Log takes ...any, so Log(x) allocates a one-element []any on every call. On a
+// server that logs every request that is an allocation per request, for a slice
+// whose only purpose is to be unwrapped again immediately. This is the same
+// entry, the same level and byte-identical output; only the boxing is gone.
+//
+// It is deliberately NOT part of the exported Logger interface -- adding a method
+// there would break every external implementation. Callers reach it through an
+// optional interface assertion, exactly as LogEnabled is reached, so a logger
+// that does not provide it keeps working unchanged.
+func (l *logger) LogEntry(entry any) {
+	l.logEntry(INFO, entry)
+}
+
+// ErrorEntry is LogEntry at ERROR.
+func (l *logger) ErrorEntry(entry any) {
+	l.logEntry(ERROR, entry)
+}
+
+// logEntry builds and emits an entry from a single already-boxed message,
+// skipping the variadic path's slice allocation and its trace-ID scan.
+func (l *logger) logEntry(level Level, msg any) {
+	if !l.enabled(level) {
+		return
+	}
+
+	out := l.normalOut
+	if level >= ERROR {
+		out = l.errorOut
+	}
+
+	entry := logEntry{
+		Level:       level,
+		Time:        time.Now(),
+		Message:     msg,
+		GofrVersion: version.Framework,
+	}
+
+	if l.isTerminal {
+		l.prettyPrint(&entry, out)
+
+		return
+	}
+
+	l.encodeJSON(&entry, out)
 }
 
 func (l *logger) Logf(format string, args ...any) {

--- a/pkg/gofr/logging/perf_parity_test.go
+++ b/pkg/gofr/logging/perf_parity_test.go
@@ -1,0 +1,111 @@
+package logging
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestLogEntryOutputMatchesLog is the parity guarantee behind the fast path.
+//
+// LogEntry exists only to avoid the []any a variadic Log allocates. If it ever
+// produced different bytes, every service that logs requests would silently
+// change its log format on upgrade -- a breaking change with no compile error to
+// catch it.
+func TestLogEntryOutputMatchesLog(t *testing.T) {
+	msgs := []any{
+		"a plain string",
+		map[string]string{"k": "v"},
+		struct {
+			A int    `json:"a"`
+			B string `json:"b"`
+		}{1, "two"},
+		42,
+		nil,
+	}
+
+	for _, msg := range msgs {
+		var viaLog, viaEntry bytes.Buffer
+
+		newLoggerAt(INFO, &viaLog, &viaLog).Log(msg)
+		newLoggerAt(INFO, &viaEntry, &viaEntry).LogEntry(msg)
+
+		if stripTime(viaLog.String()) != stripTime(viaEntry.String()) {
+			t.Errorf("output differs for %#v:\n Log:      %s\n LogEntry: %s",
+				msg, viaLog.String(), viaEntry.String())
+		}
+	}
+}
+
+// TestErrorEntryOutputMatchesError pins the same parity on the error path, which
+// is the one a 5xx takes.
+func TestErrorEntryOutputMatchesError(t *testing.T) {
+	var viaErr, viaEntry bytes.Buffer
+
+	newLoggerAt(INFO, &viaErr, &viaErr).Error("boom")
+	newLoggerAt(INFO, &viaEntry, &viaEntry).ErrorEntry("boom")
+
+	if stripTime(viaErr.String()) != stripTime(viaEntry.String()) {
+		t.Errorf("error output differs:\n Error:      %s\n ErrorEntry: %s",
+			viaErr.String(), viaEntry.String())
+	}
+}
+
+// TestLogEntryRespectsLevel pins that the fast path is gated exactly as Log is.
+// A fast path that ignored the level would emit entries a configured service
+// expects to be suppressed.
+func TestLogEntryRespectsLevel(t *testing.T) {
+	var buf bytes.Buffer
+
+	l := newLoggerAt(ERROR, &buf, &buf)
+
+	l.LogEntry("should be suppressed at ERROR")
+
+	if buf.Len() != 0 {
+		t.Errorf("LogEntry emitted below the configured level: %s", buf.String())
+	}
+
+	l.ErrorEntry("should survive at ERROR")
+
+	if buf.Len() == 0 {
+		t.Error("ErrorEntry was suppressed at ERROR")
+	}
+}
+
+// TestLogEntryFollowsChangeLevel pins that a level raised at runtime -- which is
+// what the remote logger does -- takes effect on the fast path too.
+func TestLogEntryFollowsChangeLevel(t *testing.T) {
+	var buf bytes.Buffer
+
+	l := newLoggerAt(INFO, &buf, &buf)
+
+	l.LogEntry("first")
+
+	if buf.Len() == 0 {
+		t.Fatal("entry suppressed at INFO")
+	}
+
+	buf.Reset()
+	l.ChangeLevel(FATAL)
+	l.LogEntry("second")
+
+	if buf.Len() != 0 {
+		t.Errorf("entry survived a level raise: %s", buf.String())
+	}
+}
+
+// stripTime removes the timestamp field, which necessarily differs between two
+// calls and is not what these tests are comparing.
+func stripTime(s string) string {
+	i := strings.Index(s, `"time":`)
+	if i < 0 {
+		return s
+	}
+
+	j := strings.Index(s[i:], `,`)
+	if j < 0 {
+		return s
+	}
+
+	return s[:i] + s[i+j+1:]
+}

--- a/pkg/gofr/logging/remotelogger/dynamic_level_logger.go
+++ b/pkg/gofr/logging/remotelogger/dynamic_level_logger.go
@@ -152,11 +152,26 @@ func New(level logging.Level, remoteConfigURL string, loggerFetchInterval time.D
 		l.enabler = e
 	}
 
+	// Resolved once, here, for the same reason as enabler: the embedded logger is
+	// assigned in New and never reassigned, so a per-request assertion would pay
+	// for a question whose answer cannot change.
+	if e, ok := base.(entryLogger); ok {
+		l.entries = e
+	}
+
 	if remoteConfigURL != "" {
 		go l.UpdateLogLevel()
 	}
 
 	return l
+}
+
+// entryLogger is the optional interface a logger implements when it can take an
+// already-built entry directly, without the one-element slice a variadic Log
+// allocates to carry it. It mirrors the middleware's own contract.
+type entryLogger interface {
+	LogEntry(any)
+	ErrorEntry(any)
 }
 
 // logEnabler is the optional interface a logger implements when it can report,
@@ -174,7 +189,41 @@ type remoteLogger struct {
 	// enabler is the embedded logger's LogEnabled, resolved once in New. nil
 	// when the embedded logger does not implement it.
 	enabler logEnabler
+	// entries is the embedded logger's single-value log path, resolved once in
+	// New. nil when the embedded logger does not implement it.
+	entries entryLogger
 	logging.Logger
+}
+
+// LogEntry forwards a single pre-built entry to the embedded logger's
+// allocation-free path, bypassing the slice a variadic Log allocates.
+//
+// Forwarding is safe with respect to the dynamic level: this type does not gate
+// on currentLevel, it PUSHES level changes down with ChangeLevel, and the
+// embedded logger applies them to its own atomic before deciding. So an entry
+// routed this way passes exactly the same gate as one routed through Log.
+//
+// An embedded logger without the fast path leaves entries nil and falls back to
+// Log, which is what every external Logger implementation will do.
+func (r *remoteLogger) LogEntry(entry any) {
+	if r.entries == nil {
+		r.Log(entry)
+
+		return
+	}
+
+	r.entries.LogEntry(entry)
+}
+
+// ErrorEntry forwards a single pre-built entry at ERROR, mirroring LogEntry.
+func (r *remoteLogger) ErrorEntry(entry any) {
+	if r.entries == nil {
+		r.Error(entry)
+
+		return
+	}
+
+	r.entries.ErrorEntry(entry)
 }
 
 // LogEnabled reports whether an entry written through Log survives the level


### PR DESCRIPTION
**Description:**

**10 → 8 allocations per logged request.** The bytes written are **identical** either way.

Measured through the Logging middleware with a real logger and a valid span context — GoFr installs a `NeverSample` provider when no exporter is configured, so the default deployment has one. Reverting either change individually puts it back to 9.

**1. Drop the `[]any` wrapper.** The middleware called `Log(entry)`, and `Log` takes `...any` — so every request allocated a **one-element slice** to carry a single value the logger then unwrapped again.

`LogEntry` / `ErrorEntry` take that value directly. They are found through an **optional interface**, not added to `logging.Logger`, so:
- an external implementation of `Logger` is **unaffected** and keeps using `Log`/`Error`
- `remotelogger` forwards them because it embeds the interface — nothing is promoted

**2. Encode both trace IDs into one buffer.** `TraceID.String()` and `SpanID.String()` are each a `hex.EncodeToString`, so each was its own allocation. A logged request **always needs both** — trace ID for `X-Correlation-ID`, both for the entry — so they share one buffer now.

> The span ID is formatted before the level gate rather than after. A request whose entry is discarded pays for 16 bytes it does not use; that costs no extra allocation and buys one on every request that *is* logged, which is the default.

**Breaking Changes (if applicable):**

**None.**

| | |
|---|---|
| Log output | **byte-identical** |
| `logging.Logger` interface | unchanged |
| External logger implementations | unaffected — they keep the `Log`/`Error` path |

**Additional Information:**

- No new dependencies.
- **`TestLoggingChainAllocationsDoNotRegress` pins 8 exactly, not as a ceiling.** Each saving is worth one allocation, so any tolerance wide enough to absorb toolchain drift is also wide enough to hide a regression.
- It uses a **real logger** deliberately: `logging.MockLogger` does not implement `LogEntry`, so a guard built on it takes the fallback path and **cannot see this change at all**.
- **`TestEntryLoggerFastPathIsTaken`** pins that the optional interface is actually used. Output is identical either way, so a dead type assertion would otherwise pass every test while silently forfeiting the saving.
- The allocation guard carries `//go:build !race` — the race detector adds allocations, so an exact count cannot hold under it.

**Checklist:**

-   [x] I have formatted my code using `goimport` and `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.