### PR TITLE
ci: stop passing -short to submodule tests, which skipped 10 mongo tests entirely

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -450,19 +450,24 @@ jobs:
               # is checked without mutation in the code_quality job instead.
               go mod download
 
-              # Deliberately NOT `-short`. `-short` does not merely shorten these
-              # suites, it deletes whole test functions from the coverage figure:
-              # the mongo driver's own `mtest` harness calls t.Skip("skipping
-              # mtest integration test in short mode") even for
-              # ClientType(mtest.Mock), which needs no server and no network. Ten
-              # test functions covering every mongo CRUD path were being skipped,
-              # and pkg/gofr/datasource/mongo reported 27.2% instead of 87.7% —
-              # for tests that already exist and run in 1.4s.
+              # NOTE: this whole block is the single-quoted payload of the
+              # `bash -c` above, so nothing in here may contain an apostrophe —
+              # not even inside a comment. One in a comment closes the quote and
+              # the runner fails with a syntax error before any test runs.
               #
-              # Every other submodule reports an identical coverage figure with
-              # and without the flag — nothing else in this tree is gated on
-              # testing.Short() — so dropping it changes only what mtest was
-              # hiding.
+              # Deliberately NOT `-short`. It does not merely shorten these
+              # suites, it deletes whole test functions from the coverage figure:
+              # the mtest harness shipped by the mongo driver calls t.Skip with
+              # "skipping mtest integration test in short mode" even under
+              # ClientType of mtest.Mock, which needs no server and no network.
+              # Ten test functions covering every mongo CRUD path were being
+              # skipped, so pkg/gofr/datasource/mongo reported 27.2% instead of
+              # 87.7% for tests that already exist and run in 1.4s.
+              #
+              # Measured across all 27 submodules: mongo is the only one whose
+              # figure changes at all and the only one with any testing.Short
+              # gating, and all 27 pass either way. Dropping the flag changes
+              # only what mtest was hiding.
               go test ./... -v -coverprofile="${module_name}.cov" -coverpkg=./...
 
               # Copy coverage file to the coverage_reports directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -450,8 +450,20 @@ jobs:
               # is checked without mutation in the code_quality job instead.
               go mod download
 
-              # Run tests with a focus on failed tests first
-              go test ./... -v -short -coverprofile="${module_name}.cov" -coverpkg=./...
+              # Deliberately NOT `-short`. `-short` does not merely shorten these
+              # suites, it deletes whole test functions from the coverage figure:
+              # the mongo driver's own `mtest` harness calls t.Skip("skipping
+              # mtest integration test in short mode") even for
+              # ClientType(mtest.Mock), which needs no server and no network. Ten
+              # test functions covering every mongo CRUD path were being skipped,
+              # and pkg/gofr/datasource/mongo reported 27.2% instead of 87.7% —
+              # for tests that already exist and run in 1.4s.
+              #
+              # Every other submodule reports an identical coverage figure with
+              # and without the flag — nothing else in this tree is gated on
+              # testing.Short() — so dropping it changes only what mtest was
+              # hiding.
+              go test ./... -v -coverprofile="${module_name}.cov" -coverpkg=./...
 
               # Copy coverage file to the coverage_reports directory
               cp "${module_name}.cov" "$COVERAGE_DIR/"


### PR DESCRIPTION
**Description:**

The submodule coverage job runs `go test ./... -short`. `-short` is not a speed knob for these
suites — it removes whole test functions from the coverage figure.

The mongo driver's own `mtest` harness calls `t.Skip("skipping mtest integration test in short
mode")` even for `ClientType(mtest.Mock)`, which needs neither a server nor a network. Ten test
functions covering every mongo CRUD path (`Test_InsertCommands`, `Test_FindMultipleCommands`,
`Test_UpdateCommands`, `Test_DeleteCommands`, `Test_CountDocuments`, `Test_Drop`,
`Test_CreateCollection`, `Test_FindOneCommands`, `TestClient_StartSession`, `Test_HealthCheck`)
were being compiled, skipped, and then reported as uncovered.

Measured in `pkg/gofr/datasource/mongo`:

```
go test ./... -short : 27.2% coverage, 1.50s
go test ./...        : 87.7% coverage, 1.35s
```

The tests already exist and are not slow — only the flag stood between them and the coverage
figure. Every uncovered function in `mongo.go` (`InsertOne`, `InsertMany`, `Find`, `FindOne`,
`UpdateByID`, `UpdateOne`, `UpdateMany`, `CountDocuments`, `DeleteOne`, `DeleteMany`, `Drop`,
`CreateCollection`, `HealthCheck`, `StartSession`, `StartTransaction`) is exercised by them.

This matters more now that #3866 brings the submodules into the published figure: they contribute
6,009 of 8,770 statements in the merged profile, so submodule coverage is the main lever on the
repo-wide number. This change alone is worth roughly +0.9pp.

**Breaking Changes (if applicable):**

None. CI-only.

**Additional Information:**

I measured short vs non-short for all 27 submodules. **Mongo is the only module whose figure changes
at all, and the only one with any `testing.Short()` gating** — the other 26 report an identical
percentage either way and skip zero tests. So removing the flag is a strict no-op everywhere except
mongo, at no meaningful runtime cost (the mongo suite runs in 1.35s without it).

Related: #4200 tracks the 13 submodule files still at exactly 0%, most of which already have
generated gomock mocks available.

Note on merge order: #3940 edits this same line (it adds `-covermode=atomic`), so whichever of the
two lands second needs a one-line rebase.

**Checklist:**

-   [x] I have formatted my code using `goimport` and `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMKLwXTgzev7GTP3hSkzv1
