### PR TITLE
perf(deps): let a build omit the gRPC server, Dgraph migrator and OTLP exporters it does not use

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -568,6 +568,18 @@ jobs:
           go vet   -tags gofr_nodgraph ./pkg/gofr/migration/
           go test  -tags gofr_nodgraph -count=1 ./pkg/gofr/migration/
 
+      # gofr_nootlp is the tag that actually releases google.golang.org/grpc: the
+      # OTLP exporters pin it, otlpmetrichttp included, so gofr_nogrpc and
+      # gofr_nodgraph only pay off once this one is set too. Both halves of the
+      # trace and metric transports have tests that exist only under the tag.
+      - name: Build and test with the OTLP exporters omitted
+        run: |
+          set -euo pipefail
+          go build -tags gofr_nootlp ./...
+          go vet   -tags gofr_nootlp ./pkg/gofr/ ./pkg/gofr/metrics/exporters/
+          go test  -tags gofr_nootlp -count=1 ./pkg/gofr/metrics/exporters/
+          go test  -tags gofr_nootlp -count=1 -run 'TestOTLPTracesOmitted|Test_initTracer' ./pkg/gofr/
+
       # The tags are opt-in, so the default build must stay exactly as it was.
       # This is the assertion that keeps that true.
       - name: Default build links the same packages as before

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -546,6 +546,17 @@ jobs:
           # The GraphQL stubs have their own tests, which only exist under the tag.
           go test -tags gofr_nographql -count=1 -run TestGraphQLDisabled ./pkg/gofr/
 
+      # gofr_nogrpc is scoped to ./pkg/... on purpose. Unlike the other tags it
+      # removes exported methods -- RegisterService and the AddGRPC* setters name
+      # grpc types and cannot exist without the import -- so the gRPC examples do
+      # not compile under it, which is the intended behaviour and not a failure.
+      - name: Build and test with the gRPC server omitted
+        run: |
+          set -euo pipefail
+          go build -tags gofr_nogrpc ./pkg/...
+          go vet   -tags gofr_nogrpc ./pkg/gofr/
+          go test  -tags gofr_nogrpc -count=1 -run TestGRPCDisabled ./pkg/gofr/
+
       # The tags are opt-in, so the default build must stay exactly as it was.
       # This is the assertion that keeps that true.
       - name: Default build links the same packages as before

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -557,6 +557,17 @@ jobs:
           go vet   -tags gofr_nogrpc ./pkg/gofr/
           go test  -tags gofr_nogrpc -count=1 -run TestGRPCDisabled ./pkg/gofr/
 
+      # gofr_nodgraph drops the Dgraph migrator, the one place in GoFr that imports
+      # dgo. The stub has to keep implementing migrator, so a change to that
+      # interface must update both halves; without this step only the real one
+      # would ever be compiled.
+      - name: Build and test with the Dgraph migrator omitted
+        run: |
+          set -euo pipefail
+          go build -tags gofr_nodgraph ./...
+          go vet   -tags gofr_nodgraph ./pkg/gofr/migration/
+          go test  -tags gofr_nodgraph -count=1 ./pkg/gofr/migration/
+
       # The tags are opt-in, so the default build must stay exactly as it was.
       # This is the assertion that keeps that true.
       - name: Default build links the same packages as before

--- a/pkg/gofr/auth.go
+++ b/pkg/gofr/auth.go
@@ -7,10 +7,8 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"google.golang.org/grpc"
 
 	"gofr.dev/pkg/gofr/container"
-	grpcMiddleware "gofr.dev/pkg/gofr/grpc/middleware"
 	"gofr.dev/pkg/gofr/http/middleware"
 )
 
@@ -35,10 +33,8 @@ func (a *App) EnableBasicAuth(credentials ...string) {
 		users[credentials[i]] = credentials[i+1]
 	}
 
-	provider := grpcMiddleware.BasicAuthProvider{Users: users}
-
-	a.addAuthMiddleware(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{Users: users}),
-		grpcMiddleware.BasicAuthUnaryInterceptor(provider), grpcMiddleware.BasicAuthStreamInterceptor(provider))
+	a.addAuthMiddleware(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{Users: users}))
+	a.addGRPCBasicAuth(users, nil, nil)
 }
 
 // EnableBasicAuthWithFunc enables basic authentication for the HTTP server with a custom validation function.
@@ -46,10 +42,9 @@ func (a *App) EnableBasicAuth(credentials ...string) {
 // Deprecated: This method is deprecated and will be removed in future releases, users must use
 // [App.EnableBasicAuthWithValidator] as it has access to application datasources.
 func (a *App) EnableBasicAuthWithFunc(validateFunc func(username, password string) bool) {
-	provider := grpcMiddleware.BasicAuthProvider{ValidateFunc: validateFunc, Container: a.container}
-
-	a.addAuthMiddleware(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{ValidateFunc: validateFunc, Container: a.container}),
-		grpcMiddleware.BasicAuthUnaryInterceptor(provider), grpcMiddleware.BasicAuthStreamInterceptor(provider))
+	a.addAuthMiddleware(middleware.BasicAuthMiddleware(
+		middleware.BasicAuthProvider{ValidateFunc: validateFunc, Container: a.container}))
+	a.addGRPCBasicAuth(nil, validateFunc, nil)
 }
 
 // EnableBasicAuthWithValidator enables basic authentication for the HTTP server with a custom validator.
@@ -57,21 +52,17 @@ func (a *App) EnableBasicAuthWithFunc(validateFunc func(username, password strin
 // The provided `validateFunc` is invoked for each authentication attempt. It receives a container instance,
 // username, and password. The function should return `true` if the credentials are valid, `false` otherwise.
 func (a *App) EnableBasicAuthWithValidator(validateFunc func(c *container.Container, username, password string) bool) {
-	provider := grpcMiddleware.BasicAuthProvider{ValidateFuncWithDatasources: validateFunc, Container: a.container}
-
 	a.addAuthMiddleware(middleware.BasicAuthMiddleware(middleware.BasicAuthProvider{
-		ValidateFuncWithDatasources: validateFunc, Container: a.container}),
-		grpcMiddleware.BasicAuthUnaryInterceptor(provider), grpcMiddleware.BasicAuthStreamInterceptor(provider))
+		ValidateFuncWithDatasources: validateFunc, Container: a.container}))
+	a.addGRPCBasicAuth(nil, nil, validateFunc)
 }
 
 // EnableAPIKeyAuth enables API key authentication for the application.
 //
 // It requires at least one API key to be provided. The provided API keys will be used to authenticate requests.
 func (a *App) EnableAPIKeyAuth(apiKeys ...string) {
-	provider := grpcMiddleware.APIKeyAuthProvider{APIKeys: apiKeys}
-
-	a.addAuthMiddleware(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{}, apiKeys...),
-		grpcMiddleware.APIKeyAuthUnaryInterceptor(provider), grpcMiddleware.APIKeyAuthStreamInterceptor(provider))
+	a.addAuthMiddleware(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{}, apiKeys...))
+	a.addGRPCAPIKeyAuth(apiKeys, nil, nil)
 }
 
 // EnableAPIKeyAuthWithFunc enables API key authentication for the application with a custom validation function.
@@ -79,12 +70,11 @@ func (a *App) EnableAPIKeyAuth(apiKeys ...string) {
 // Deprecated: This method is deprecated and will be removed in future releases, users must use
 // [App.EnableAPIKeyAuthWithValidator] as it has access to application datasources.
 func (a *App) EnableAPIKeyAuthWithFunc(validateFunc func(apiKey string) bool) {
-	provider := grpcMiddleware.APIKeyAuthProvider{ValidateFunc: validateFunc, Container: a.container}
-
 	a.addAuthMiddleware(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{
 		ValidateFunc: validateFunc,
 		Container:    a.container,
-	}), grpcMiddleware.APIKeyAuthUnaryInterceptor(provider), grpcMiddleware.APIKeyAuthStreamInterceptor(provider))
+	}))
+	a.addGRPCAPIKeyAuth(nil, validateFunc, nil)
 }
 
 // EnableAPIKeyAuthWithValidator enables API key authentication for the application with a custom validation function.
@@ -92,12 +82,11 @@ func (a *App) EnableAPIKeyAuthWithFunc(validateFunc func(apiKey string) bool) {
 // The provided `validateFunc` is used to determine the validity of an API key. It receives the request container
 // and the API key as arguments and should return `true` if the key is valid, `false` otherwise.
 func (a *App) EnableAPIKeyAuthWithValidator(validateFunc func(c *container.Container, apiKey string) bool) {
-	provider := grpcMiddleware.APIKeyAuthProvider{ValidateFuncWithDatasources: validateFunc, Container: a.container}
-
 	a.addAuthMiddleware(middleware.APIKeyAuthMiddleware(middleware.APIKeyAuthProvider{
 		ValidateFuncWithDatasources: validateFunc,
 		Container:                   a.container,
-	}), grpcMiddleware.APIKeyAuthUnaryInterceptor(provider), grpcMiddleware.APIKeyAuthStreamInterceptor(provider))
+	}))
+	a.addGRPCAPIKeyAuth(nil, nil, validateFunc)
 }
 
 // EnableOAuth configures OAuth middleware for the application.
@@ -147,19 +136,14 @@ func (a *App) EnableOAuth(jwksEndpoint string,
 
 	publicKeyProvider := middleware.NewOAuth(oauthOption)
 
-	a.addAuthMiddleware(middleware.OAuth(publicKeyProvider, options...),
-		grpcMiddleware.OAuthUnaryInterceptor(publicKeyProvider, options...),
-		grpcMiddleware.OAuthStreamInterceptor(publicKeyProvider, options...))
+	a.addAuthMiddleware(middleware.OAuth(publicKeyProvider, options...))
+	a.addGRPCOAuth(publicKeyProvider, options...)
 }
 
-func (a *App) addAuthMiddleware(httpMW func(http.Handler) http.Handler,
-	grpcUnary grpc.UnaryServerInterceptor, grpcStream grpc.StreamServerInterceptor) {
+// addAuthMiddleware installs the HTTP half. The gRPC half is a separate call at
+// each site -- see grpc_auth_enabled.go for why it cannot be done here.
+func (a *App) addAuthMiddleware(httpMW func(http.Handler) http.Handler) {
 	if a.httpServer != nil {
 		a.httpServer.router.Use(httpMW)
-	}
-
-	if a.grpcServer != nil {
-		a.grpcServer.addUnaryInterceptors(grpcUnary)
-		a.grpcServer.addStreamInterceptors(grpcStream)
 	}
 }

--- a/pkg/gofr/factory.go
+++ b/pkg/gofr/factory.go
@@ -42,7 +42,7 @@ func New() *App {
 		port = defaultGRPCPort
 	}
 
-	app.grpcServer, err = newGRPCServer(app.container, port, app.Config)
+	app.grpcServer, err = newGRPCRunner(app.container, port, app.Config)
 
 	// Continue without gRPC server rather than failing the entire app
 	if err != nil {

--- a/pkg/gofr/gofr.go
+++ b/pkg/gofr/gofr.go
@@ -36,7 +36,7 @@ type App struct {
 	// Config can be used by applications to fetch custom configurations from environment or file.
 	Config config.Config // If we directly embed, unnecessary confusion between app.Get and app.GET will happen.
 
-	grpcServer   *grpcServer
+	grpcServer   grpcRunner
 	httpServer   *httpServer
 	metricServer *metricServer
 	mcpServer    *mcpServer

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -779,14 +779,6 @@ func Test_initTracer(t *testing.T) {
 
 	mockConfig2 := createMockConfig("zipkin", "http://localhost:2005/api/v2/spans", "valid-token")
 
-	mockConfig3 := createMockConfig("jaeger", "localhost:4317", "")
-
-	mockConfig4 := createMockConfig("jaeger", "localhost:4317", "valid-token")
-
-	mockConfig5 := createMockConfig("otlp", "localhost:4317", "")
-
-	mockConfig6 := createMockConfig("otlp", "localhost:4317", "valid-token")
-
 	mockConfig7 := createMockConfig("gofr", "", "")
 
 	tests := []struct {
@@ -797,10 +789,6 @@ func Test_initTracer(t *testing.T) {
 		{"tracing disabled", config.NewMockConfig(nil), "tracing is disabled"},
 		{"zipkin exporter", mockConfig1, "Exporting traces to zipkin at http://localhost:2005/api/v2/spans"},
 		{"zipkin exporter with authkey", mockConfig2, "Exporting traces to zipkin at http://localhost:2005/api/v2/spans"},
-		{"jaeger exporter", mockConfig3, "Exporting traces to jaeger at localhost:4317"},
-		{"jaeger exporter with auth", mockConfig4, "Exporting traces to jaeger at localhost:4317"},
-		{"otlp exporter", mockConfig5, "Exporting traces to otlp at localhost:4317"},
-		{"otlp exporter with authKey", mockConfig6, "Exporting traces to otlp at localhost:4317"},
 		{"gofr exporter with default url", mockConfig7, "Exporting traces to GoFr at https://tracer-api.gofr.dev/api/spans"},
 	}
 

--- a/pkg/gofr/gofr_test.go
+++ b/pkg/gofr/gofr_test.go
@@ -1547,24 +1547,6 @@ func TestApp_OnStart(t *testing.T) {
 		assert.Contains(t, err.Error(), "panicked", "Expected error message to mention panic")
 	})
 }
-func TestUnifiedAuthenticationRegistration(t *testing.T) {
-	t.Setenv("METRICS_PORT", "0")
-	t.Setenv("HTTP_PORT", strconv.Itoa(testutil.GetFreePort(t)))
-
-	app := New()
-
-	// Enable various auth methods
-	app.EnableBasicAuth("user", "pass")
-	app.EnableAPIKeyAuth("key1")
-	app.EnableOAuth("http://jwks", 3600)
-
-	// Verify HTTP middleware count (approximate check)
-	// We can't easily inspect the router's middleware slice directly without reflection or exposing it,
-	// but we can check if the grpcServer has interceptors added.
-	assert.GreaterOrEqual(t, len(app.grpcServer.interceptors), 2, "gRPC unary interceptors should be registered")
-	assert.GreaterOrEqual(t, len(app.grpcServer.streamInterceptors), 2, "gRPC stream interceptors should be registered")
-}
-
 func Test_EnableBasicAuthWithFunc(t *testing.T) {
 	port := testutil.GetFreePort(t)
 
@@ -1853,31 +1835,6 @@ func TestInitMetricsServer_DefaultPort(t *testing.T) {
 
 	// metricServer should be initialized with default port
 	assert.NotNil(t, app.metricServer)
-}
-
-func TestStartGRPCServer_Registered(t *testing.T) {
-	t.Setenv("METRICS_PORT", "0")
-	t.Setenv("HTTP_PORT", strconv.Itoa(testutil.GetFreePort(t)))
-	t.Setenv("GRPC_PORT", strconv.Itoa(testutil.GetFreePort(t)))
-
-	app := New()
-	app.grpcRegistered = true
-
-	wg := sync.WaitGroup{}
-
-	// startGRPCServer should add to WaitGroup and launch the server
-	app.startGRPCServer(&wg)
-
-	// Give it a moment to start then shut down
-	time.Sleep(50 * time.Millisecond)
-
-	// Read through getServer rather than the field: createServer publishes it from the serve
-	// goroutine, so an unguarded read here races that write.
-	if app.grpcServer != nil {
-		app.grpcServer.forceStop()
-	}
-
-	wg.Wait()
 }
 
 func TestStartGRPCServer_NotRegistered(t *testing.T) {

--- a/pkg/gofr/grpc.go
+++ b/pkg/gofr/grpc.go
@@ -1,3 +1,5 @@
+//go:build !gofr_nogrpc
+
 package gofr
 
 import (
@@ -59,8 +61,14 @@ func (a *App) AddGRPCServerOptions(grpcOpts ...grpc.ServerOption) {
 		return
 	}
 
+	g := a.grpcSrv()
+	if g == nil {
+		a.container.Logger.Error("no gRPC server to add options to")
+		return
+	}
+
 	a.container.Logger.Debugf("adding %d gRPC server options", len(grpcOpts))
-	a.grpcServer.options = append(a.grpcServer.options, grpcOpts...)
+	g.addServerOptions(grpcOpts...)
 }
 
 // AddGRPCUnaryInterceptors allows users to add custom gRPC interceptors.
@@ -78,8 +86,14 @@ func (a *App) AddGRPCUnaryInterceptors(interceptors ...grpc.UnaryServerIntercept
 		return
 	}
 
+	g := a.grpcSrv()
+	if g == nil {
+		a.container.Logger.Error("no gRPC server to add unary interceptors to")
+		return
+	}
+
 	a.container.Logger.Debugf("adding %d valid unary interceptors", len(interceptors))
-	a.grpcServer.interceptors = append(a.grpcServer.interceptors, interceptors...)
+	g.addUnaryInterceptors(interceptors...)
 }
 
 func (a *App) AddGRPCServerStreamInterceptors(interceptors ...grpc.StreamServerInterceptor) {
@@ -88,8 +102,42 @@ func (a *App) AddGRPCServerStreamInterceptors(interceptors ...grpc.StreamServerI
 		return
 	}
 
+	g := a.grpcSrv()
+	if g == nil {
+		a.container.Logger.Error("no gRPC server to add stream interceptors to")
+		return
+	}
+
 	a.container.Logger.Debugf("adding %d stream interceptors", len(interceptors))
-	a.grpcServer.streamInterceptors = append(a.grpcServer.streamInterceptors, interceptors...)
+	g.addStreamInterceptors(interceptors...)
+}
+
+// grpcSrv returns the concrete server behind App's grpcRunner field, or nil when
+// this app has none -- newGRPCRunner failed, typically on an out-of-range
+// GRPC_PORT, and factory.go logs and continues. The exported AddGRPC* methods
+// dereferenced the field blind before it became an interface and panicked in
+// exactly that case; they now log and return.
+func (a *App) grpcSrv() *grpcServer {
+	g, ok := a.grpcServer.(*grpcServer)
+	if !ok {
+		return nil
+	}
+
+	return g
+}
+
+// newGRPCRunner is the enabled half of the pair declared in grpc_runner.go.
+//
+// It returns the interface, not *grpcServer, so that a nil result cannot reach
+// App as a non-nil interface holding a nil pointer -- the typed-nil trap that
+// container.isNil exists to catch elsewhere.
+func newGRPCRunner(c *container.Container, port int, cfg config.Config) (grpcRunner, error) {
+	srv, err := newGRPCServer(c, port, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return srv, nil
 }
 
 func newGRPCServer(c *container.Container, port int, cfg config.Config) (*grpcServer, error) {
@@ -244,7 +292,13 @@ func (g *grpcServer) forceStop() {
 
 // RegisterService adds a gRPC service to the GoFr application.
 func (a *App) RegisterService(desc *grpc.ServiceDesc, impl any) {
-	srv, err := a.grpcServer.ensureServer()
+	g := a.grpcSrv()
+	if g == nil {
+		a.container.Logger.Errorf("no gRPC server to register service %s on", desc.ServiceName)
+		return
+	}
+
+	srv, err := g.ensureServer()
 	if err != nil {
 		a.container.Logger.Errorf("failed to create gRPC server for service %s: %v", desc.ServiceName, err)
 		return

--- a/pkg/gofr/grpc_auth_disabled.go
+++ b/pkg/gofr/grpc_auth_disabled.go
@@ -1,0 +1,29 @@
+//go:build gofr_nogrpc
+
+package gofr
+
+import (
+	"github.com/golang-jwt/jwt/v5"
+
+	"gofr.dev/pkg/gofr/container"
+	"gofr.dev/pkg/gofr/http/middleware"
+)
+
+// No-op counterparts to grpc_auth_enabled.go for a build made with
+// -tags gofr_nogrpc.
+//
+// There is nothing to warn about here: EnableBasicAuth and friends are how a
+// user protects the HTTP server, and that half still runs. Only the gRPC
+// interceptors, which this binary has no server to attach to, are skipped.
+
+func (*App) addGRPCBasicAuth(map[string]string,
+	func(username, password string) bool,
+	func(c *container.Container, username, password string) bool) {
+}
+
+func (*App) addGRPCAPIKeyAuth([]string,
+	func(apiKey string) bool,
+	func(c *container.Container, apiKey string) bool) {
+}
+
+func (*App) addGRPCOAuth(middleware.PublicKeyProvider, ...jwt.ParserOption) {}

--- a/pkg/gofr/grpc_auth_enabled.go
+++ b/pkg/gofr/grpc_auth_enabled.go
@@ -1,0 +1,82 @@
+//go:build !gofr_nogrpc
+
+package gofr
+
+import (
+	"github.com/golang-jwt/jwt/v5"
+	"google.golang.org/grpc"
+
+	"gofr.dev/pkg/gofr/container"
+	grpcMiddleware "gofr.dev/pkg/gofr/grpc/middleware"
+	"gofr.dev/pkg/gofr/http/middleware"
+)
+
+// The gRPC half of EnableBasicAuth, EnableAPIKeyAuth and EnableOAuth.
+//
+// It lives here, rather than in auth.go beside the HTTP half, because building
+// an interceptor names gofr.dev/pkg/gofr/grpc/middleware, which imports
+// google.golang.org/grpc. auth.go is not tagged -- HTTP auth works in every
+// build -- so it must not name those types. What crosses the boundary is the
+// credentials themselves, which are plain Go values.
+//
+// grpc_auth_disabled.go holds the no-op counterparts.
+
+// addGRPCBasicAuth registers basic-auth interceptors on the gRPC server. Exactly
+// one of the three validation modes is set by the caller; BasicAuthProvider
+// picks between them the same way the HTTP provider does.
+func (a *App) addGRPCBasicAuth(users map[string]string,
+	validateFunc func(username, password string) bool,
+	validateFuncWithDatasources func(c *container.Container, username, password string) bool,
+) {
+	a.addGRPCInterceptors(func() (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+		p := grpcMiddleware.BasicAuthProvider{
+			Users:                       users,
+			ValidateFunc:                validateFunc,
+			ValidateFuncWithDatasources: validateFuncWithDatasources,
+			Container:                   a.container,
+		}
+
+		return grpcMiddleware.BasicAuthUnaryInterceptor(p), grpcMiddleware.BasicAuthStreamInterceptor(p)
+	})
+}
+
+// addGRPCAPIKeyAuth registers API-key interceptors on the gRPC server.
+func (a *App) addGRPCAPIKeyAuth(apiKeys []string,
+	validateFunc func(apiKey string) bool,
+	validateFuncWithDatasources func(c *container.Container, apiKey string) bool,
+) {
+	a.addGRPCInterceptors(func() (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+		p := grpcMiddleware.APIKeyAuthProvider{
+			APIKeys:                     apiKeys,
+			ValidateFunc:                validateFunc,
+			ValidateFuncWithDatasources: validateFuncWithDatasources,
+			Container:                   a.container,
+		}
+
+		return grpcMiddleware.APIKeyAuthUnaryInterceptor(p), grpcMiddleware.APIKeyAuthStreamInterceptor(p)
+	})
+}
+
+// addGRPCOAuth registers OAuth interceptors on the gRPC server. The public-key
+// provider is an HTTP-middleware type shared with the gRPC interceptors, so it
+// crosses the boundary unchanged.
+func (a *App) addGRPCOAuth(publicKeyProvider middleware.PublicKeyProvider, options ...jwt.ParserOption) {
+	a.addGRPCInterceptors(func() (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+		return grpcMiddleware.OAuthUnaryInterceptor(publicKeyProvider, options...),
+			grpcMiddleware.OAuthStreamInterceptor(publicKeyProvider, options...)
+	})
+}
+
+// addGRPCInterceptors builds the pair only when there is a real gRPC server to
+// take them, so a gRPC-free app pays nothing for an auth call it made for HTTP.
+func (a *App) addGRPCInterceptors(build func() (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor)) {
+	g, ok := a.grpcServer.(*grpcServer)
+	if !ok || g == nil {
+		return
+	}
+
+	unary, stream := build()
+
+	g.addUnaryInterceptors(unary)
+	g.addStreamInterceptors(stream)
+}

--- a/pkg/gofr/grpc_disabled.go
+++ b/pkg/gofr/grpc_disabled.go
@@ -1,0 +1,31 @@
+//go:build gofr_nogrpc
+
+package gofr
+
+import (
+	"context"
+
+	"gofr.dev/pkg/gofr/config"
+	"gofr.dev/pkg/gofr/container"
+)
+
+// disabledGRPC stands in for the gRPC server in a build made with
+// -tags gofr_nogrpc, which omits google.golang.org/grpc entirely.
+//
+// It is constructed like the real one, so App's lifecycle is unchanged, but it
+// never listens. Nothing reaches Run: App starts the gRPC server only when
+// grpcRegistered is set, and the only thing that sets it is RegisterService,
+// which does not exist in this build. Shutdown is on the shutdown path
+// unconditionally, so it has to be a working no-op rather than a panic.
+type disabledGRPC struct{}
+
+func newGRPCRunner(_ *container.Container, _ int, _ config.Config) (grpcRunner, error) {
+	return disabledGRPC{}, nil
+}
+
+func (disabledGRPC) Run(c *container.Container) {
+	c.Logger.Error("gRPC server was started, but this binary was built with -tags gofr_nogrpc, " +
+		"which omits the gRPC server. Rebuild without the tag to use it.")
+}
+
+func (disabledGRPC) Shutdown(context.Context) error { return nil }

--- a/pkg/gofr/grpc_disabled_test.go
+++ b/pkg/gofr/grpc_disabled_test.go
@@ -1,0 +1,54 @@
+//go:build gofr_nogrpc
+
+package gofr
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gofr.dev/pkg/gofr/testutil"
+)
+
+// A binary built with -tags gofr_nogrpc must still construct, authenticate and
+// shut down. Only the gRPC server is gone. Everything here is unreachable in the
+// default build.
+
+func TestGRPCDisabled_AppStillBuildsAndShutsDown(t *testing.T) {
+	t.Setenv("METRICS_PORT", "0")
+	t.Setenv("HTTP_PORT", strconv.Itoa(testutil.GetFreePort(t)))
+
+	app := New()
+
+	require.NotNil(t, app.grpcServer, "the runner is still constructed, so Shutdown has something to call")
+	require.NoError(t, app.grpcServer.Shutdown(context.Background()))
+}
+
+// startGRPCServer is gated on grpcRegistered, and the only thing that sets it is
+// RegisterService, which does not exist in this build. This asserts the gate
+// rather than the absence of the method, which the compiler already enforces.
+func TestGRPCDisabled_ServerNeverStarts(t *testing.T) {
+	t.Setenv("METRICS_PORT", "0")
+	t.Setenv("HTTP_PORT", strconv.Itoa(testutil.GetFreePort(t)))
+
+	app := New()
+
+	assert.False(t, app.grpcRegistered, "nothing in this build can register a gRPC service")
+}
+
+// HTTP auth is not gRPC's to take away: EnableBasicAuth and friends must still
+// install their HTTP middleware, with the gRPC half quietly skipped.
+func TestGRPCDisabled_HTTPAuthStillWorks(t *testing.T) {
+	t.Setenv("METRICS_PORT", "0")
+	t.Setenv("HTTP_PORT", strconv.Itoa(testutil.GetFreePort(t)))
+
+	app := New()
+
+	require.NotPanics(t, func() {
+		app.EnableBasicAuth("user", "pass")
+		app.EnableAPIKeyAuth("key1")
+	})
+}

--- a/pkg/gofr/grpc_runner.go
+++ b/pkg/gofr/grpc_runner.go
@@ -1,0 +1,31 @@
+package gofr
+
+import (
+	"context"
+
+	"gofr.dev/pkg/gofr/container"
+)
+
+// grpcRunner is everything App needs from the gRPC server once it has been
+// built: start it, and stop it.
+//
+// The field on App is this interface rather than the concrete *grpcServer so
+// that the implementation -- and with it google.golang.org/grpc, its reflection
+// and health services and the recovery middleware -- can be left out of a build
+// that serves no gRPC. As with GraphQL, the interface is only half of it:
+// grpc.go carries the build tag too, because an interface field does not stop
+// the concrete file from compiling the library in.
+//
+// The methods that take gRPC types -- AddGRPCServerOptions, the interceptor
+// setters, RegisterService -- deliberately stay off this interface and live in
+// grpc.go. They cannot be named here without importing google.golang.org/grpc,
+// which is the import this whole arrangement exists to make optional. A user who
+// calls them and also sets -tags gofr_nogrpc gets a compile error, which is the
+// honest outcome: they asked for a binary without gRPC and then used gRPC.
+//
+// newGRPCRunner, which builds one, likewise has two definitions selected by the
+// same tag: the real one in grpc.go, a stub in grpc_disabled.go.
+type grpcRunner interface {
+	Run(c *container.Container)
+	Shutdown(ctx context.Context) error
+}

--- a/pkg/gofr/grpc_test.go
+++ b/pkg/gofr/grpc_test.go
@@ -1,3 +1,5 @@
+//go:build !gofr_nogrpc
+
 package gofr
 
 import (
@@ -491,11 +493,11 @@ func TestGRPC_ServerRun_WithInterceptorAndOptions(t *testing.T) {
 	app.AddGRPCUnaryInterceptors(interceptor1, interceptor2)
 
 	// Create the server first
-	srv, err := app.grpcServer.ensureServer()
+	srv, err := g.ensureServer()
 	require.NoError(t, err)
 
 	// Start the server in a goroutine
-	go app.grpcServer.Run(c)
+	go g.Run(c)
 
 	// Wait for the server to start
 	time.Sleep(100 * time.Millisecond)
@@ -505,13 +507,13 @@ func TestGRPC_ServerRun_WithInterceptorAndOptions(t *testing.T) {
 
 	defer cancel()
 
-	err = app.grpcServer.Shutdown(ctx)
+	err = g.Shutdown(ctx)
 	require.NoError(t, err)
 
 	// Verify that the server was created with the interceptors and options
 	assert.NotNil(t, srv)
-	assert.Len(t, app.grpcServer.interceptors, 4) // 2 default + 2 test interceptors
-	assert.Len(t, app.grpcServer.options, 4)      // 2 test options + 2 default (interceptor) options
+	assert.Len(t, g.interceptors, 4) // 2 default + 2 test interceptors
+	assert.Len(t, g.options, 4)      // 2 test options + 2 default (interceptor) options
 }
 
 func TestApp_WithReflection(t *testing.T) {
@@ -521,10 +523,58 @@ func TestApp_WithReflection(t *testing.T) {
 	app.container = c
 	app.grpcServer = g
 
-	srv, err := app.grpcServer.ensureServer()
+	srv, err := g.ensureServer()
 	require.NoError(t, err)
 
 	services := srv.GetServiceInfo()
 	_, ok := services["grpc.reflection.v1alpha.ServerReflection"]
 	assert.True(t, ok, "reflection service should be registered")
+}
+
+// Moved here from gofr_test.go when App.grpcServer became an interface: both
+// tests reach the concrete server, which exists only in this build.
+
+func TestUnifiedAuthenticationRegistration(t *testing.T) {
+	t.Setenv("METRICS_PORT", "0")
+	t.Setenv("HTTP_PORT", strconv.Itoa(testutil.GetFreePort(t)))
+
+	app := New()
+
+	// Enable various auth methods
+	app.EnableBasicAuth("user", "pass")
+	app.EnableAPIKeyAuth("key1")
+	app.EnableOAuth("http://jwks", 3600)
+
+	// The router's middleware slice is not inspectable without reflection, but the
+	// gRPC interceptors are. Two are registered by default (recovery and
+	// observability), so the three Enable calls above must take the count to five.
+	// Asserting >= 2 -- as this did before the interceptors moved behind
+	// addGRPCInterceptors -- passes on the defaults alone and proves nothing.
+	assert.Len(t, app.grpcSrv().interceptors, 5, "gRPC unary interceptors should be registered")
+	assert.Len(t, app.grpcSrv().streamInterceptors, 5, "gRPC stream interceptors should be registered")
+}
+
+func TestStartGRPCServer_Registered(t *testing.T) {
+	t.Setenv("METRICS_PORT", "0")
+	t.Setenv("HTTP_PORT", strconv.Itoa(testutil.GetFreePort(t)))
+	t.Setenv("GRPC_PORT", strconv.Itoa(testutil.GetFreePort(t)))
+
+	app := New()
+	app.grpcRegistered = true
+
+	wg := sync.WaitGroup{}
+
+	// startGRPCServer should add to WaitGroup and launch the server
+	app.startGRPCServer(&wg)
+
+	// Give it a moment to start then shut down
+	time.Sleep(50 * time.Millisecond)
+
+	// Read through getServer rather than the field: createServer publishes it from the serve
+	// goroutine, so an unguarded read here races that write.
+	if g := app.grpcSrv(); g != nil {
+		g.forceStop()
+	}
+
+	wg.Wait()
 }

--- a/pkg/gofr/metrics/exporters/otlp.go
+++ b/pkg/gofr/metrics/exporters/otlp.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"strings"
 
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	metricSdk "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -50,73 +48,6 @@ func buildOTLPReader(ctx context.Context, cfg *Config, logger Logger) (metricSdk
 		protocol(cfg.Protocol), cfg.Endpoint, cfg.Interval, temporalityName(cfg.Temporality))
 
 	return metricSdk.NewPeriodicReader(exporter, metricSdk.WithInterval(cfg.Interval)), nil
-}
-
-func buildOTLPExporter(ctx context.Context, cfg *Config) (metricSdk.Exporter, error) {
-	endpoint := strings.TrimSpace(cfg.Endpoint)
-	hasScheme := strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://")
-
-	if strings.EqualFold(cfg.Protocol, protocolHTTP) {
-		opts := otlpOptions(cfg, endpoint, hasScheme, otlpOptionFuncs[otlpmetrichttp.Option]{
-			temporality: otlpmetrichttp.WithTemporalitySelector,
-			endpointURL: otlpmetrichttp.WithEndpointURL,
-			endpoint:    otlpmetrichttp.WithEndpoint,
-			insecure:    otlpmetrichttp.WithInsecure,
-			headers:     otlpmetrichttp.WithHeaders,
-		})
-
-		return otlpmetrichttp.New(ctx, opts...)
-	}
-
-	opts := otlpOptions(cfg, endpoint, hasScheme, otlpOptionFuncs[otlpmetricgrpc.Option]{
-		temporality: otlpmetricgrpc.WithTemporalitySelector,
-		endpointURL: otlpmetricgrpc.WithEndpointURL,
-		endpoint:    otlpmetricgrpc.WithEndpoint,
-		insecure:    otlpmetricgrpc.WithInsecure,
-		headers:     otlpmetricgrpc.WithHeaders,
-	})
-
-	return otlpmetricgrpc.New(ctx, opts...)
-}
-
-// otlpOptionFuncs adapts the (structurally identical, but distinctly typed)
-// option constructors of otlpmetrichttp and otlpmetricgrpc to a common shape,
-// so the option-selection logic in otlpOptions is written once instead of
-// duplicated per protocol.
-type otlpOptionFuncs[T any] struct {
-	temporality func(metricSdk.TemporalitySelector) T
-	endpointURL func(string) T
-	endpoint    func(string) T
-	insecure    func() T
-	headers     func(map[string]string) T
-}
-
-// otlpOptions builds the shared set of OTLP exporter options (temporality,
-// endpoint, insecure, headers) for either transport, given its option
-// constructors via f.
-func otlpOptions[T any](cfg *Config, endpoint string, hasScheme bool, f otlpOptionFuncs[T]) []T {
-	opts := []T{f.temporality(temporalitySelector(cfg.Temporality))}
-
-	if hasScheme {
-		opts = append(opts, f.endpointURL(endpoint))
-	} else {
-		opts = append(opts, f.endpoint(endpoint))
-	}
-
-	// WithEndpointURL derives Insecure from the URL scheme (http vs https); an
-	// unconditional WithInsecure() appended afterwards would override that and
-	// silently downgrade an https:// endpoint to plaintext. Only apply the
-	// METRICS_INSECURE override for schemeless host:port endpoints, where
-	// there is no scheme to derive security from.
-	if !hasScheme && cfg.Insecure {
-		opts = append(opts, f.insecure())
-	}
-
-	if len(cfg.Headers) > 0 {
-		opts = append(opts, f.headers(cfg.Headers))
-	}
-
-	return opts
 }
 
 // temporalitySelector maps the METRICS_TEMPORALITY preference to an OTLP

--- a/pkg/gofr/metrics/exporters/otlp_test.go
+++ b/pkg/gofr/metrics/exporters/otlp_test.go
@@ -38,40 +38,6 @@ func Test_temporalitySelector(t *testing.T) {
 	}
 }
 
-func Test_buildOTLPExporter(t *testing.T) {
-	tests := []struct {
-		name string
-		cfg  Config
-	}{
-		{"grpc default", Config{Endpoint: "localhost:4317", Protocol: "grpc", Insecure: true}},
-		{"grpc with headers", Config{Endpoint: "localhost:4317", Protocol: "grpc", Insecure: true, Headers: map[string]string{"x": "y"}}},
-		{"grpc secure with delta", Config{Endpoint: "otlp.nr-data.net:4317", Protocol: "grpc", Temporality: "delta"}},
-		{"http host:port", Config{Endpoint: "localhost:4318", Protocol: "http", Insecure: true}},
-		{"http full url", Config{Endpoint: "https://collector.example.com/v1/metrics", Protocol: "http"}},
-		{"grpc https scheme ignores insecure override", Config{
-			Endpoint: "https://collector.example.com:4317", Protocol: "grpc", Insecure: true,
-		}},
-		{"http https scheme ignores insecure override", Config{
-			Endpoint: "https://collector.example.com/v1/metrics", Protocol: "http", Insecure: true,
-		}},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			exp, err := buildOTLPExporter(context.Background(), &tc.cfg)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if exp == nil {
-				t.Fatal("expected non-nil exporter")
-			}
-
-			_ = exp.Shutdown(context.Background())
-		})
-	}
-}
-
 func Test_buildOTLPReader_emptyEndpoint(t *testing.T) {
 	cfg := Config{Endpoint: "", Protocol: "grpc"}
 
@@ -101,31 +67,5 @@ func Test_buildOTLPReader_pushReaderDegradesOnEmptyEndpoint(t *testing.T) {
 
 	if !strings.Contains(out, "METRICS_URL") {
 		t.Errorf("expected the degrade error to mention METRICS_URL, got: %q", out)
-	}
-}
-
-func Test_buildOTLPReader_warnsOnUnrecognizedProtocolAndTemporality(t *testing.T) {
-	tests := []struct {
-		name    string
-		cfg     Config
-		wantLog string
-	}{
-		{"unrecognized protocol", Config{Endpoint: "localhost:4317", Protocol: "carrier-pigeon"}, "METRICS_PROTOCOL"},
-		{"unrecognized temporality", Config{Endpoint: "localhost:4317", Temporality: "quantum"}, "METRICS_TEMPORALITY"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			out := testutil.StdoutOutputForFunc(func() {
-				_, err := buildOTLPReader(context.Background(), &tc.cfg, logging.NewMockLogger(logging.WARN))
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-			})
-
-			if !strings.Contains(out, tc.wantLog) {
-				t.Errorf("expected warning to mention %q, got: %q", tc.wantLog, out)
-			}
-		})
 	}
 }

--- a/pkg/gofr/metrics/exporters/otlp_transport.go
+++ b/pkg/gofr/metrics/exporters/otlp_transport.go
@@ -1,0 +1,88 @@
+//go:build !gofr_nootlp
+
+package exporters
+
+import (
+	"context"
+	"strings"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	metricSdk "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// The OTLP wire transports, split out of otlp.go so that -tags gofr_nootlp can
+// leave them out. Everything else about the exporter -- registration, config
+// validation, temporality, the periodic reader -- stays shared, so the tag
+// changes how metrics leave the process and nothing else.
+//
+// Both transports have to go together. otlpmetrichttp imports
+// google.golang.org/grpc for its status codes, so keeping the HTTP one would
+// keep the gRPC tree that this tag exists to drop.
+
+func buildOTLPExporter(ctx context.Context, cfg *Config) (metricSdk.Exporter, error) {
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+	hasScheme := strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://")
+
+	if strings.EqualFold(cfg.Protocol, protocolHTTP) {
+		opts := otlpOptions(cfg, endpoint, hasScheme, otlpOptionFuncs[otlpmetrichttp.Option]{
+			temporality: otlpmetrichttp.WithTemporalitySelector,
+			endpointURL: otlpmetrichttp.WithEndpointURL,
+			endpoint:    otlpmetrichttp.WithEndpoint,
+			insecure:    otlpmetrichttp.WithInsecure,
+			headers:     otlpmetrichttp.WithHeaders,
+		})
+
+		return otlpmetrichttp.New(ctx, opts...)
+	}
+
+	opts := otlpOptions(cfg, endpoint, hasScheme, otlpOptionFuncs[otlpmetricgrpc.Option]{
+		temporality: otlpmetricgrpc.WithTemporalitySelector,
+		endpointURL: otlpmetricgrpc.WithEndpointURL,
+		endpoint:    otlpmetricgrpc.WithEndpoint,
+		insecure:    otlpmetricgrpc.WithInsecure,
+		headers:     otlpmetricgrpc.WithHeaders,
+	})
+
+	return otlpmetricgrpc.New(ctx, opts...)
+}
+
+// otlpOptionFuncs adapts the (structurally identical, but distinctly typed)
+// option constructors of otlpmetrichttp and otlpmetricgrpc to a common shape,
+// so the option-selection logic in otlpOptions is written once instead of
+// duplicated per protocol.
+type otlpOptionFuncs[T any] struct {
+	temporality func(metricSdk.TemporalitySelector) T
+	endpointURL func(string) T
+	endpoint    func(string) T
+	insecure    func() T
+	headers     func(map[string]string) T
+}
+
+// otlpOptions builds the shared set of OTLP exporter options (temporality,
+// endpoint, insecure, headers) for either transport, given its option
+// constructors via f.
+func otlpOptions[T any](cfg *Config, endpoint string, hasScheme bool, f otlpOptionFuncs[T]) []T {
+	opts := []T{f.temporality(temporalitySelector(cfg.Temporality))}
+
+	if hasScheme {
+		opts = append(opts, f.endpointURL(endpoint))
+	} else {
+		opts = append(opts, f.endpoint(endpoint))
+	}
+
+	// WithEndpointURL derives Insecure from the URL scheme (http vs https); an
+	// unconditional WithInsecure() appended afterwards would override that and
+	// silently downgrade an https:// endpoint to plaintext. Only apply the
+	// METRICS_INSECURE override for schemeless host:port endpoints, where
+	// there is no scheme to derive security from.
+	if !hasScheme && cfg.Insecure {
+		opts = append(opts, f.insecure())
+	}
+
+	if len(cfg.Headers) > 0 {
+		opts = append(opts, f.headers(cfg.Headers))
+	}
+
+	return opts
+}

--- a/pkg/gofr/metrics/exporters/otlp_transport_disabled.go
+++ b/pkg/gofr/metrics/exporters/otlp_transport_disabled.go
@@ -1,0 +1,25 @@
+//go:build gofr_nootlp
+
+package exporters
+
+import (
+	"context"
+	"errors"
+
+	metricSdk "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// The OTLP metric transports are omitted from this build. Prometheus, which is
+// the default and needs no transport of its own, is unaffected; so is gcp,
+// which brings its own.
+//
+// METRICS_EXPORTER=otlp still registers and still validates its config -- it
+// fails at the point where it would open the connection, with an error naming
+// the tag, rather than being quietly absent from the registry and falling
+// through to a different exporter than the operator configured.
+var errOTLPMetricsOmitted = errors.New("METRICS_EXPORTER=otlp is unavailable: this binary was built with " +
+	"-tags gofr_nootlp, which omits the OTLP exporters. Use METRICS_EXPORTER=prometheus, or rebuild without the tag")
+
+func buildOTLPExporter(context.Context, *Config) (metricSdk.Exporter, error) {
+	return nil, errOTLPMetricsOmitted
+}

--- a/pkg/gofr/metrics/exporters/otlp_transport_disabled_test.go
+++ b/pkg/gofr/metrics/exporters/otlp_transport_disabled_test.go
@@ -1,0 +1,42 @@
+//go:build gofr_nootlp
+
+package exporters
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testLogger struct{}
+
+func (testLogger) Debug(...any)          {}
+func (testLogger) Infof(string, ...any)  {}
+func (testLogger) Warnf(string, ...any)  {}
+func (testLogger) Errorf(string, ...any) {}
+
+// A build made with -tags gofr_nootlp must fail METRICS_EXPORTER=otlp with an
+// error that names the tag, rather than dropping "otlp" from the registry and
+// letting the caller silently get a different exporter than it configured.
+
+func TestOTLPMetricsOmitted_ExporterErrors(t *testing.T) {
+	_, err := buildOTLPExporter(context.Background(), &Config{Endpoint: "localhost:4317"})
+
+	require.ErrorIs(t, err, errOTLPMetricsOmitted)
+	assert.Contains(t, err.Error(), "gofr_nootlp")
+}
+
+// The reader still validates its config first, so an empty endpoint is still
+// reported as an empty endpoint and not as a missing transport.
+func TestOTLPMetricsOmitted_StillRegisteredAndValidates(t *testing.T) {
+	build, ok := lookup("otlp")
+	require.True(t, ok, "otlp stays in the registry so the failure names the tag")
+
+	_, err := build(context.Background(), &Config{Endpoint: ""}, testLogger{})
+	require.ErrorIs(t, err, errEmptyOTLPEndpoint)
+
+	_, err = build(context.Background(), &Config{Endpoint: "localhost:4317"}, testLogger{})
+	require.ErrorIs(t, err, errOTLPMetricsOmitted)
+}

--- a/pkg/gofr/metrics/exporters/otlp_transport_test.go
+++ b/pkg/gofr/metrics/exporters/otlp_transport_test.go
@@ -1,0 +1,75 @@
+//go:build !gofr_nootlp
+
+package exporters
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"gofr.dev/pkg/gofr/logging"
+	"gofr.dev/pkg/gofr/testutil"
+)
+
+// Tests for the OTLP wire transports, which exist only in a build without
+// -tags gofr_nootlp. Moved out of otlp_test.go alongside the code they cover.
+
+func Test_buildOTLPExporter(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{"grpc default", Config{Endpoint: "localhost:4317", Protocol: "grpc", Insecure: true}},
+		{"grpc with headers", Config{Endpoint: "localhost:4317", Protocol: "grpc", Insecure: true, Headers: map[string]string{"x": "y"}}},
+		{"grpc secure with delta", Config{Endpoint: "otlp.nr-data.net:4317", Protocol: "grpc", Temporality: "delta"}},
+		{"http host:port", Config{Endpoint: "localhost:4318", Protocol: "http", Insecure: true}},
+		{"http full url", Config{Endpoint: "https://collector.example.com/v1/metrics", Protocol: "http"}},
+		{"grpc https scheme ignores insecure override", Config{
+			Endpoint: "https://collector.example.com:4317", Protocol: "grpc", Insecure: true,
+		}},
+		{"http https scheme ignores insecure override", Config{
+			Endpoint: "https://collector.example.com/v1/metrics", Protocol: "http", Insecure: true,
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			exp, err := buildOTLPExporter(context.Background(), &tc.cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if exp == nil {
+				t.Fatal("expected non-nil exporter")
+			}
+
+			_ = exp.Shutdown(context.Background())
+		})
+	}
+}
+
+func Test_buildOTLPReader_warnsOnUnrecognizedProtocolAndTemporality(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantLog string
+	}{
+		{"unrecognized protocol", Config{Endpoint: "localhost:4317", Protocol: "carrier-pigeon"}, "METRICS_PROTOCOL"},
+		{"unrecognized temporality", Config{Endpoint: "localhost:4317", Temporality: "quantum"}, "METRICS_TEMPORALITY"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := testutil.StdoutOutputForFunc(func() {
+				_, err := buildOTLPReader(context.Background(), &tc.cfg, logging.NewMockLogger(logging.WARN))
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			if !strings.Contains(out, tc.wantLog) {
+				t.Errorf("expected warning to mention %q, got: %q", tc.wantLog, out)
+			}
+		})
+	}
+}

--- a/pkg/gofr/migration/dgraph.go
+++ b/pkg/gofr/migration/dgraph.go
@@ -1,3 +1,5 @@
+//go:build !gofr_nodgraph
+
 package migration
 
 import (

--- a/pkg/gofr/migration/dgraph_disabled.go
+++ b/pkg/gofr/migration/dgraph_disabled.go
@@ -1,0 +1,69 @@
+//go:build gofr_nodgraph
+
+package migration
+
+import (
+	"context"
+	"errors"
+
+	"gofr.dev/pkg/gofr/container"
+)
+
+// Stubs for a build made with -tags gofr_nodgraph.
+//
+// The Dgraph migrator is the only thing in GoFr that imports
+// github.com/dgraph-io/dgo, and it does so for a single value: the *api.Mutation
+// that commitMigration hands to DGraph.Mutate, whose parameter is any. That one
+// construction pulls in dgo's protobufs, which pull in google.golang.org/grpc --
+// 83 packages and 3.7 MB for a service that has never heard of Dgraph.
+//
+// The container's Dgraph interface itself is dgo-free (its methods take and
+// return any), so nothing else in the default path is affected, and a service
+// that does use Dgraph links the driver through its own datasource module.
+//
+// Under the tag a Dgraph migration fails rather than silently doing nothing:
+// running migrations against a datasource whose bookkeeping table cannot be
+// written is how you get a migration applied twice.
+type dgraphDS struct {
+	client DGraph
+}
+
+type dgraphMigrator struct {
+	dgraphDS
+	migrator
+}
+
+var errDgraphMigratorOmitted = errors.New("dgraph migrations are unavailable: this binary was built with " +
+	"-tags gofr_nodgraph, which omits the Dgraph migrator. Rebuild without the tag to run them")
+
+func (ds dgraphDS) apply(m migrator) migrator {
+	return dgraphMigrator{dgraphDS: ds, migrator: m}
+}
+
+func (dgraphDS) ApplySchema(context.Context, string) error { return errDgraphMigratorOmitted }
+
+func (dgraphDS) AddOrUpdateField(context.Context, string, string, string) error {
+	return errDgraphMigratorOmitted
+}
+
+func (dgraphDS) DropField(context.Context, string) error { return errDgraphMigratorOmitted }
+
+func (dgraphMigrator) checkAndCreateMigrationTable(*container.Container) error {
+	return errDgraphMigratorOmitted
+}
+
+func (dgraphMigrator) getLastMigration(*container.Container) (int64, error) {
+	return 0, errDgraphMigratorOmitted
+}
+
+func (dm dgraphMigrator) beginTransaction(c *container.Container) transactionData {
+	return dm.migrator.beginTransaction(c)
+}
+
+func (dgraphMigrator) commitMigration(*container.Container, transactionData) error {
+	return errDgraphMigratorOmitted
+}
+
+func (dgraphMigrator) rollback(*container.Container, transactionData) {}
+
+func (dgraphMigrator) name() string { return "DGraph (omitted)" }

--- a/pkg/gofr/migration/dgraph_disabled_test.go
+++ b/pkg/gofr/migration/dgraph_disabled_test.go
@@ -1,0 +1,38 @@
+//go:build gofr_nodgraph
+
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A build made with -tags gofr_nodgraph must refuse a Dgraph migration rather
+// than skip it: Run treats a checkAndCreateMigrationTable error as fatal, which
+// is what stops a migration being recorded as applied when it was not.
+
+func TestDgraphMigratorOmitted_RefusesToMigrate(t *testing.T) {
+	dm := dgraphDS{}.apply(nil)
+
+	require.ErrorIs(t, dm.checkAndCreateMigrationTable(nil), errDgraphMigratorOmitted)
+
+	_, err := dm.getLastMigration(nil)
+	require.ErrorIs(t, err, errDgraphMigratorOmitted)
+
+	require.ErrorIs(t, dm.commitMigration(nil, transactionData{}), errDgraphMigratorOmitted)
+}
+
+func TestDgraphMigratorOmitted_DataSourceMethodsError(t *testing.T) {
+	ds := dgraphDS{}
+
+	require.ErrorIs(t, ds.ApplySchema(context.Background(), "schema"), errDgraphMigratorOmitted)
+	require.ErrorIs(t, ds.AddOrUpdateField(context.Background(), "f", "string", ""), errDgraphMigratorOmitted)
+	require.ErrorIs(t, ds.DropField(context.Background(), "f"), errDgraphMigratorOmitted)
+}
+
+func TestDgraphMigratorOmitted_NamesItself(t *testing.T) {
+	assert.Equal(t, "DGraph (omitted)", dgraphMigrator{}.name())
+}

--- a/pkg/gofr/migration/dgraph_test.go
+++ b/pkg/gofr/migration/dgraph_test.go
@@ -1,3 +1,5 @@
+//go:build !gofr_nodgraph
+
 package migration
 
 import (

--- a/pkg/gofr/otel.go
+++ b/pkg/gofr/otel.go
@@ -1,13 +1,11 @@
 package gofr
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/zipkin" //nolint:staticcheck // deprecated but kept for backward compatibility
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -76,7 +74,19 @@ func (a *App) initTracer() {
 
 	exporter, err := a.getExporter(traceExporter, tracerHost, tracerPort, tracerURL)
 	if err != nil {
-		a.container.Error(err)
+		// Errorf, not Error: the logger JSON-marshals a bare error value, and an
+		// errors.errorString has no exported fields, so Error(err) logs
+		// {"message":{}} and the reason is lost.
+		a.container.Errorf("failed to build trace exporter: %v", err)
+	}
+
+	// getExporter can return a nil exporter without an error -- an unsupported
+	// TRACE_EXPORTER takes that path, and so does any exporter this build omits.
+	// A BatchSpanProcessor over a nil exporter panics on its first flush, on the
+	// processor's own goroutine, so tracing stays off instead. The provider is
+	// already installed above, which keeps trace and span IDs on every request.
+	if exporter == nil {
+		return
 	}
 
 	batcher := sdktrace.NewBatchSpanProcessor(exporter)
@@ -179,24 +189,6 @@ func (a *App) getExporter(name, host, port, url string) (sdktrace.SpanExporter, 
 	}
 
 	return exporter, err
-}
-
-// buildOpenTelemetryProtocol using OpenTelemetryProtocol as the trace exporter
-// jaeger accept OpenTelemetry Protocol (OTLP) over gRPC to upload trace data.
-func buildOtlpExporter(logger logging.Logger, name, url, host, port string, headers map[string]string) (sdktrace.SpanExporter, error) {
-	if url == "" {
-		url = fmt.Sprintf("%s:%s", host, port)
-	}
-
-	logger.Infof("Exporting traces to %s at %s", strings.ToLower(name), url)
-
-	opts := []otlptracegrpc.Option{otlptracegrpc.WithInsecure(), otlptracegrpc.WithEndpoint(url)}
-
-	if len(headers) > 0 {
-		opts = append(opts, otlptracegrpc.WithHeaders(headers))
-	}
-
-	return otlptracegrpc.New(context.Background(), opts...)
 }
 
 func buildZipkinExporter(logger logging.Logger, url, host, port string, headers map[string]string) (sdktrace.SpanExporter, error) {

--- a/pkg/gofr/otlp_trace.go
+++ b/pkg/gofr/otlp_trace.go
@@ -1,0 +1,36 @@
+//go:build !gofr_nootlp
+
+package gofr
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"gofr.dev/pkg/gofr/logging"
+)
+
+// The OTLP trace transport, split out of otel.go so that -tags gofr_nootlp can
+// leave it out. TRACE_EXPORTER=zipkin and TRACE_EXPORTER=gofr are unaffected --
+// neither goes through OTLP -- so a build with the tag can still trace.
+
+// buildOpenTelemetryProtocol using OpenTelemetryProtocol as the trace exporter
+// jaeger accept OpenTelemetry Protocol (OTLP) over gRPC to upload trace data.
+func buildOtlpExporter(logger logging.Logger, name, url, host, port string, headers map[string]string) (sdktrace.SpanExporter, error) {
+	if url == "" {
+		url = fmt.Sprintf("%s:%s", host, port)
+	}
+
+	logger.Infof("Exporting traces to %s at %s", strings.ToLower(name), url)
+
+	opts := []otlptracegrpc.Option{otlptracegrpc.WithInsecure(), otlptracegrpc.WithEndpoint(url)}
+
+	if len(headers) > 0 {
+		opts = append(opts, otlptracegrpc.WithHeaders(headers))
+	}
+
+	return otlptracegrpc.New(context.Background(), opts...)
+}

--- a/pkg/gofr/otlp_trace_disabled.go
+++ b/pkg/gofr/otlp_trace_disabled.go
@@ -1,0 +1,28 @@
+//go:build gofr_nootlp
+
+package gofr
+
+import (
+	"errors"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"gofr.dev/pkg/gofr/logging"
+)
+
+// The OTLP trace transport is omitted from this build. TRACE_EXPORTER=zipkin
+// and TRACE_EXPORTER=gofr do not go through OTLP and still work, so a service
+// built with the tag can still trace -- it just cannot speak OTLP.
+//
+// getExporter returns this error, which initTracer logs; tracing is then off
+// and the rest of the app starts normally. Failing loudly here is the point:
+// the alternative, quietly exporting over a different transport than
+// TRACE_EXPORTER asked for, loses spans at a collector that is not listening.
+
+var errOTLPTracesOmitted = errors.New("TRACE_EXPORTER=otlp is unavailable: this binary was built with " +
+	"-tags gofr_nootlp, which omits the OTLP exporters. Use TRACE_EXPORTER=zipkin or gofr, " +
+	"or rebuild without the tag")
+
+func buildOtlpExporter(_ logging.Logger, _, _, _, _ string, _ map[string]string) (sdktrace.SpanExporter, error) {
+	return nil, errOTLPTracesOmitted
+}

--- a/pkg/gofr/otlp_trace_disabled_test.go
+++ b/pkg/gofr/otlp_trace_disabled_test.go
@@ -1,0 +1,62 @@
+//go:build gofr_nootlp
+
+package gofr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gofr.dev/pkg/gofr/config"
+	"gofr.dev/pkg/gofr/container"
+	"gofr.dev/pkg/gofr/testutil"
+)
+
+// The counterpart to otlp_trace_test.go for a build made with -tags
+// gofr_nootlp: TRACE_EXPORTER=otlp must say why it cannot export, and must not
+// take the process down doing so.
+
+func TestOTLPTracesOmitted_ExporterErrors(t *testing.T) {
+	_, err := buildOtlpExporter(nil, "otlp", "localhost:4317", "", "", nil)
+
+	require.ErrorIs(t, err, errOTLPTracesOmitted)
+	assert.Contains(t, err.Error(), "gofr_nootlp")
+}
+
+// initTracer logs the error and returns without a span processor. The nil-check
+// it does before NewBatchSpanProcessor is what keeps this from panicking on the
+// processor's first flush.
+func TestOTLPTracesOmitted_InitTracerReportsAndContinues(t *testing.T) {
+	cfg := config.NewMockConfig(map[string]string{
+		"TRACE_EXPORTER": "otlp",
+		"TRACER_URL":     "localhost:4317",
+	})
+
+	logMessage := testutil.StderrOutputForFunc(func() {
+		mockContainer, _ := container.NewMockContainer(t)
+
+		a := App{Config: cfg, container: mockContainer}
+
+		require.NotPanics(t, a.initTracer)
+	})
+
+	assert.Contains(t, logMessage, "gofr_nootlp")
+}
+
+// zipkin does not go through OTLP, so it still exports in this build.
+func TestOTLPTracesOmitted_ZipkinStillWorks(t *testing.T) {
+	cfg := config.NewMockConfig(map[string]string{
+		"TRACE_EXPORTER": "zipkin",
+		"TRACER_URL":     "http://localhost:2005/api/v2/spans",
+	})
+
+	logMessage := testutil.StdoutOutputForFunc(func() {
+		mockContainer, _ := container.NewMockContainer(t)
+
+		a := App{Config: cfg, container: mockContainer}
+		a.initTracer()
+	})
+
+	assert.Contains(t, logMessage, "Exporting traces to zipkin")
+}

--- a/pkg/gofr/otlp_trace_test.go
+++ b/pkg/gofr/otlp_trace_test.go
@@ -1,0 +1,47 @@
+//go:build !gofr_nootlp
+
+package gofr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"gofr.dev/pkg/gofr/config"
+	"gofr.dev/pkg/gofr/container"
+	"gofr.dev/pkg/gofr/testutil"
+)
+
+// The OTLP-transport cases of Test_initTracer, which exist only in a build
+// without -tags gofr_nootlp. The zipkin and gofr cases stay in gofr_test.go:
+// neither goes through OTLP, so both work in either build.
+func Test_initTracer_otlpTransport(t *testing.T) {
+	mockConfig := func(traceExporter, authKey string) config.Config {
+		return config.NewMockConfig(map[string]string{
+			"TRACE_EXPORTER":  traceExporter,
+			"TRACER_URL":      "localhost:4317",
+			"TRACER_AUTH_KEY": authKey,
+		})
+	}
+
+	tests := []struct {
+		desc               string
+		config             config.Config
+		expectedLogMessage string
+	}{
+		{"jaeger exporter", mockConfig("jaeger", ""), "Exporting traces to jaeger at localhost:4317"},
+		{"jaeger exporter with auth", mockConfig("jaeger", "valid-token"), "Exporting traces to jaeger at localhost:4317"},
+		{"otlp exporter", mockConfig("otlp", ""), "Exporting traces to otlp at localhost:4317"},
+		{"otlp exporter with authKey", mockConfig("otlp", "valid-token"), "Exporting traces to otlp at localhost:4317"},
+	}
+
+	for i, tc := range tests {
+		logMessage := testutil.StdoutOutputForFunc(func() {
+			mockContainer, _ := container.NewMockContainer(t)
+
+			a := App{Config: tc.config, container: mockContainer}
+			a.initTracer()
+		})
+		assert.Contains(t, logMessage, tc.expectedLogMessage, "TEST[%d], Failed.\n%s", i, tc.desc)
+	}
+}

--- a/pkg/gofr/run.go
+++ b/pkg/gofr/run.go
@@ -166,7 +166,7 @@ func (a *App) startGRPCServer(wg *sync.WaitGroup) {
 	if a.grpcRegistered {
 		wg.Add(1)
 
-		go func(s *grpcServer) {
+		go func(s grpcRunner) {
 			defer wg.Done()
 
 			s.Run(a.container)


### PR DESCRIPTION
> ### ⚠️ Read first
> **Stacked on #4167** — review that one first. This PR's base is `perf/optional-datasources-graphql`, so the diff below is only the three tags described here.
>
> **CI does not run on this PR yet.** `.github/workflows/go.yml` triggers on `pull_request: branches: [main, development]`, and this one targets a feature branch. **Retarget it to `development` once #4167 merges** and the full pipeline fires. Local verification is in *Additional Information* below.

**Description:**

Three more opt-in build tags. **A build that sets none of them is unchanged.**

| tag | omits |
|---|---|
| `gofr_nogrpc` | GoFr's gRPC server, reflection, health, recovery middleware |
| `gofr_nodgraph` | the Dgraph **migrator** — the only dgo importer in GoFr |
| `gofr_nootlp` | the OTLP trace and metric transports |

| build | binary | packages | gRPC pkgs |
|---|---|---|---|
| default | 57.10 MB | 831 | 86 |
| + the two tags from #4167 | 41.26 MB | 554 | 70 |
| + `gofr_nogrpc` | 40.59 MB | 543 | 66 |
| + `gofr_nodgraph` | 39.47 MB | 541 | 66 |
| + `gofr_nootlp` | **35.35 MB** | **414** | **0** |

**All six tags: 57.10 → 35.35 MB (−38.1%), 831 → 414 packages (−50.2%).**

**⚠️ These tags are conjunctive, not additive.** On its own `gofr_nogrpc` is worth **0.67 MB** and `gofr_nodgraph` **1.12 MB** — which looks like nothing. That is the point worth understanding before judging them.

`google.golang.org/grpc` was pinned by **four independent importers**:

- GoFr's own gRPC server
- dgo's protobufs, via **one** `&api.Mutation{}` in `pkg/gofr/migration`
- `otlptracegrpc` (`otel.go`) and `otlpmetricgrpc` (`metrics/exporters`)
- `otlpmetrichttp` — which imports grpc for its status codes, so the HTTP transport cannot be kept either

**Only the last tag releases the tree**, and it then measures 4.12 MB / 127 packages. Each of the first two is a prerequisite, not a standalone win.

**Breaking Changes (if applicable):**

⚠️ **`gofr_nogrpc` is the only tag in either PR that changes the exported API — and only when the tag is set.**

`RegisterService`, `AddGRPCServerOptions`, `AddGRPCUnaryInterceptors` and `AddGRPCServerStreamInterceptors` all name grpc types in their signatures, so they **cannot exist without the import** and are compiled out.

A build that sets the tag and calls them **fails to compile**. That is the intended outcome — it asked for a binary without gRPC and then used gRPC — and it is why this tag's CI step builds `./pkg/...` rather than `./...`: the gRPC examples are *supposed* to fail under it.

**A default build keeps all four methods and is unchanged.**

Under `gofr_nootlp` and `gofr_nodgraph` the affected features fail loudly rather than silently degrading:
- `"otlp"` stays registered in the metrics registry and fails where it would open the connection — rather than vanishing and letting `METRICS_EXPORTER=otlp` quietly resolve to a *different* exporter than the operator configured
- `checkAndCreateMigrationTable` returns an error naming the tag and `Run` treats it as fatal — which is what stops a migration being recorded as applied when it was not

Prometheus, `gcp`, `TRACE_EXPORTER=zipkin` and `TRACE_EXPORTER=gofr` are untouched, so a tagged build can still export metrics and traces.

**Additional Information:**

- No new dependencies — this PR only removes linkage.
- **HTTP auth is not gRPC's to take away.** `EnableBasicAuth` and the other five entry points build gRPC interceptors, which names `pkg/gofr/grpc/middleware`, which imports grpc — so `auth.go` could not stay untagged while doing it. The gRPC half now lives in `grpc_auth_enabled.go` behind three bridges taking plain credentials; `auth.go` keeps the HTTP half in every build.

**Four pre-existing defects fixed on the way:**

1. **`initTracer` built a `BatchSpanProcessor` over a nil exporter.** `getExporter` returns nil-and-no-error for an unsupported `TRACE_EXPORTER` — a typo in config is enough. The processor panics on its first flush, on its own goroutine. It now returns, leaving the provider installed so trace and span IDs still appear on every request.
2. **`container.Error(err)` logged `{"message":{}}`.** The logger JSON-marshals the value and an `errors.errorString` has no exported fields, so **every trace-exporter failure logged nothing usable**. Uses `Errorf` now. ⚠️ The same pattern is likely elsewhere and deserves its own sweep.
3. **Four exported gRPC methods dereferenced `App.grpcServer` without checking it.** `factory.go` leaves it nil when the server fails to build — an out-of-range `GRPC_PORT` is enough — and logs and continues, so all four panicked in a case the surrounding code treats as recoverable. They log and return now.
4. **`TestUnifiedAuthenticationRegistration` could not fail.** It asserted `>= 2` interceptors after three `Enable` calls; two are registered by default, so it passed on the defaults alone and would not have noticed any auth bridge going missing. It now asserts exactly five.

**Local verification, since CI cannot run here yet:**

- `go build ./...` and `go vet ./pkg/...` clean in the default build and under all six tags
- **30/30 packages pass** in both configurations
- `golangci-lint` clean on every file this PR adds or changes, in both configurations

**Checklist:**

-   [x] I have formatted my code using `goimport` and `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.