### PR TITLE
chore(deps): bump crate-ci/typos from 1.50.0 to 1.50.1 (actions)

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v7
       - name: typos-action
-        uses: crate-ci/typos@4d9c206a77c041268485162b8e2579ad7a5cb9a3 # v1.50.0
+        uses: crate-ci/typos@d43b6c087ac471e2ea7b8af622ff15f05c0c365b # v1.50.1


### PR DESCRIPTION
Bumps the `crate-ci/typos` GitHub Action from v1.50.0 to v1.50.1 (SHA-pinned) in `.github/workflows/typos.yml`.

SHA-pinned file edit (not a `go get`), kept separate from the go-module consolidation.

```
- crate-ci/typos@4d9c206a77c041268485162b8e2579ad7a5cb9a3 # v1.50.0
+ crate-ci/typos@d43b6c087ac471e2ea7b8af622ff15f05c0c365b # v1.50.1
```

Closes #4171