### PR TITLE
ci: measure every in-repo pkg/gofr package, not just the 29 top-level files (#4202)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -286,10 +286,19 @@ jobs:
             set -eo pipefail
             export APP_ENV=test
 
-            # Run tests for root gofr package
+            # Run tests for root gofr package.
+            #
+            # `-coverpkg=./pkg/gofr/...`, not `./pkg/gofr`: the narrow form
+            # instruments only the 29 top-level pkg/gofr/*.go files, so every
+            # in-repo sub-package — http, http/middleware, container, service,
+            # logging, cmd, migration, rbac, datasource/sql, datasource/redis
+            # and the rest — was absent from the published figure even though
+            # its tests run here on every push. The narrow glob measured 1,848
+            # statements; the tree measures 10,482, and the figure went from
+            # 86.5% to 90.0% without a new test being written (#4202).
             exit_code=0
             go test -v -short -covermode=atomic \
-              -coverpkg=./pkg/gofr -coverprofile=gofr_only.cov ./pkg/gofr || exit_code=$?
+              -coverpkg=./pkg/gofr/... -coverprofile=root_pkg.cov ./pkg/gofr || exit_code=$?
             if [ $exit_code -eq 2 ]; then
               echo "::error::Panic detected in root gofr package tests"
               exit 2
@@ -298,10 +307,13 @@ jobs:
               exit $exit_code
             fi
 
-            # Run tests for sub-packages
+            # Run tests for sub-packages. Same widening as above; the profile
+            # name says sub-packages because these are packages of this module,
+            # not the pkg/gofr/datasource/* submodules (those are separate Go
+            # modules, covered by Submodule-Unit-Testing).
             exit_code=0
             go test -v -covermode=atomic \
-              -coverpkg=./pkg/gofr -coverprofile=submodules.cov ./pkg/gofr/... || exit_code=$?
+              -coverpkg=./pkg/gofr/... -coverprofile=sub_pkgs.cov ./pkg/gofr/... || exit_code=$?
             if [ $exit_code -eq 2 ]; then
               echo "::error::Panic detected in gofr sub-packages tests"
               exit 2
@@ -310,9 +322,28 @@ jobs:
               exit $exit_code
             fi
 
-            # Combine coverage profiles
+            # Combine coverage profiles.
+            #
+            # `/mock_` strips generated gomock files. `/testutil/` strips the
+            # test helper package, which the widened -coverpkg would otherwise
+            # admit: it is scaffolding for tests, not shipped behaviour, and at
+            # 98% it flatters the numerator the same way the mocks would.
+            #
+            # The awk merges duplicate blocks. Under a multi-package -coverpkg
+            # every block is emitted once per test binary, so a plain
+            # concatenation here is 31 copies of the same 12k blocks: 21 MB of
+            # profile to upload, download and hand to qlty. Keyed by block
+            # position, statement count carried through, execution counts
+            # summed — which is what merging two profiles of the same code
+            # means. `go tool cover` reaches the same percentage either way
+            # (it resolves duplicates itself); this is about the artifact, and
+            # about a profile a human can read.
             echo "mode: atomic" > profile.cov
-            grep -h -v "mode:" gofr_only.cov submodules.cov | grep -v '/mock_' >> profile.cov
+            grep -h -v "mode:" root_pkg.cov sub_pkgs.cov \
+              | grep -v '/mock_' \
+              | grep -v '/testutil/' \
+              | awk '{stmts[$1] = $2; count[$1] += $3} END {for (blk in stmts) print blk, stmts[blk], count[blk]}' \
+              | sort >> profile.cov
 
             # Show coverage summary
             go tool cover -func profile.cov


### PR DESCRIPTION
**Description:**

Fixes #4202.

`PKG-Unit-Testing` ran both of its suites with `-coverpkg=./pkg/gofr`. That glob is a single
package, not a tree, so only the 29 top-level `pkg/gofr/*.go` files were ever instrumented. Every
in-repo sub-package — `http`, `http/middleware`, `container`, `service`, `logging`, `cmd`,
`migration`, `rbac`, `datasource/sql`, `datasource/redis` and 23 more — was absent from the
published figure. Their tests run here on every push; what they cover of their own code was measured
and thrown away.

Measured by CI, not locally (numbers from this PR's run 34614375793 against the last `development`
run 33841432012):

```
                        statements   PKG job   published figure
-coverpkg=./pkg/gofr         1,848     87.3%              86.5%
-coverpkg=./pkg/gofr/...    10,482     90.4%              90.0%
```

**The 3.5pp is not a gain in tested behaviour.** Nothing about the framework is safer than it was
yesterday — the number is catching up with tests that were already running. The claim worth making
is the other one: a figure computed over 1,848 statements has been reported as a whole-repo number
for a repository with roughly ten thousand in the main module alone.

What the widened denominator admits: `http`, `http/middleware`, `service`, `container`, `migration`,
`rbac`, `datasource/sql`, `datasource/redis`, `datasource/file`, `pubsub/kafka` and 20 others, all
of which were already being tested on every run.

Two supporting changes, both explained inline:

- **`pkg/gofr/testutil` is stripped alongside the generated mocks.** The wider glob admits it: test
  scaffolding at 98%, which would flatter the numerator exactly as `mock_*.go` would.
- **The combine step merges duplicate blocks instead of concatenating them.** Under a multi-package
  `-coverpkg` every block is emitted once per test binary, so a concatenation is dozens of copies of
  the same profile. `go tool cover -func` resolves duplicates itself and reaches the same percentage
  either way, so this costs no accuracy; it is about the artifact that two jobs download and qlty
  ingests. Keyed by block position, execution counts summed — the uploaded profile is **381 KB,
  down from 1.6 MB** despite covering 5.7x the statements.

Profile filenames follow the reality: `gofr_only.cov` → `root_pkg.cov`, and `submodules.cov` →
`sub_pkgs.cov` (it never held submodules — those are separate Go modules under
`Submodule-Unit-Testing`).

**Breaking Changes (if applicable):**

None. CI-only. No framework code is touched.

**Additional Information:**

- **Where this leaves the repo-wide number.** Merging this run's Example + PKG + submodule artifacts
  the way #3940 will merge them gives **84.6%**, or **85.1%** with #4201's mongo fix also applied.
  So the three CI-only changes together land the honest whole-repo figure at ~85% without a single
  new test — and #4200's list of 0% files is what moves it from there.
- **Runtime is not affected.** The PKG job's test time is unchanged; instrumentation widens the
  build, not the run. The job keeps its 5-minute retry timeout and passed on 1.24, 1.25 and 1.26.
- **Independent of the other coverage work.** It does not touch `Submodule-Unit-Testing`, so there
  is no overlap with #4201 and no rebase against #3940 either way.
- **Correction to an earlier version of this description.** It quoted 81.0% → 88.0% from a local
  run. Those numbers were not comparable to CI: Go 1.27 (local) and Go 1.24 (CI) do not divide code
  into the same coverage blocks — the same `logging/logger.go` counts 136 statements under 1.27 and
  96 under 1.24 — so a local absolute percentage cannot be used to predict the published one. The
  direction and the mechanism were right; the figures above are CI's own and replace them.

**Checklist:**

-   [x] I have formatted my code using `goimport` and `golangci-lint`.
-   [x] All new code is covered by unit tests.
-   [x] This PR does not decrease the overall code coverage.
-   [x] I have reviewed the code comments and documentation for clarity.
