### PR TITLE
fix(websocket): use the embedded context as WithValue's parent, not *Context

### DIFF
--- a/pkg/gofr/websocket.go
+++ b/pkg/gofr/websocket.go
@@ -44,7 +44,14 @@ func (a *App) WebSocket(route string, handler Handler) {
 
 		ctx.Request = conn
 
-		ctx.Context = context.WithValue(ctx, websocket.WSConnectionKey, conn)
+		// The parent must be ctx.Context (the embedded context.Context), not ctx
+		// itself: ctx is a *Context, so passing ctx here would make the value
+		// context's parent be ctx, whose .Context field is the very value context
+		// being constructed. Any walk of the parent chain other than the lucky
+		// first lookup (e.g. .Done(), or a .Value() for any other key) would then
+		// recurse into itself forever -- an unrecoverable stack overflow, since
+		// recover() cannot catch a fatal error.
+		ctx.Context = context.WithValue(ctx.Context, websocket.WSConnectionKey, conn)
 
 		defer a.httpServer.ws.CloseConnection(connID)
 

--- a/pkg/gofr/websocket_test.go
+++ b/pkg/gofr/websocket_test.go
@@ -71,6 +71,55 @@ func Test_WebSocket_Success(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// Test_WebSocket_ContextIsNotSelfReferential pins the fix for the
+// self-referential ctx.Context found in review of #4111 (see the issue
+// linked from that PR): App.WebSocket built the handler's context with
+// context.WithValue(ctx, ...) instead of context.WithValue(ctx.Context, ...).
+// ctx is a *Context, which embeds context.Context, so the parent of the
+// resulting value-context was ctx itself -- and ctx.Context was the very
+// value-context being constructed. Any walk of the parent chain other than
+// the lucky first lookup recursed forever.
+//
+// Calling .Done() is what recurses -- not receiving from the channel it
+// returns -- so this handler need only make that call, not read the result,
+// to exercise the bug. Pre-fix, that call alone crashes the whole test
+// binary with "fatal error: stack overflow" (unrecoverable: recover() cannot
+// catch a fatal error), rather than this test failing cleanly.
+func Test_WebSocket_ContextIsNotSelfReferential(t *testing.T) {
+	testutil.NewServerConfigs(t)
+
+	app := New()
+
+	server := httptest.NewServer(app.httpServer.router)
+	defer server.Close()
+
+	app.WebSocket("/ws-selfref", func(ctx *Context) (any, error) {
+		_ = ctx.Context.Done()
+
+		return "ok", nil
+	})
+
+	go app.Run()
+
+	time.Sleep(100 * time.Millisecond)
+
+	wsURL := "ws" + server.URL[len("http"):] + "/ws-selfref"
+
+	ws, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+
+	defer ws.Close()
+	defer resp.Body.Close()
+
+	err = ws.WriteMessage(websocket.TextMessage, []byte("hi"))
+	require.NoError(t, err)
+
+	_, message, err := ws.ReadMessage()
+	require.NoError(t, err)
+
+	assert.Equal(t, "ok", string(message))
+}
+
 // Test_WebSocket_PlainHTTPRequestDoesNotPanic pins the fix for #3862: a plain
 // HTTP request to a route registered via app.WebSocket (no Upgrade headers,
 // so no WSConnectionKey is ever set on the request context) must get a clean


### PR DESCRIPTION
## Summary

Fixes #4169.

`App.WebSocket` built the handler's context with `context.WithValue(ctx, websocket.WSConnectionKey, conn)`, passing `ctx` itself (a `*Context`, which embeds `context.Context`) as the parent instead of `ctx.Context`. That makes the resulting value-context self-referential: its parent is `ctx`, and `ctx.Context` is the very context being constructed.

Any call that walks the parent chain rather than resolving at the first level, such as `.Done()` or a `.Value()` lookup for any key other than `WSConnectionKey`, recurses into itself forever:

```
fatal error: stack overflow
```

A stack overflow is a `fatal error`, not a `panic`, so `recover()` cannot catch it and the whole process dies. It went unnoticed because `Container.GetConnectionFromContext` looks up exactly the one key that resolves before recursing.

## Fix

One word: pass `ctx.Context`, not `ctx`, as the parent.

## Relationship to #4111

Found during review of #4111, which fixes an unrelated data race on the same line (`serveWithGoroutine` reading `c.Context` concurrently with this reassignment). That fix stops the race's reader from ever calling `.Done()` on the poisoned context, closing one crash path, but leaves the self-reference in `c.Context` itself for the handler and anything downstream of it. Independent bugs, independent fixes, tracked as a separate issue and PR per the review's request.

## Testing

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/gofr/...`
- [x] New test: `Test_WebSocket_ContextIsNotSelfReferential` registers a handler that calls `ctx.Context.Done()` (the call itself recurses, not reading from the returned channel) and asserts the round trip completes normally. Verified this test crashes the whole test binary with the exact `fatal error: stack overflow` from the issue when the fix is reverted, and passes cleanly with it applied.