### PR TITLE
ci(website-stage): deploy to asia-south1 zopdev-tech cluster and zopdev registry

### DIFF
--- a/.github/workflows/website-stage.yml
+++ b/.github/workflows/website-stage.yml
@@ -22,8 +22,9 @@ env:
   APP_NAME: gofr-website
   WEBSITE_REGISTRY: ghcr.io
   GAR_PROJECT: raramuri-tech
-  GAR_REGISTRY: kops-dev
-  CLUSTER_NAME: raramuri-tech
+  GAR_REGISTRY: zopdev
+  CLUSTER_NAME: zopdev-tech
+  CLUSTER_REGION: asia-south1
   CLUSTER_PROJECT: raramuri-tech
   NAMESPACE: gofr-dev
   NAMESPACE_STAGE: gofr-dev-stg
@@ -86,7 +87,7 @@ jobs:
       - name: Login to GAR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
-          registry: us-central1-docker.pkg.dev
+          registry: asia-south1-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GOFR_WEBSITE_GOFR_DEV_STG_DEPLOYMENT_KEY }}
 
@@ -129,15 +130,15 @@ jobs:
         run: |
           docker build \
             --build-arg WEBSITE_TAG=stage \
-            -t us-central1-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REGISTRY }}/${{ env.APP_NAME }}:${{ env.TAG }} \
+            -t asia-south1-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REGISTRY }}/${{ env.APP_NAME }}:${{ env.TAG }} \
             -f ./docs/Dockerfile \
             .
 
       - name: Push framework docs image to GAR
-        run: docker push us-central1-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REGISTRY }}/${{ env.APP_NAME }}:${{ env.TAG }}
+        run: docker push asia-south1-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REGISTRY }}/${{ env.APP_NAME }}:${{ env.TAG }}
 
       - id: output-image
-        run: echo "image=`echo us-central1-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REGISTRY }}/${{ env.APP_NAME }}:${{ env.TAG }}`" >> "$GITHUB_OUTPUT"
+        run: echo "image=`echo asia-south1-docker.pkg.dev/${{ env.GAR_PROJECT }}/${{ env.GAR_REGISTRY }}/${{ env.APP_NAME }}:${{ env.TAG }}`" >> "$GITHUB_OUTPUT"
 
   deployment_stage:
     runs-on: ubuntu-latest
@@ -160,7 +161,7 @@ jobs:
           credentials_json: ${{ secrets.GOFR_WEBSITE_GOFR_DEV_STG_DEPLOYMENT_KEY }}
 
       - name: Set GCloud Project and Fetch Cluster Credentials
-        run: gcloud container clusters get-credentials ${{ env.CLUSTER_NAME }} --region=us-central1 --project=${{ env.CLUSTER_PROJECT }}
+        run: gcloud container clusters get-credentials ${{ env.CLUSTER_NAME }} --region=${{ env.CLUSTER_REGION }} --project=${{ env.CLUSTER_PROJECT }}
 
       - name: Update Deployment Image
         run: kubectl set image deployment/${{ env.APP_NAME }} ${{ env.APP_NAME }}=${{ env.image }} --namespace ${{ env.NAMESPACE_STAGE }}


### PR DESCRIPTION
## What
Retarget the stage website workflow (`website-stage.yml`) from the us-central1 `kops-dev` Artifact Registry + `raramuri-tech` cluster to the asia-south1 **`zopdev`** registry + **`zopdev-tech`** cluster. Mirrors the prod move in #4198.

## Changes
- `GAR_REGISTRY`: `kops-dev` → `zopdev`
- `CLUSTER_NAME`: `raramuri-tech` → `zopdev-tech`
- add `CLUSTER_REGION: asia-south1`; the deploy step now uses it instead of a hardcoded `us-central1`
- image build/push/output tags + GAR login registry: `us-central1-docker.pkg.dev` → `asia-south1-docker.pkg.dev`

GAR project (`raramuri-tech`), deploy namespace (`gofr-dev-stg`), app name, image tagging, and the build pipeline are unchanged.

## Note
`website-pr.yml` needs no change — it builds `gofr-website:pr` locally for validation and neither pushes to a registry nor deploys.